### PR TITLE
refactor(web): apply MiniMax design system (tokens, typography, primitives, chrome)

### DIFF
--- a/web/src/shared/components/Badge.tsx
+++ b/web/src/shared/components/Badge.tsx
@@ -3,7 +3,28 @@
 import { cn } from "@/shared/utils/cn";
 import React from "react";
 
-type BadgeVariant = "default" | "primary" | "success" | "warning" | "error" | "info";
+/**
+ * MiniMax Badge variants:
+ *   default  -> generic neutral chip on surface
+ *   primary  -> coral product chip
+ *   success  -> badge-success (pale-green confirmation)
+ *   warning  -> warm warning chip (legacy)
+ *   error    -> red error chip (legacy)
+ *   info     -> brand-blue informational chip (legacy)
+ *   new      -> badge-new (coral "NEW" / "Live")
+ *   beta     -> badge-beta (pale-blue "BETA")
+ *   code     -> badge-code (inline code-style chip, square corners)
+ */
+type BadgeVariant =
+  | "default"
+  | "primary"
+  | "success"
+  | "warning"
+  | "error"
+  | "info"
+  | "new"
+  | "beta"
+  | "code";
 type BadgeSize = "sm" | "md" | "lg";
 
 interface BadgeProps {
@@ -16,18 +37,21 @@ interface BadgeProps {
 }
 
 const variants: Record<BadgeVariant, string> = {
-  default: "bg-surface-2 text-text-muted",
-  primary: "bg-brand-500/10 text-brand-600 dark:text-brand-300",
-  success: "bg-green-500/10 text-green-600 dark:text-green-400",
-  warning: "bg-yellow-500/10 text-yellow-600 dark:text-yellow-400",
-  error: "bg-red-500/10 text-red-600 dark:text-red-400",
-  info: "bg-blue-500/10 text-blue-600 dark:text-blue-400",
+  default: "bg-surface-base text-slate",
+  primary: "bg-brand-coral/10 text-brand-coral",
+  success: "bg-success-bg text-success-text",
+  warning: "bg-yellow-500/12 text-yellow-700 dark:text-yellow-400",
+  error: "bg-[color:var(--color-danger)]/12 text-[color:var(--color-danger)]",
+  info: "bg-brand-blue-200 text-brand-blue-deep",
+  new: "bg-brand-coral text-on-dark",
+  beta: "bg-brand-blue-200 text-brand-blue-deep",
+  code: "bg-brand-blue-200 text-brand-blue-deep",
 };
 
 const sizes: Record<BadgeSize, string> = {
-  sm: "px-2 py-0.5 text-[10px]",
-  md: "px-2.5 py-1 text-xs",
-  lg: "px-3 py-1.5 text-sm",
+  sm: "px-2 py-0.5 text-[10px] tracking-wide",
+  md: "px-2.5 py-1 text-[11px] tracking-wide",
+  lg: "px-3 py-1.5 text-[13px]",
 };
 
 export default function Badge({
@@ -38,10 +62,15 @@ export default function Badge({
   icon,
   className,
 }: BadgeProps) {
+  // `code` variant uses square corners (rounded-mini-sm) per spec; all
+  // other badge variants use full pill.
+  const radius = variant === "code" ? "rounded-mini-sm" : "rounded-full";
+
   return (
     <span
       className={cn(
-        "inline-flex items-center gap-1.5 rounded-full font-semibold",
+        "inline-flex items-center gap-1.5 font-semibold leading-none",
+        radius,
         variants[variant],
         sizes[size],
         className
@@ -51,12 +80,15 @@ export default function Badge({
         <span
           className={cn(
             "size-1.5 rounded-full",
-            variant === "success" && "bg-green-500",
+            variant === "success" && "bg-success-text",
             variant === "warning" && "bg-yellow-500",
-            variant === "error" && "bg-red-500",
-            variant === "info" && "bg-blue-500",
-            variant === "primary" && "bg-brand-500",
-            variant === "default" && "bg-gray-500"
+            variant === "error" && "bg-[color:var(--color-danger)]",
+            variant === "info" && "bg-brand-blue-deep",
+            variant === "primary" && "bg-brand-coral",
+            variant === "new" && "bg-on-dark",
+            variant === "beta" && "bg-brand-blue-deep",
+            variant === "code" && "bg-brand-blue-deep",
+            variant === "default" && "bg-stone"
           )}
         />
       )}

--- a/web/src/shared/components/Button.tsx
+++ b/web/src/shared/components/Button.tsx
@@ -4,19 +4,36 @@ import { cn } from "@/shared/utils/cn";
 import React from "react";
 import type { ButtonProps } from "@/types";
 
+/**
+ * MiniMax Button — pill-shaped, two-tier dominance.
+ *
+ * Variants map to the MiniMax design system:
+ *   primary    -> button-primary       (black-pill, dominant CTA)
+ *   secondary  -> button-secondary     (outlined-pill, paired with primary)
+ *   outline    -> button-tertiary      (white-fill quieter pill)
+ *   ghost      -> button-link          (inline text-button)
+ *   danger     -> red destructive pill (kept from legacy palette)
+ *   success    -> green confirm pill   (kept from legacy palette)
+ */
 const variants = {
-  primary: "bg-brand-500 hover:bg-brand-600 text-white shadow-sm disabled:bg-surface-3 disabled:text-text-muted",
-  secondary: "bg-surface-2 hover:bg-surface-3 text-text-main border border-border disabled:opacity-50",
-  outline: "border border-border text-text-main hover:bg-surface-2 hover:border-brand-500/40",
-  ghost: "text-text-muted hover:bg-surface-2 hover:text-text-main",
-  danger: "bg-red-500 hover:bg-red-600 text-white shadow-sm disabled:bg-surface-3 disabled:text-text-muted",
-  success: "bg-green-600 hover:bg-green-700 text-white shadow-sm disabled:bg-surface-3 disabled:text-text-muted",
+  primary:
+    "bg-ink text-on-primary hover:bg-charcoal disabled:bg-hairline disabled:text-muted",
+  secondary:
+    "bg-transparent text-ink border border-ink hover:bg-ink/5 disabled:border-hairline disabled:text-muted",
+  outline:
+    "bg-canvas text-ink border border-hairline hover:border-ink/40 hover:bg-surface-soft disabled:border-hairline disabled:text-muted",
+  ghost:
+    "bg-transparent text-ink hover:bg-surface-soft disabled:text-muted",
+  danger:
+    "bg-[color:var(--color-danger)] text-white hover:opacity-90 disabled:bg-hairline disabled:text-muted",
+  success:
+    "bg-success-text text-white hover:opacity-90 disabled:bg-hairline disabled:text-muted",
 };
 
 const sizes = {
-  sm: "h-7 px-3 text-xs rounded-[8px]",
-  md: "h-9 px-4 text-sm rounded-[10px]",
-  lg: "h-11 px-6 text-sm rounded-[10px]",
+  sm: "h-8 px-3 text-[12px] font-semibold",
+  md: "h-9 px-4 text-[13px] font-semibold",
+  lg: "h-11 px-6 text-[14px] font-semibold",
 };
 
 export default function Button({
@@ -34,8 +51,10 @@ export default function Button({
   return (
     <button
       className={cn(
-        "inline-flex items-center justify-center gap-2 font-semibold transition-all duration-150 ease-out cursor-pointer",
-        "active:scale-[0.97] disabled:opacity-50 disabled:cursor-not-allowed disabled:active:scale-100",
+        // MiniMax button: pill-shaped, tight tracking, weight 600.
+        "inline-flex items-center justify-center gap-2 rounded-full leading-none",
+        "transition-colors duration-150 ease-out cursor-pointer tracking-tight",
+        "active:scale-[0.98] disabled:cursor-not-allowed disabled:active:scale-100",
         variants[variant],
         sizes[size],
         fullWidth && "w-full",

--- a/web/src/shared/components/Card.tsx
+++ b/web/src/shared/components/Card.tsx
@@ -3,7 +3,8 @@
 import { cn } from "@/shared/utils/cn";
 import React from "react";
 
-type CardPadding = "none" | "xs" | "sm" | "md" | "lg";
+type CardPadding = "none" | "xs" | "sm" | "md" | "lg" | "xl";
+type CardRadius = "lg" | "xl" | "xxl" | "xxxl" | "hero";
 
 interface CardProps extends React.HTMLAttributes<HTMLDivElement> {
   children?: React.ReactNode;
@@ -12,6 +13,15 @@ interface CardProps extends React.HTMLAttributes<HTMLDivElement> {
   icon?: string;
   action?: React.ReactNode;
   padding?: CardPadding;
+  /**
+   * MiniMax radius scale.
+   *   lg    = 12px (recommendation tile)
+   *   xl    = 16px (default; standard feature card / docs card)
+   *   xxl   = 20px (larger feature panel)
+   *   xxxl  = 24px (AI product tile)
+   *   hero  = 32px (vibrant gradient product card)
+   */
+  radius?: CardRadius;
   hover?: boolean;
   elev?: boolean;
   className?: string;
@@ -40,6 +50,7 @@ export default function Card({
   icon,
   action,
   padding = "md",
+  radius = "xl",
   hover = false,
   elev = false,
   className,
@@ -49,16 +60,27 @@ export default function Card({
     none: "",
     xs: "p-3",
     sm: "p-4",
-    md: "p-6",
-    lg: "p-8",
+    md: "p-5",
+    lg: "p-6",
+    xl: "p-8",
+  };
+
+  const radii: Record<CardRadius, string> = {
+    lg: "rounded-mini-lg",
+    xl: "rounded-mini-xl",
+    xxl: "rounded-mini-xxl",
+    xxxl: "rounded-mini-xxxl",
+    hero: "rounded-hero",
   };
 
   return (
     <div
       className={cn(
-        "bg-surface border border-border-subtle",
-        elev ? "rounded-[14px] shadow-[var(--shadow-elev)]" : "rounded-[14px] shadow-[var(--shadow-soft)]",
-        hover && "hover:shadow-[var(--shadow-warm)] hover:border-brand-500/30 transition-all cursor-pointer",
+        // MiniMax docs/feature card: flat-with-borders, white canvas.
+        "bg-canvas border border-hairline",
+        radii[radius],
+        elev ? "shadow-card" : "shadow-none",
+        hover && "hover:border-ink/30 hover:shadow-soft transition-colors cursor-pointer",
         paddings[padding],
         className
       )}
@@ -68,16 +90,16 @@ export default function Card({
         <div className="flex items-center justify-between mb-4">
           <div className="flex items-center gap-3">
             {icon && (
-              <div className="p-2 rounded-[10px] bg-bg text-text-muted">
+              <div className="p-2 rounded-mini-md bg-surface-base text-slate">
                 <span className="material-symbols-outlined text-[20px]">{icon}</span>
               </div>
             )}
             <div>
               {title && (
-                <h3 className="text-text-main font-semibold">{title}</h3>
+                <h3 className="text-ink font-semibold text-[15px] leading-tight">{title}</h3>
               )}
               {subtitle && (
-                <p className="text-sm text-text-muted">{subtitle}</p>
+                <p className="text-[13px] text-slate mt-0.5">{subtitle}</p>
               )}
             </div>
           </div>
@@ -93,8 +115,8 @@ Card.Section = function CardSection({ children, className, ...props }: CardSecti
   return (
     <div
       className={cn(
-        "p-4 rounded-[10px]",
-        "bg-bg border border-border-subtle",
+        "p-4 rounded-mini-md",
+        "bg-surface-soft border border-hairline-soft",
         className
       )}
       {...props}
@@ -109,8 +131,8 @@ Card.Row = function CardRow({ children, className, ...props }: CardRowProps) {
     <div
       className={cn(
         "p-3 -mx-3 px-3 transition-colors",
-        "border-b border-border-subtle last:border-b-0",
-        "hover:bg-surface-2/50",
+        "border-b border-hairline-soft last:border-b-0",
+        "hover:bg-surface-soft",
         className
       )}
       {...props}
@@ -130,8 +152,8 @@ Card.ListItem = function CardListItem({
     <div
       className={cn(
         "group flex items-center justify-between p-3 -mx-3 px-3",
-        "border-b border-border-subtle last:border-b-0",
-        "hover:bg-surface-2/50 transition-colors",
+        "border-b border-hairline-soft last:border-b-0",
+        "hover:bg-surface-soft transition-colors",
         className
       )}
       {...props}

--- a/web/src/shared/components/Header.tsx
+++ b/web/src/shared/components/Header.tsx
@@ -205,13 +205,13 @@ export default function Header({ onMenuClick, showMenuButton = true }: HeaderPro
   };
 
   return (
-    <header className="shrink-0 flex items-center justify-between gap-3 px-4 lg:px-8 pt-3 pb-2 border-b border-border-subtle bg-surface/60 backdrop-blur-xl lg:bg-transparent lg:backdrop-blur-none z-20">
+    <header className="shrink-0 flex items-center justify-between gap-3 px-4 lg:px-8 pt-3 pb-3 border-b border-hairline-soft bg-canvas/95 backdrop-blur-xl lg:bg-canvas lg:backdrop-blur-none z-20">
       {/* Mobile menu button */}
       <div className="flex items-center gap-3 lg:hidden shrink-0">
         {showMenuButton && (
           <button
             onClick={onMenuClick}
-            className="text-text-main hover:text-primary transition-colors"
+            className="text-ink hover:opacity-70 transition-opacity"
           >
             <span className="material-symbols-outlined">menu</span>
           </button>
@@ -235,7 +235,7 @@ export default function Header({ onMenuClick, showMenuButton = true }: HeaderPro
                 {crumb.href ? (
                   <a
                     href={crumb.href}
-                    className="text-text-muted hover:text-primary transition-colors"
+                    className="text-slate hover:text-ink transition-colors text-[13px] font-medium"
                   >
                     {crumb.label}
                   </a>
@@ -250,7 +250,7 @@ export default function Header({ onMenuClick, showMenuButton = true }: HeaderPro
                         fallbackText={crumb.label.slice(0, 2).toUpperCase()}
                       />
                     )}
-                    <h1 className="text-base lg:text-2xl font-semibold text-text-main tracking-tight truncate">
+                    <h1 className="text-[18px] lg:text-[28px] font-semibold text-ink tracking-tight truncate leading-tight">
                       {translate(crumb.label)}
                     </h1>
                   </div>
@@ -260,18 +260,18 @@ export default function Header({ onMenuClick, showMenuButton = true }: HeaderPro
           </div>
         ) : title ? (
           <div>
-            <div className="flex items-center gap-2">
+            <div className="flex items-center gap-2.5">
               {icon && (
-                <span className="material-symbols-outlined text-primary text-xl lg:text-2xl">
+                <span className="material-symbols-outlined text-ink text-xl lg:text-2xl">
                   {icon}
                 </span>
               )}
-              <h1 className="text-base lg:text-2xl font-semibold tracking-tight truncate">
+              <h1 className="text-[18px] lg:text-[28px] font-semibold tracking-tight truncate text-ink leading-tight">
                 {translate(title)}
               </h1>
             </div>
             {description && (
-              <p className="hidden lg:block text-sm text-text-muted truncate">
+              <p className="hidden lg:block text-[13px] text-slate truncate mt-0.5">
                 {translate(description)}
               </p>
             )}

--- a/web/src/shared/components/Input.tsx
+++ b/web/src/shared/components/Input.tsx
@@ -4,6 +4,11 @@ import { cn } from "@/shared/utils/cn";
 import React from "react";
 import type { InputProps } from "@/types";
 
+/**
+ * MiniMax text-input — 8px rounded, 1px hairline border, 2px brand-blue-deep
+ * focus ring, 40px desktop height. Error: 1px #d45656 border + matching
+ * red label.
+ */
 export default function Input({
   label,
   type = "text",
@@ -22,15 +27,15 @@ export default function Input({
   return (
     <div className={cn("flex flex-col gap-1.5", className)}>
       {label && (
-        <label className="text-sm font-medium text-text-main">
+        <label className="type-body-sm-medium text-ink">
           {label}
-          {required && <span className="text-red-500 ml-1">*</span>}
+          {required && <span className="text-[color:var(--color-danger)] ml-1">*</span>}
         </label>
       )}
       <div className="relative">
         {icon && (
-          <div className="absolute inset-y-0 left-0 flex items-center pl-3 pointer-events-none text-text-muted">
-            <span className="material-symbols-outlined text-[20px]">{icon}</span>
+          <div className="absolute inset-y-0 left-0 flex items-center pl-3 pointer-events-none text-steel">
+            <span className="material-symbols-outlined text-[18px]">{icon}</span>
           </div>
         )}
         <input
@@ -40,27 +45,28 @@ export default function Input({
           onChange={onChange}
           disabled={disabled}
           className={cn(
-            "w-full py-2.5 px-3 text-sm text-text-main bg-surface-2 rounded-[10px]",
-            "border border-transparent placeholder-text-muted/70",
-            "focus:outline-none focus:ring-2 focus:ring-brand-500/30 focus:border-brand-500/40",
-            "transition-all duration-150 ease-out disabled:opacity-50 disabled:cursor-not-allowed",
+            "w-full h-10 py-2.5 px-3 text-[14px] text-ink bg-canvas rounded-mini-md",
+            "border border-hairline placeholder:text-steel",
+            "focus:outline-none focus:border-brand-blue-deep focus:ring-0 focus:[border-width:2px] focus:px-[11px]",
+            "transition-colors duration-150 ease-out disabled:opacity-50 disabled:cursor-not-allowed",
             // iOS zoom fix
-            "text-[16px] sm:text-sm",
+            "text-[16px] sm:text-[14px]",
             icon && "pl-10",
-            error && "ring-1 ring-red-500 focus:ring-2 focus:ring-red-500/40 border-red-500/40",
+            error &&
+              "border-[color:var(--color-danger)] focus:border-[color:var(--color-danger)]",
             inputClassName
           )}
           {...props}
         />
       </div>
       {error && (
-        <p className="text-xs text-red-500 flex items-center gap-1">
+        <p className="type-body-sm text-[color:var(--color-danger)] flex items-center gap-1">
           <span className="material-symbols-outlined text-[14px]">error</span>
           {error}
         </p>
       )}
       {hint && !error && (
-        <p className="text-xs text-text-muted">{hint}</p>
+        <p className="type-body-sm text-slate">{hint}</p>
       )}
     </div>
   );

--- a/web/src/shared/components/SegmentedControl.tsx
+++ b/web/src/shared/components/SegmentedControl.tsx
@@ -4,6 +4,7 @@ import { cn } from "@/shared/utils/cn";
 import React from "react";
 
 type SegmentedControlSize = "sm" | "md" | "lg";
+type SegmentedControlVariant = "pill" | "segmented" | "underline";
 
 interface SegmentedControlOption {
   value: string;
@@ -16,6 +17,13 @@ interface SegmentedControlProps {
   value: string;
   onChange: (value: string) => void;
   size?: SegmentedControlSize;
+  /**
+   * MiniMax tab variants:
+   *   pill       -> pill-tab (default; black-fill active, hairline inactive)
+   *   segmented  -> grouped segmented control on surface base
+   *   underline  -> segmented-tab (underline-style; M2.7 page pattern)
+   */
+  variant?: SegmentedControlVariant;
   className?: string;
 }
 
@@ -24,42 +32,112 @@ export default function SegmentedControl({
   value,
   onChange,
   size = "md",
+  variant = "pill",
   className,
 }: SegmentedControlProps) {
   const sizes: Record<SegmentedControlSize, string> = {
-    sm: "h-7 text-xs",
-    md: "h-9 text-sm",
-    lg: "h-11 text-base",
+    sm: "h-7 text-[12px] px-3",
+    md: "h-9 text-[13px] px-4",
+    lg: "h-11 text-[14px] px-5",
   };
 
+  if (variant === "underline") {
+    return (
+      <div
+        className={cn(
+          "inline-flex items-center gap-1 border-b border-hairline-soft",
+          className
+        )}
+      >
+        {options.map((option) => {
+          const active = value === option.value;
+          return (
+            <button
+              key={option.value}
+              onClick={() => onChange(option.value)}
+              className={cn(
+                "shrink-0 px-4 py-2.5 type-body-sm-medium relative transition-colors",
+                "border-b-2 -mb-px",
+                active
+                  ? "text-ink border-ink"
+                  : "text-steel border-transparent hover:text-ink"
+              )}
+            >
+              {option.icon && (
+                <span className="material-symbols-outlined text-[16px] mr-1.5 align-middle">
+                  {option.icon}
+                </span>
+              )}
+              {option.label}
+            </button>
+          );
+        })}
+      </div>
+    );
+  }
+
+  if (variant === "pill") {
+    return (
+      <div className={cn("inline-flex items-center gap-2 flex-wrap", className)}>
+        {options.map((option) => {
+          const active = value === option.value;
+          return (
+            <button
+              key={option.value}
+              onClick={() => onChange(option.value)}
+              className={cn(
+                "shrink-0 rounded-full font-semibold transition-colors leading-none",
+                sizes[size],
+                active
+                  ? "bg-ink text-on-primary border border-ink"
+                  : "bg-canvas text-steel border border-hairline hover:text-ink hover:border-ink/40"
+              )}
+            >
+              {option.icon && (
+                <span className="material-symbols-outlined text-[16px] mr-1.5 align-middle">
+                  {option.icon}
+                </span>
+              )}
+              {option.label}
+            </button>
+          );
+        })}
+      </div>
+    );
+  }
+
+  // segmented (grouped — legacy default)
   return (
     <div
       className={cn(
-        "inline-flex items-center p-1 rounded-[10px] overflow-x-auto",
-        "bg-surface-2",
+        "inline-flex items-center p-1 rounded-mini-md overflow-x-auto",
+        "bg-surface-base border border-hairline-soft",
         className
       )}
     >
-      {options.map((option) => (
-        <button
-          key={option.value}
-          onClick={() => onChange(option.value)}
-          className={cn(
-            "shrink-0 px-4 rounded-[8px] font-medium transition-all",
-            sizes[size],
-            value === option.value
-              ? "bg-surface text-text-main shadow-sm"
-              : "text-text-muted hover:text-text-main"
-          )}
-        >
-          {option.icon && (
-            <span className="material-symbols-outlined text-[16px] mr-1.5">
-              {option.icon}
-            </span>
-          )}
-          {option.label}
-        </button>
-      ))}
+      {options.map((option) => {
+        const active = value === option.value;
+        return (
+          <button
+            key={option.value}
+            onClick={() => onChange(option.value)}
+            className={cn(
+              "shrink-0 rounded-mini-sm font-semibold transition-colors leading-none",
+              sizes[size],
+              active
+                ? "bg-canvas text-ink shadow-soft"
+                : "text-steel hover:text-ink"
+            )}
+          >
+            {option.icon && (
+              <span className="material-symbols-outlined text-[16px] mr-1.5 align-middle">
+                {option.icon}
+              </span>
+            )}
+            {option.label}
+          </button>
+        );
+      })}
     </div>
   );
 }

--- a/web/src/shared/components/Sidebar.tsx
+++ b/web/src/shared/components/Sidebar.tsx
@@ -154,7 +154,7 @@ export default function Sidebar({ onClose }: SidebarProps) {
 
   return (
     <>
-      <aside className="flex w-72 flex-col border-r border-border-subtle bg-vibrancy backdrop-blur-xl transition-colors duration-300 min-h-full">
+      <aside className="flex w-72 flex-col border-r border-hairline-soft bg-canvas transition-colors duration-300 min-h-full">
         {/* Traffic lights */}
         <div className="flex items-center gap-2 px-6 pt-5 pb-2">
           <div className="w-3 h-3 rounded-full bg-[#FF5F56]" />
@@ -165,14 +165,14 @@ export default function Sidebar({ onClose }: SidebarProps) {
         {/* Logo */}
         <div className="px-6 py-4 flex flex-col gap-2">
           <a href="/dashboard" className="flex items-center gap-3">
-            <div className="flex items-center justify-center size-9 rounded-[10px] bg-gradient-to-br from-brand-500 to-brand-700 shadow-[var(--shadow-warm)]">
-              <span className="material-symbols-outlined text-white text-[20px]">hub</span>
+            <div className="flex items-center justify-center size-9 rounded-mini-md bg-ink">
+              <span className="material-symbols-outlined text-on-primary text-[20px]">hub</span>
             </div>
             <div className="flex flex-col">
-              <h1 className="text-lg font-semibold tracking-tight text-text-main">
+              <h1 className="text-[17px] font-semibold tracking-tight text-ink">
                 {APP_CONFIG.name}
               </h1>
-              <span className="text-xs text-text-muted">v{APP_CONFIG.version}</span>
+              <span className="text-[11px] text-stone">v{APP_CONFIG.version}</span>
             </div>
           </a>
           {updateInfo && (
@@ -209,27 +209,27 @@ export default function Sidebar({ onClose }: SidebarProps) {
               href={item.href}
               onClick={onClose}
               className={cn(
-                "flex items-center gap-3 px-3 py-1 rounded-lg transition-all group",
+                "flex items-center gap-3 px-3 py-1.5 rounded-mini-sm transition-colors group",
                 isActive(item.href)
-                  ? "bg-primary/10 text-primary"
-                  : "text-text-muted hover:bg-surface-2 hover:text-text-main"
+                  ? "bg-surface-base text-ink font-medium"
+                  : "text-charcoal hover:bg-surface-soft hover:text-ink"
               )}
             >
               <span
                 className={cn(
                   "material-symbols-outlined text-[18px]",
-                  isActive(item.href) ? "fill-1" : "group-hover:text-primary transition-colors"
+                  isActive(item.href) ? "fill-1" : ""
                 )}
               >
                 {item.icon}
               </span>
-              <span className="text-[13px] font-medium">{item.label}</span>
+              <span className="text-[13px]">{item.label}</span>
             </a>
           ))}
 
           {/* System section */}
           <div className="pt-3 mt-2 space-y-0.5">
-            <p className="px-4 text-xs font-semibold text-text-muted/60 uppercase tracking-wider mb-2">
+            <p className="px-3 text-[11px] font-semibold text-stone uppercase tracking-[0.08em] mb-2">
               System
             </p>
 
@@ -237,14 +237,14 @@ export default function Sidebar({ onClose }: SidebarProps) {
             <button
               onClick={() => setMediaOpen((v) => !v)}
               className={cn(
-                "w-full flex items-center gap-3 px-3 py-1 rounded-lg transition-all group",
+                "w-full flex items-center gap-3 px-3 py-1.5 rounded-mini-sm transition-colors group",
                 pathname.startsWith("/dashboard/media-providers")
-                  ? "bg-primary/10 text-primary"
-                  : "text-text-muted hover:bg-surface-2 hover:text-text-main"
+                  ? "bg-surface-base text-ink font-medium"
+                  : "text-charcoal hover:bg-surface-soft hover:text-ink"
               )}
             >
               <span className="material-symbols-outlined text-[18px]">perm_media</span>
-              <span className="text-[13px] font-medium flex-1 text-left">Media Providers</span>
+              <span className="text-[13px] flex-1 text-left">Media Providers</span>
               <span className="material-symbols-outlined text-[14px] transition-transform" style={{ transform: mediaOpen ? "rotate(180deg)" : "rotate(0deg)" }}>
                 expand_more
               </span>
@@ -257,14 +257,14 @@ export default function Sidebar({ onClose }: SidebarProps) {
                     href={`/dashboard/media-providers/${kind.id}`}
                     onClick={onClose}
                     className={cn(
-                      "flex items-center gap-3 px-4 py-1 rounded-lg transition-all group",
+                      "flex items-center gap-3 px-4 py-1.5 rounded-mini-sm transition-colors group",
                       pathname.startsWith(`/dashboard/media-providers/${kind.id}`)
-                        ? "bg-primary/10 text-primary"
-                        : "text-text-muted hover:bg-surface-2 hover:text-text-main"
+                        ? "bg-surface-base text-ink font-medium"
+                        : "text-charcoal hover:bg-surface-soft hover:text-ink"
                     )}
                   >
                     <span className="material-symbols-outlined text-[16px]">{kind.icon}</span>
-                    <span className="text-sm">{kind.label}</span>
+                    <span className="text-[13px]">{kind.label}</span>
                   </a>
                 ))}
                 <a
@@ -272,14 +272,14 @@ export default function Sidebar({ onClose }: SidebarProps) {
                   href={COMBINED_WEB_ITEM.href}
                   onClick={onClose}
                   className={cn(
-                    "flex items-center gap-3 px-4 py-1 rounded-lg transition-all group",
+                    "flex items-center gap-3 px-4 py-1.5 rounded-mini-sm transition-colors group",
                     pathname.startsWith(COMBINED_WEB_ITEM.href)
-                      ? "bg-primary/10 text-primary"
-                      : "text-text-muted hover:bg-surface-2 hover:text-text-main"
+                      ? "bg-surface-base text-ink font-medium"
+                      : "text-charcoal hover:bg-surface-soft hover:text-ink"
                   )}
                 >
                   <span className="material-symbols-outlined text-[16px]">{COMBINED_WEB_ITEM.icon}</span>
-                  <span className="text-sm">{COMBINED_WEB_ITEM.label}</span>
+                  <span className="text-[13px]">{COMBINED_WEB_ITEM.label}</span>
                 </a>
               </div>
             )}
@@ -290,21 +290,21 @@ export default function Sidebar({ onClose }: SidebarProps) {
                 href={item.href}
                 onClick={onClose}
                 className={cn(
-                  "flex items-center gap-3 px-3 py-1 rounded-lg transition-all group",
+                  "flex items-center gap-3 px-3 py-1.5 rounded-mini-sm transition-colors group",
                   isActive(item.href)
-                    ? "bg-primary/10 text-primary"
-                    : "text-text-muted hover:bg-surface-2 hover:text-text-main"
+                    ? "bg-surface-base text-ink font-medium"
+                    : "text-charcoal hover:bg-surface-soft hover:text-ink"
                 )}
               >
                 <span
                   className={cn(
                     "material-symbols-outlined text-[18px]",
-                    isActive(item.href) ? "fill-1" : "group-hover:text-primary transition-colors"
+                    isActive(item.href) ? "fill-1" : ""
                   )}
                 >
                   {item.icon}
                 </span>
-                <span className="text-[13px] font-medium">{item.label}</span>
+                <span className="text-[13px]">{item.label}</span>
               </a>
             ))}
 
@@ -317,21 +317,21 @@ export default function Sidebar({ onClose }: SidebarProps) {
                   href={item.href}
                   onClick={onClose}
                   className={cn(
-                    "flex items-center gap-3 px-3 py-1 rounded-lg transition-all group",
+                    "flex items-center gap-3 px-3 py-1.5 rounded-mini-sm transition-colors group",
                     isActive(item.href)
-                      ? "bg-primary/10 text-primary"
-                      : "text-text-muted hover:bg-surface-2 hover:text-text-main"
+                      ? "bg-surface-base text-ink font-medium"
+                      : "text-charcoal hover:bg-surface-soft hover:text-ink"
                   )}
                 >
                   <span
                     className={cn(
                       "material-symbols-outlined text-[18px]",
-                      isActive(item.href) ? "fill-1" : "group-hover:text-primary transition-colors"
+                      isActive(item.href) ? "fill-1" : ""
                     )}
                   >
                     {item.icon}
                   </span>
-                  <span className="text-[13px] font-medium">{item.label}</span>
+                  <span className="text-[13px]">{item.label}</span>
                 </a>
               ) : null;
             })}
@@ -341,27 +341,27 @@ export default function Sidebar({ onClose }: SidebarProps) {
               href="/dashboard/profile"
               onClick={onClose}
               className={cn(
-                "flex items-center gap-3 px-3 py-1 rounded-lg transition-all group",
+                "flex items-center gap-3 px-3 py-1.5 rounded-mini-sm transition-colors group",
                 isActive("/dashboard/profile")
-                  ? "bg-primary/10 text-primary"
-                  : "text-text-muted hover:bg-surface-2 hover:text-text-main"
+                  ? "bg-surface-base text-ink font-medium"
+                  : "text-charcoal hover:bg-surface-soft hover:text-ink"
               )}
             >
               <span
                 className={cn(
                   "material-symbols-outlined text-[18px]",
-                  isActive("/dashboard/profile") ? "fill-1" : "group-hover:text-primary transition-colors"
+                  isActive("/dashboard/profile") ? "fill-1" : ""
                 )}
               >
                 settings
               </span>
-              <span className="text-[13px] font-medium">Settings</span>
+              <span className="text-[13px]">Settings</span>
             </a>
           </div>
         </nav>
 
         {/* Footer section */}
-        <div className="p-3 border-t border-border-subtle">
+        <div className="p-3 border-t border-hairline-soft">
           {/* Shutdown button */}
           <Button
             variant="outline"

--- a/web/src/shared/components/layouts/DashboardLayout.tsx
+++ b/web/src/shared/components/layouts/DashboardLayout.tsx
@@ -13,13 +13,13 @@ interface DashboardLayoutProps {
 function getToastStyle(type: string) {
   if (type === "success") {
     return {
-      wrapper: "border-green-500/30 bg-green-500/10 text-green-600 dark:text-green-400",
+      wrapper: "border-success-text/30 bg-success-bg text-success-text",
       icon: "check_circle",
     };
   }
   if (type === "error") {
     return {
-      wrapper: "border-red-500/30 bg-red-500/10 text-red-600 dark:text-red-400",
+      wrapper: "border-[color:var(--color-danger)]/30 bg-[color:var(--color-danger)]/10 text-[color:var(--color-danger)]",
       icon: "error",
     };
   }
@@ -30,7 +30,7 @@ function getToastStyle(type: string) {
     };
   }
   return {
-    wrapper: "border-blue-500/30 bg-blue-500/10 text-blue-600 dark:text-blue-400",
+    wrapper: "border-brand-blue-deep/30 bg-brand-blue-200 text-brand-blue-deep",
     icon: "info",
   };
 }
@@ -49,14 +49,14 @@ export default function DashboardLayout({ children }: DashboardLayoutProps) {
   const removeNotification = useNotificationStore((state) => state.removeNotification);
 
   return (
-    <div className="flex h-screen w-full overflow-hidden bg-bg">
+    <div className="flex h-screen w-full overflow-hidden bg-canvas">
       <div className="fixed top-4 right-4 z-[80] flex w-[min(92vw,380px)] flex-col gap-2">
         {notifications.map((n) => {
           const style = getToastStyle(n.type);
           return (
             <div
               key={n.id}
-              className={`rounded-lg border px-3 py-2 shadow-lg backdrop-blur-sm ${style.wrapper}`}
+              className={`rounded-mini-md border px-3 py-2 shadow-modal backdrop-blur-sm ${style.wrapper}`}
             >
               <div className="flex items-start gap-2">
                 <span className="material-symbols-outlined text-[18px] leading-5">{style.icon}</span>

--- a/web/src/shared/components/styles/global.css
+++ b/web/src/shared/components/styles/global.css
@@ -1,4 +1,5 @@
 @import url('https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined:wght,FILL@100..700,0..1&display=swap');
+@import url('https://fonts.googleapis.com/css2?family=DM+Sans:opsz,wght@9..40,400;9..40,500;9..40,600;9..40,700&family=Inter:wght@400;500;600;700&display=swap');
 
 @tailwind base;
 @tailwind components;
@@ -7,118 +8,232 @@
 @custom-variant dark (&:where(.dark, .dark *));
 
 /* ============================================================
-   OpenProxy palette — adopted from 9remote_private/web
-   Brand orange (dark) / soft coral (light), neutral warm bases
+   OpenProxy palette — MiniMax design system
+   Stark black/white canvas + product brand accents (coral, magenta,
+   blue, purple). DM Sans primary, Inter fallback.
    ============================================================ */
 :root {
-  /* Brand scale (light) - centered on #E56A4A */
-  --color-brand-50: #fdf1ed;
-  --color-brand-100: #fadccf;
-  --color-brand-200: #f4b59c;
-  --color-brand-300: #ee8d6a;
-  --color-brand-400: #ea7855;
-  --color-brand-500: #E56A4A;
-  --color-brand-600: #cc5236;
-  --color-brand-700: #a64027;
-  --color-brand-800: #7a2f1d;
-  --color-brand-900: #4d1e12;
+  /* ------------------------------------------------------------
+     MiniMax brand & product accents
+     ------------------------------------------------------------ */
+  --color-brand-coral: #E2400D;
+  --color-brand-magenta: #D8266F;
+  --color-brand-blue: #1668EE;
+  --color-brand-blue-deep: #0040D8;
+  --color-brand-blue-700: #1F3DB7;
+  --color-brand-blue-200: #DCE7FB;
+  --color-brand-cyan: #5BD2F7;
+  --color-brand-purple: #6E3FF3;
 
-  /* Primary (legacy alias for backward compat with existing components) */
-  --color-primary: var(--color-brand-500);
-  --color-primary-hover: var(--color-brand-600);
+  /* Coral as legacy "brand" scale for backward-compat with existing
+     bg-brand-500 / text-brand-600 utilities. Kept on the coral hue. */
+  --color-brand-50: #FCE9E2;
+  --color-brand-100: #F8C9B8;
+  --color-brand-200: #F2A488;
+  --color-brand-300: #EC7E58;
+  --color-brand-400: #E76434;
+  --color-brand-500: #E2400D;
+  --color-brand-600: #BD350B;
+  --color-brand-700: #962A09;
+  --color-brand-800: #6E1F06;
+  --color-brand-900: #461404;
 
-  /* Surfaces & backgrounds (light) */
-  --color-bg: #FDFAF6;
-  --color-bg-alt: #F7F3EE;
-  --color-surface: #ffffff;
-  --color-surface-2: #f4f4f5;
-  --color-surface-3: #e7e7e9;
-  --color-sidebar: rgba(244, 241, 236, 0.85);
+  /* ------------------------------------------------------------
+     Surface tokens (light)
+     ------------------------------------------------------------ */
+  --color-canvas: #FFFFFF;
+  --color-surface-base: #F5F5F5;
+  --color-surface-soft: #F9F9F9;
+  --color-hairline: #E5E5E5;
+  --color-hairline-soft: #F0F0F0;
+  --color-footer-bg: #0A0A0A;
 
-  /* Borders */
-  --color-border: #e5e7eb;
-  --color-border-subtle: #f1f1f3;
+  /* Legacy aliases for unchanged components.
+     bg / surface / surface-2 / surface-3 still work but point at the
+     new MiniMax tokens. */
+  --color-bg: var(--color-canvas);
+  --color-bg-alt: var(--color-surface-soft);
+  --color-surface: var(--color-canvas);
+  --color-surface-2: var(--color-surface-base);
+  --color-surface-3: var(--color-hairline);
+  --color-sidebar: var(--color-surface-soft);
 
-  /* Text */
-  --color-text: #0a0a0a;
-  --color-text-main: #0a0a0a;
-  --color-text-muted: #6B7280;
-  --color-text-subtle: #9CA3AF;
+  --color-border: var(--color-hairline);
+  --color-border-subtle: var(--color-hairline-soft);
 
-  /* Status */
-  --color-danger: #cf222e;
-  --color-success: #10B981;
+  /* ------------------------------------------------------------
+     Text tokens (light)
+     ------------------------------------------------------------ */
+  --color-ink: #0A0A0A;
+  --color-ink-strong: #000000;
+  --color-charcoal: #1F1F1F;
+  --color-slate: #4A4A4A;
+  --color-steel: #707070;
+  --color-stone: #8A8A8A;
+  --color-muted: #B0B0B0;
+  --color-on-primary: #FFFFFF;
+  --color-on-dark: #FFFFFF;
+
+  /* Legacy aliases — primary becomes near-black per MiniMax spec. */
+  --color-primary: var(--color-ink);
+  --color-primary-hover: var(--color-charcoal);
+  --color-text: var(--color-ink);
+  --color-text-main: var(--color-ink);
+  --color-text-muted: var(--color-slate);
+  --color-text-subtle: var(--color-steel);
+
+  /* ------------------------------------------------------------
+     Status
+     ------------------------------------------------------------ */
+  --color-success-bg: #E8F8E8;
+  --color-success-text: #168A1F;
+  --color-danger: #D45656;
+  --color-success: #168A1F;
   --color-warning: #F59E0B;
-  --color-info: #3B82F6;
+  --color-info: var(--color-brand-blue);
 
-  /* Radius */
-  --radius-brand: 10px;
-  --radius-brand-lg: 14px;
+  /* ------------------------------------------------------------
+     Radius scale (MiniMax)
+     ------------------------------------------------------------ */
+  --radius-xs: 4px;
+  --radius-sm: 6px;
+  --radius-md: 8px;
+  --radius-lg: 12px;
+  --radius-xl: 16px;
+  --radius-xxl: 20px;
+  --radius-xxxl: 24px;
+  --radius-hero: 32px;
+  --radius-pill: 9999px;
 
-  /* Shadows */
-  --shadow-soft: 0 1px 2px 0 rgba(0,0,0,0.04);
-  --shadow-warm: 0 2px 12px -2px rgba(229, 106, 74, 0.18);
-  --shadow-elevated: 0 12px 28px -4px rgba(60, 50, 45, 0.06);
-  --shadow-elev:
-    inset 0 1px 0 0 rgba(255,255,255,0.8),
-    0 1px 2px rgba(15,23,42,0.04),
-    0 12px 36px -8px rgba(15,23,42,0.10);
-  --shadow-focus: 0 0 0 3px rgba(229,106,74,0.18);
+  /* Legacy aliases. */
+  --radius-brand: var(--radius-md);
+  --radius-brand-lg: var(--radius-xl);
+
+  /* ------------------------------------------------------------
+     Spacing scale (MiniMax)
+     ------------------------------------------------------------ */
+  --space-xxs: 4px;
+  --space-xs: 8px;
+  --space-sm: 12px;
+  --space-md: 16px;
+  --space-lg: 20px;
+  --space-xl: 24px;
+  --space-xxl: 32px;
+  --space-xxxl: 40px;
+  --space-section-sm: 48px;
+  --space-section: 64px;
+  --space-section-lg: 80px;
+  --space-hero: 96px;
+
+  /* ------------------------------------------------------------
+     Shadow / elevation
+     ------------------------------------------------------------ */
+  --shadow-soft: 0 1px 2px 0 rgba(0, 0, 0, 0.04);
+  --shadow-card: 0 4px 6px 0 rgba(0, 0, 0, 0.08);
+  --shadow-atmospheric: 0 0 22px 0 rgba(0, 0, 0, 0.08);
+  --shadow-modal: 0 12px 16px -4px rgba(36, 36, 36, 0.08);
+  --shadow-focus: 0 0 0 3px rgba(0, 64, 216, 0.18);
+  --shadow-elevated: var(--shadow-card);
+  --shadow-elev: var(--shadow-card);
+  --shadow-warm: var(--shadow-atmospheric);
+
+  /* ------------------------------------------------------------
+     Typography
+     ------------------------------------------------------------ */
+  --font-sans: 'DM Sans', 'Inter', -apple-system, BlinkMacSystemFont,
+    'Helvetica Neue', Helvetica, Arial, sans-serif;
 
   color-scheme: light;
 }
 
 .dark {
-  /* Brand scale (dark) - centered on #E56A4A, same as light for consistency */
-  --color-brand-50: #fdf1ed;
-  --color-brand-100: #fadccf;
-  --color-brand-200: #f4b59c;
-  --color-brand-300: #ee8d6a;
-  --color-brand-400: #ea7855;
-  --color-brand-500: #E56A4A;
-  --color-brand-600: #cc5236;
-  --color-brand-700: #a64027;
-  --color-brand-800: #7a2f1d;
-  --color-brand-900: #4d1e12;
+  /* Keep all MiniMax brand accents identical in dark mode. */
+  --color-brand-coral: #E2400D;
+  --color-brand-magenta: #D8266F;
+  --color-brand-blue: #2F7AF7;
+  --color-brand-blue-deep: #0F4FE8;
+  --color-brand-blue-700: #2745C2;
+  --color-brand-blue-200: rgba(220, 231, 251, 0.16);
+  --color-brand-cyan: #5BD2F7;
+  --color-brand-purple: #8C5FFF;
 
-  --color-primary: #E56A4A;
-  --color-primary-hover: #cc5236;
+  --color-brand-50: #2C0F02;
+  --color-brand-100: #461404;
+  --color-brand-200: #6E1F06;
+  --color-brand-300: #962A09;
+  --color-brand-400: #BD350B;
+  --color-brand-500: #E2400D;
+  --color-brand-600: #EC7E58;
+  --color-brand-700: #F2A488;
+  --color-brand-800: #F8C9B8;
+  --color-brand-900: #FCE9E2;
 
-  /* Surfaces (dark - Claude-like neutral warm) */
-  --color-bg: #1a1a1a;
-  --color-bg-alt: #1F1F1E;
-  --color-surface: #262626;
-  --color-surface-2: #303030;
-  --color-surface-3: #3a3a3a;
-  --color-sidebar: rgba(30, 30, 30, 0.85);
+  /* Dark surfaces */
+  --color-canvas: #0E0E0E;
+  --color-surface-base: #1A1A1A;
+  --color-surface-soft: #161616;
+  --color-hairline: #2A2A2A;
+  --color-hairline-soft: #1F1F1F;
 
-  --color-border: #333333;
-  --color-border-subtle: #2a2a2a;
+  --color-bg: var(--color-canvas);
+  --color-bg-alt: var(--color-surface-soft);
+  --color-surface: #1A1A1A;
+  --color-surface-2: #232323;
+  --color-surface-3: #303030;
+  --color-sidebar: var(--color-surface-soft);
 
-  --color-text: #ededed;
-  --color-text-main: #ededed;
-  --color-text-muted: #9ca3af;
-  --color-text-subtle: #6b7280;
+  --color-border: var(--color-hairline);
+  --color-border-subtle: var(--color-hairline-soft);
 
-  --color-danger: #ef4444;
-  --color-success: #22c55e;
-  --color-warning: #fbbf24;
-  --color-info: #60a5fa;
+  /* Dark text */
+  --color-ink: #F4F4F4;
+  --color-ink-strong: #FFFFFF;
+  --color-charcoal: #E0E0E0;
+  --color-slate: #B5B5B5;
+  --color-steel: #909090;
+  --color-stone: #6E6E6E;
+  --color-muted: #4A4A4A;
+  --color-on-primary: #0A0A0A;
+  --color-on-dark: #FFFFFF;
 
-  --shadow-soft: 0 1px 2px 0 rgba(0,0,0,0.3);
-  --shadow-warm: 0 2px 12px -2px rgba(229, 106, 74, 0.25);
-  --shadow-elevated: 0 12px 28px -4px rgba(0, 0, 0, 0.45);
-  --shadow-elev:
-    inset 0 1px 0 0 rgba(255,255,255,0.06),
-    0 1px 2px rgba(0,0,0,0.4),
-    0 16px 48px -8px rgba(0,0,0,0.55);
-  --shadow-focus: 0 0 0 3px rgba(229, 106, 74, 0.18);
+  --color-primary: var(--color-ink);
+  --color-primary-hover: var(--color-charcoal);
+  --color-text: var(--color-ink);
+  --color-text-main: var(--color-ink);
+  --color-text-muted: var(--color-slate);
+  --color-text-subtle: var(--color-steel);
+
+  --color-success-bg: rgba(22, 138, 31, 0.18);
+  --color-success-text: #5DD167;
+  --color-danger: #EF6A6A;
+  --color-success: #5DD167;
+  --color-warning: #FBBF24;
+  --color-info: var(--color-brand-blue);
+
+  --shadow-soft: 0 1px 2px 0 rgba(0, 0, 0, 0.4);
+  --shadow-card: 0 4px 6px 0 rgba(0, 0, 0, 0.5);
+  --shadow-atmospheric: 0 0 22px 0 rgba(0, 0, 0, 0.5);
+  --shadow-modal: 0 12px 16px -4px rgba(0, 0, 0, 0.55);
+  --shadow-focus: 0 0 0 3px rgba(47, 122, 247, 0.32);
+  --shadow-elevated: var(--shadow-card);
+  --shadow-elev: var(--shadow-card);
+  --shadow-warm: var(--shadow-atmospheric);
 
   color-scheme: dark;
 }
 
 @theme inline {
-  /* Brand scale */
+  /* MiniMax brand accents */
+  --color-brand-coral: var(--color-brand-coral);
+  --color-brand-magenta: var(--color-brand-magenta);
+  --color-brand-blue: var(--color-brand-blue);
+  --color-brand-blue-deep: var(--color-brand-blue-deep);
+  --color-brand-blue-700: var(--color-brand-blue-700);
+  --color-brand-blue-200: var(--color-brand-blue-200);
+  --color-brand-cyan: var(--color-brand-cyan);
+  --color-brand-purple: var(--color-brand-purple);
+
+  /* Brand scale (legacy compat) */
   --color-brand-50: var(--color-brand-50);
   --color-brand-100: var(--color-brand-100);
   --color-brand-200: var(--color-brand-200);
@@ -130,11 +245,28 @@
   --color-brand-800: var(--color-brand-800);
   --color-brand-900: var(--color-brand-900);
 
-  /* Primary aliases */
+  /* Surface tokens */
+  --color-canvas: var(--color-canvas);
+  --color-surface-base: var(--color-surface-base);
+  --color-surface-soft: var(--color-surface-soft);
+  --color-hairline: var(--color-hairline);
+  --color-hairline-soft: var(--color-hairline-soft);
+  --color-footer-bg: var(--color-footer-bg);
+
+  /* Text tokens */
+  --color-ink: var(--color-ink);
+  --color-ink-strong: var(--color-ink-strong);
+  --color-charcoal: var(--color-charcoal);
+  --color-slate: var(--color-slate);
+  --color-steel: var(--color-steel);
+  --color-stone: var(--color-stone);
+  --color-muted: var(--color-muted);
+  --color-on-primary: var(--color-on-primary);
+  --color-on-dark: var(--color-on-dark);
+
+  /* Legacy semantic aliases */
   --color-primary: var(--color-primary);
   --color-primary-hover: var(--color-primary-hover);
-
-  /* Semantic */
   --color-bg: var(--color-bg);
   --color-bg-alt: var(--color-bg-alt);
   --color-surface: var(--color-surface);
@@ -147,66 +279,173 @@
   --color-text-main: var(--color-text-main);
   --color-text-muted: var(--color-text-muted);
   --color-text-subtle: var(--color-text-subtle);
-  --color-accent: var(--color-brand-500);
+  --color-accent: var(--color-brand-coral);
+  --color-success-bg: var(--color-success-bg);
+  --color-success-text: var(--color-success-text);
   --color-danger: var(--color-danger);
   --color-success: var(--color-success);
   --color-warning: var(--color-warning);
   --color-info: var(--color-info);
 
-  /* Static fallbacks (explicit per-mode usage if needed) */
-  --color-bg-light: #FCFBF9;
-  --color-bg-dark: #1a1a1a;
-  --color-surface-light: #ffffff;
-  --color-surface-dark: #262626;
-  --color-sidebar-light: #F4F1EC;
-  --color-sidebar-dark: #1F1F1E;
-  --color-border-light: #e5e7eb;
-  --color-border-dark: #333333;
-  --color-text-main-light: #0a0a0a;
-  --color-text-main-dark: #ededed;
-  --color-text-muted-light: #6B7280;
-  --color-text-muted-dark: #9ca3af;
+  /* Static fallbacks */
+  --color-bg-light: #FFFFFF;
+  --color-bg-dark: #0E0E0E;
+  --color-surface-light: #FFFFFF;
+  --color-surface-dark: #1A1A1A;
+  --color-sidebar-light: #F9F9F9;
+  --color-sidebar-dark: #161616;
+  --color-border-light: #E5E5E5;
+  --color-border-dark: #2A2A2A;
+  --color-text-main-light: #0A0A0A;
+  --color-text-main-dark: #F4F4F4;
+  --color-text-muted-light: #4A4A4A;
+  --color-text-muted-dark: #B5B5B5;
 
   /* Radius */
+  --radius-xs: var(--radius-xs);
+  --radius-sm: var(--radius-sm);
+  --radius-md: var(--radius-md);
+  --radius-lg: var(--radius-lg);
+  --radius-xl: var(--radius-xl);
+  --radius-xxl: var(--radius-xxl);
+  --radius-xxxl: var(--radius-xxxl);
+  --radius-hero: var(--radius-hero);
+  --radius-pill: var(--radius-pill);
   --radius-brand: var(--radius-brand);
   --radius-brand-lg: var(--radius-brand-lg);
 
   /* Shadows */
   --shadow-soft: var(--shadow-soft);
-  --shadow-warm: var(--shadow-warm);
+  --shadow-card: var(--shadow-card);
+  --shadow-atmospheric: var(--shadow-atmospheric);
+  --shadow-modal: var(--shadow-modal);
+  --shadow-focus: var(--shadow-focus);
   --shadow-elevated: var(--shadow-elevated);
   --shadow-elev: var(--shadow-elev);
-  --shadow-focus: var(--shadow-focus);
+  --shadow-warm: var(--shadow-warm);
 
-  /* Font - Inter primary, Apple system fallback */
-  --font-sans: 'Inter', -apple-system, BlinkMacSystemFont, 'SF Pro Text', 'SF Pro Display', system-ui, sans-serif;
+  /* Font */
+  --font-sans: var(--font-sans);
 }
 
-/* Base */
+/* ============================================================
+   Base
+   ============================================================ */
 body {
-  background-color: var(--color-bg);
-  color: var(--color-text-main);
+  background-color: var(--color-canvas);
+  color: var(--color-ink);
   font-family: var(--font-sans);
+  font-feature-settings: 'ss01', 'cv11';
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
 }
 
-/* Selection - brand-tinted */
+/* MiniMax tightens hero/display leading & letter-spacing. */
+h1, h2, h3 {
+  letter-spacing: -0.01em;
+}
+
+/* Selection — ink (not brand) per MiniMax monochrome canvas. */
 ::selection {
-  background-color: rgba(229, 106, 74, 0.25);
-  color: var(--color-primary);
+  background-color: rgba(10, 10, 10, 0.18);
+  color: var(--color-ink);
 }
 .dark ::selection {
-  background-color: rgba(229, 106, 74, 0.3);
-  color: var(--color-brand-300);
+  background-color: rgba(244, 244, 244, 0.18);
+  color: var(--color-ink);
 }
 
-/* iOS keyboard accent */
+/* iOS keyboard accent — uses brand-blue-deep (form activation color). */
 input, textarea {
-  accent-color: var(--color-primary);
+  accent-color: var(--color-brand-blue-deep);
 }
 
-/* Scrollbar (custom-scrollbar utility kept for compat) */
+/* ============================================================
+   Typography utilities — MiniMax scale
+   ============================================================ */
+.type-hero-display {
+  font-size: 80px;
+  line-height: 1.10;
+  letter-spacing: -2px;
+  font-weight: 600;
+}
+.type-display-lg {
+  font-size: 56px;
+  line-height: 1.10;
+  letter-spacing: -1.5px;
+  font-weight: 600;
+}
+.type-heading-lg {
+  font-size: 40px;
+  line-height: 1.20;
+  letter-spacing: -1px;
+  font-weight: 600;
+}
+.type-heading-md {
+  font-size: 32px;
+  line-height: 1.25;
+  letter-spacing: -0.5px;
+  font-weight: 600;
+}
+.type-heading-sm {
+  font-size: 24px;
+  line-height: 1.30;
+  font-weight: 600;
+}
+.type-card-title {
+  font-size: 20px;
+  line-height: 1.40;
+  font-weight: 600;
+}
+.type-subtitle {
+  font-size: 18px;
+  line-height: 1.50;
+  font-weight: 500;
+}
+.type-body-md {
+  font-size: 16px;
+  line-height: 1.50;
+  font-weight: 400;
+}
+.type-body-md-bold {
+  font-size: 16px;
+  line-height: 1.50;
+  font-weight: 700;
+}
+.type-body-sm {
+  font-size: 14px;
+  line-height: 1.50;
+  font-weight: 400;
+}
+.type-body-sm-medium {
+  font-size: 14px;
+  line-height: 1.50;
+  font-weight: 500;
+}
+.type-caption {
+  font-size: 13px;
+  line-height: 1.70;
+  font-weight: 400;
+}
+.type-caption-bold {
+  font-size: 13px;
+  line-height: 1.50;
+  font-weight: 600;
+}
+.type-micro {
+  font-size: 12px;
+  line-height: 1.50;
+  font-weight: 400;
+}
+.type-button-md {
+  font-size: 14px;
+  line-height: 1.40;
+  font-weight: 600;
+}
+
+/* ============================================================
+   Scrollbar (custom-scrollbar utility kept for compat)
+   ============================================================ */
 .custom-scrollbar::-webkit-scrollbar {
   width: 6px;
 }
@@ -214,46 +453,49 @@ input, textarea {
   background: transparent;
 }
 .custom-scrollbar::-webkit-scrollbar-thumb {
-  background-color: rgba(156, 163, 175, 0.3);
+  background-color: rgba(112, 112, 112, 0.32);
   border-radius: 20px;
 }
 .custom-scrollbar::-webkit-scrollbar-thumb:hover {
-  background-color: var(--color-primary);
+  background-color: var(--color-ink);
 }
 
-/* Thin horizontal scrollbar - brand colored */
+/* Thin horizontal scrollbar — ink colored */
 .scroll-thin-x {
   scrollbar-width: thin;
-  scrollbar-color: rgba(229, 106, 74, 0.55) transparent;
+  scrollbar-color: rgba(10, 10, 10, 0.45) transparent;
 }
 .dark .scroll-thin-x {
-  scrollbar-color: rgba(229, 106, 74, 0.55) transparent;
+  scrollbar-color: rgba(244, 244, 244, 0.45) transparent;
 }
 .scroll-thin-x::-webkit-scrollbar { height: 3px; }
 .scroll-thin-x::-webkit-scrollbar-track { background: transparent; }
 .scroll-thin-x::-webkit-scrollbar-thumb {
-  background: rgba(229, 106, 74, 0.55);
+  background: rgba(10, 10, 10, 0.45);
   border-radius: 3px;
 }
 .dark .scroll-thin-x::-webkit-scrollbar-thumb {
-  background: rgba(229, 106, 74, 0.55);
+  background: rgba(244, 244, 244, 0.45);
 }
 
-/* Reusable elevated card */
+/* ============================================================
+   Reusable card chrome (MiniMax: flat-with-borders default)
+   ============================================================ */
 .card-soft {
-  background-color: var(--color-surface);
-  box-shadow: var(--shadow-soft);
-  border-radius: var(--radius-brand-lg);
+  background-color: var(--color-canvas);
+  border: 1px solid var(--color-hairline);
+  border-radius: var(--radius-xl);
 }
 .card-elev {
-  background-color: var(--color-surface);
-  box-shadow: var(--shadow-elev);
-  border-radius: var(--radius-brand-lg);
+  background-color: var(--color-canvas);
+  border: 1px solid var(--color-hairline);
+  box-shadow: var(--shadow-card);
+  border-radius: var(--radius-xl);
 }
 
 /* Hero gradient (compat) */
 .bg-hero-gradient {
-  background: linear-gradient(180deg, var(--color-bg-alt) 0%, var(--color-bg) 100%);
+  background: linear-gradient(180deg, var(--color-surface-soft) 0%, var(--color-canvas) 100%);
 }
 
 /* macOS Vibrancy */
@@ -263,7 +505,7 @@ input, textarea {
   background: rgba(255, 255, 255, 0.72);
 }
 .dark .bg-vibrancy {
-  background: rgba(38, 38, 38, 0.72);
+  background: rgba(26, 26, 26, 0.72);
 }
 
 /* macOS Traffic Lights */
@@ -325,12 +567,12 @@ button {
 
 @keyframes border-glow {
   0%, 100% {
-    box-shadow: 0 0 5px rgba(229, 106, 74, 0.3), 0 0 10px rgba(229, 106, 74, 0.2);
-    border-color: rgba(229, 106, 74, 0.5);
+    box-shadow: 0 0 5px rgba(226, 64, 13, 0.3), 0 0 10px rgba(226, 64, 13, 0.2);
+    border-color: rgba(226, 64, 13, 0.5);
   }
   50% {
-    box-shadow: 0 0 10px rgba(229, 106, 74, 0.5), 0 0 20px rgba(229, 106, 74, 0.3);
-    border-color: rgba(229, 106, 74, 0.8);
+    box-shadow: 0 0 10px rgba(226, 64, 13, 0.5), 0 0 20px rgba(226, 64, 13, 0.3);
+    border-color: rgba(226, 64, 13, 0.8);
   }
 }
 .animate-border-glow { animation: border-glow 2s ease-in-out infinite; }
@@ -347,110 +589,23 @@ button {
   from { transform: translateY(-10px); opacity: 0; }
   to { transform: translateY(0); opacity: 1; }
 }
-.slide-in-right { animation: slideInFromRight 0.25s cubic-bezier(0.22, 1, 0.36, 1) forwards; }
-.fade-in { animation: fadeIn 0.2s ease-out forwards; }
-.slide-in-top { animation: slideInFromTop 0.18s cubic-bezier(0.22, 1, 0.36, 1) forwards; }
+.animate-slide-in-right { animation: slideInFromRight 0.3s ease-out; }
+.animate-fade-in { animation: fadeIn 0.2s ease-out; }
+.animate-slide-in-top { animation: slideInFromTop 0.2s ease-out; }
 
-@keyframes pulseGlow {
-  0%, 100% { opacity: 0.4; transform: scale(1); }
-  50% { opacity: 0.7; transform: scale(1.05); }
-}
-.animate-pulse-glow { animation: pulseGlow 3s ease-in-out infinite; }
-
-/* CTA shimmer + glow pulse */
-@keyframes ctaShimmer {
-  0% { transform: translateX(-120%) skewX(-20deg); }
-  100% { transform: translateX(220%) skewX(-20deg); }
-}
-@keyframes ctaGlowPulse {
-  0%, 100% { box-shadow: 0 8px 24px -8px rgba(229, 106, 74, 0.45), 0 0 0 0 rgba(229, 106, 74, 0.5); }
-  50% { box-shadow: 0 12px 32px -8px rgba(229, 106, 74, 0.6), 0 0 0 8px rgba(229, 106, 74, 0); }
-}
-.btn-cta {
-  position: relative;
-  overflow: hidden;
-  isolation: isolate;
-  animation: ctaGlowPulse 2.4s ease-in-out infinite;
-}
-.btn-cta::before {
-  content: "";
-  position: absolute;
-  top: 0;
-  left: 0;
-  width: 50%;
-  height: 100%;
-  background: linear-gradient(90deg, transparent, rgba(255,255,255,0.35), transparent);
-  animation: ctaShimmer 2.8s ease-in-out infinite;
-  pointer-events: none;
-  z-index: 1;
-}
-.btn-cta > * { position: relative; z-index: 2; }
-
-/* Dot Grid Background Pattern */
-.dot-grid-bg {
-  background-color: var(--color-bg);
-  background-image:
-    radial-gradient(circle at 15% 20%, rgba(229, 106, 74, 0.10) 0%, transparent 40%),
-    radial-gradient(circle at 85% 80%, rgba(229, 106, 74, 0.06) 0%, transparent 40%);
-}
-.dark .dot-grid-bg {
-  background-image:
-    radial-gradient(circle at 15% 20%, rgba(229, 106, 74, 0.18) 0%, transparent 40%),
-    radial-gradient(circle at 85% 80%, rgba(229, 106, 74, 0.10) 0%, transparent 40%);
-}
-
-/* Landing-style faint grid overlay (use absolute pos inside relative parent) */
+/* ============================================================
+   Landing-grid utility (used as faint background on dashboard)
+   ============================================================ */
 .landing-grid {
   background-image:
-    linear-gradient(to right, var(--color-accent) 1px, transparent 1px),
-    linear-gradient(to bottom, var(--color-accent) 1px, transparent 1px);
-  background-size: 40px 40px;
-  opacity: 0.08;
+    linear-gradient(to right, rgba(10, 10, 10, 0.04) 1px, transparent 1px),
+    linear-gradient(to bottom, rgba(10, 10, 10, 0.04) 1px, transparent 1px);
+  background-size: 32px 32px;
+  mask-image: radial-gradient(ellipse at center, black 30%, transparent 80%);
+  -webkit-mask-image: radial-gradient(ellipse at center, black 30%, transparent 80%);
 }
 .dark .landing-grid {
-  opacity: 0.04;
-}
-
-/* Changelog markdown body */
-.changelog-body h1 {
-  font-size: 1.4rem;
-  font-weight: 700;
-  margin: 1.5rem 0 0.75rem;
-  padding-bottom: 0.5rem;
-  border-bottom: 1px solid var(--color-border);
-}
-.changelog-body h1:first-child { margin-top: 0; }
-.changelog-body h2 {
-  font-size: 1.05rem;
-  font-weight: 600;
-  margin: 1rem 0 0.5rem;
-  color: var(--color-primary);
-}
-.changelog-body h3 {
-  font-size: 0.95rem;
-  font-weight: 600;
-  margin: 0.75rem 0 0.4rem;
-}
-.changelog-body ul {
-  list-style: disc;
-  padding-left: 1.5rem;
-  margin: 0.5rem 0;
-}
-.changelog-body li { margin: 0.25rem 0; line-height: 1.6; }
-.changelog-body p { margin: 0.5rem 0; line-height: 1.6; }
-.changelog-body code {
-  background: var(--color-bg-alt);
-  padding: 0.1rem 0.35rem;
-  border-radius: 4px;
-  font-size: 0.875em;
-  font-family: ui-monospace, monospace;
-}
-.changelog-body a {
-  color: var(--color-primary);
-  text-decoration: underline;
-}
-.changelog-body hr {
-  border: none;
-  border-top: 1px solid var(--color-border);
-  margin: 1.5rem 0;
+  background-image:
+    linear-gradient(to right, rgba(244, 244, 244, 0.04) 1px, transparent 1px),
+    linear-gradient(to bottom, rgba(244, 244, 244, 0.04) 1px, transparent 1px);
 }

--- a/web/tailwind.config.js
+++ b/web/tailwind.config.js
@@ -6,6 +6,44 @@ export default {
   theme: {
     extend: {
       colors: {
+        // ----------------------------------------------------------
+        // MiniMax brand & product accents
+        // ----------------------------------------------------------
+        'brand-coral': 'var(--color-brand-coral)',
+        'brand-magenta': 'var(--color-brand-magenta)',
+        'brand-blue': 'var(--color-brand-blue)',
+        'brand-blue-deep': 'var(--color-brand-blue-deep)',
+        'brand-blue-700': 'var(--color-brand-blue-700)',
+        'brand-blue-200': 'var(--color-brand-blue-200)',
+        'brand-cyan': 'var(--color-brand-cyan)',
+        'brand-purple': 'var(--color-brand-purple)',
+
+        // Surface tokens
+        canvas: 'var(--color-canvas)',
+        'surface-base': 'var(--color-surface-base)',
+        'surface-soft': 'var(--color-surface-soft)',
+        hairline: 'var(--color-hairline)',
+        'hairline-soft': 'var(--color-hairline-soft)',
+        'footer-bg': 'var(--color-footer-bg)',
+
+        // Text tokens
+        ink: 'var(--color-ink)',
+        'ink-strong': 'var(--color-ink-strong)',
+        charcoal: 'var(--color-charcoal)',
+        slate: 'var(--color-slate)',
+        steel: 'var(--color-steel)',
+        stone: 'var(--color-stone)',
+        muted: 'var(--color-muted)',
+        'on-primary': 'var(--color-on-primary)',
+        'on-dark': 'var(--color-on-dark)',
+
+        // Status
+        'success-bg': 'var(--color-success-bg)',
+        'success-text': 'var(--color-success-text)',
+
+        // ----------------------------------------------------------
+        // Legacy aliases (do not remove — referenced across the app)
+        // ----------------------------------------------------------
         brand: {
           50: 'var(--color-brand-50)',
           100: 'var(--color-brand-100)',
@@ -44,11 +82,38 @@ export default {
         },
       },
       borderRadius: {
+        // MiniMax radius scale
+        'mini-xs': 'var(--radius-xs)',
+        'mini-sm': 'var(--radius-sm)',
+        'mini-md': 'var(--radius-md)',
+        'mini-lg': 'var(--radius-lg)',
+        'mini-xl': 'var(--radius-xl)',
+        'mini-xxl': 'var(--radius-xxl)',
+        'mini-xxxl': 'var(--radius-xxxl)',
+        hero: 'var(--radius-hero)',
+        // Legacy aliases
         brand: 'var(--radius-brand)',
         'brand-lg': 'var(--radius-brand-lg)',
       },
+      spacing: {
+        'mini-xxs': 'var(--space-xxs)',
+        'mini-xs': 'var(--space-xs)',
+        'mini-sm': 'var(--space-sm)',
+        'mini-md': 'var(--space-md)',
+        'mini-lg': 'var(--space-lg)',
+        'mini-xl': 'var(--space-xl)',
+        'mini-xxl': 'var(--space-xxl)',
+        'mini-xxxl': 'var(--space-xxxl)',
+        'section-sm': 'var(--space-section-sm)',
+        section: 'var(--space-section)',
+        'section-lg': 'var(--space-section-lg)',
+        hero: 'var(--space-hero)',
+      },
       boxShadow: {
         soft: 'var(--shadow-soft)',
+        card: 'var(--shadow-card)',
+        atmospheric: 'var(--shadow-atmospheric)',
+        modal: 'var(--shadow-modal)',
         warm: 'var(--shadow-warm)',
         elevated: 'var(--shadow-elevated)',
         elev: 'var(--shadow-elev)',


### PR DESCRIPTION
## Summary

Applies the MiniMax design system to the OpenProxy dashboard across three phases. Pure UI refactor — no behavior changes, no backend touched.

### Phase 1 — design tokens & typography
- `web/src/shared/components/styles/global.css`: full MiniMax token system
  - **Brand accents**: `brand-coral`, `brand-magenta`, `brand-blue`, `brand-blue-deep`, `brand-blue-700`, `brand-blue-200`, `brand-cyan`, `brand-purple`
  - **Text scale**: `ink`, `ink-strong`, `charcoal`, `slate`, `steel`, `stone`, `muted`
  - **Surface**: `canvas`, `surface-base`, `surface-soft`, `hairline`, `hairline-soft`
  - **Radius**: `xs`(4) `sm`(6) `md`(8) `lg`(12) `xl`(16) `xxl`(20) `xxxl`(24) `hero`(32) `pill`(9999)
  - **Spacing**: `xxs`(4) -> `hero`(96)
  - **Shadow**: `soft`, `card`, `atmospheric`, `modal`
- DM Sans + Inter import from Google Fonts
- 15 typography utility classes (`type-hero-display` through `type-button-md`) per spec
- Dark-mode shifts for canvas/surface/ink/hairline
- Legacy aliases preserved (`brand-50..900`, `primary`, `bg`, `surface`, `border`, `text-main`) for backward compat

### Phase 2 — primitive components
- **Button**: pill-shaped (`rounded-full`); primary=ink black-pill, secondary=outlined-pill, outline=tertiary white-pill, ghost=link, danger/success kept; sizes `h-8`/`h-9`/`h-11`
- **Card**: radius prop (`lg`/`xl`/`xxl`/`xxxl`/`hero`), defaults to `xl`=16px; `text-ink` on `bg-canvas` with `border-hairline`
- **Badge**: variants `default`/`primary`/`success`/`warning`/`error`/`info`/`new`/`beta`/`code`; success=pale-green, new=coral, beta+code=blue-200; `code` uses square corners per spec
- **Input**: 8px rounded, 1px hairline border, 2px `brand-blue-deep` focus, 40px height
- **SegmentedControl**: three variants — `pill` (default; black-fill active), `segmented` (grouped), `underline` (M2.7-page tab style)

### Phase 3 — chrome / layout
- **Sidebar**: nav-item active = `bg-surface-base text-ink font-medium` (was `bg-primary/10 text-primary`); inactive = `text-charcoal hover:bg-surface-soft`; logo box switched to solid ink; section headers in `text-stone uppercase`
- **Header**: `bg-canvas` + `border-b border-hairline-soft` (removed `surface/60` backdrop blur on desktop); page title in `text-ink` at 28px lg / 18px base
- **DashboardLayout**: `bg-canvas` page background; toast styles use `success-bg`/`danger`/`brand-blue-200`

**Phase 4 (vibrant gradient provider cards) skipped per user direction** — provider cards remain white tiles.

## Verification
- `npm run build` passes — 111 pages
- DM Sans loads from Google Fonts
- Visual sweep on `/dashboard`, `/dashboard/providers`, `/dashboard/providers/openai`, `/dashboard/usage` (Overview + Details tabs), `/dashboard/quota`
- All buttons render as pills (`rounded-full`), active sidebar item shows `surface-base` bg, segmented controls render as black-pill active per `pill-tab` spec

## Screenshots

### Dashboard (Endpoint)
![dashboard](https://app.devin.ai/attachments/b992a950-273c-407c-89dc-1817dd48f467/dashboard.png)

### Providers grid
![providers](https://app.devin.ai/attachments/e64ed1a4-2cde-412b-a21c-b4e0f89e4e0c/providers.png)

### Provider detail (`/openai`)
![provider-detail](https://app.devin.ai/attachments/7f6e762a-1c67-4df7-aca4-b8224ce329ca/provider-detail.png)

### Usage (Overview tab + period selector)
![usage](https://app.devin.ai/attachments/15856d9d-7471-476f-9b52-efc8535656e9/usage.png)
