### PR TITLE
test(combo): isolate rotation tests with unique combo names (fix CI flake)

### DIFF
--- a/tests/combo.rs
+++ b/tests/combo.rs
@@ -33,23 +33,26 @@ fn combo_lookup_ignores_provider_prefixed_models() {
 
 #[test]
 fn round_robin_rotation_advances_state() {
-    reset_combo_rotation(None);
+    // Use a unique combo name + reset only that name so this test does not
+    // race with other tests that mutate the global COMBO_ROTATION_STATE.
+    let combo_name = "writer-rotation-advances";
+    reset_combo_rotation(Some(combo_name));
     let models = vec!["a".to_string(), "b".to_string(), "c".to_string()];
 
     assert_eq!(
-        get_rotated_models(&models, Some("writer"), ComboStrategy::RoundRobin),
+        get_rotated_models(&models, Some(combo_name), ComboStrategy::RoundRobin),
         vec!["a", "b", "c"]
     );
-    assert_eq!(rotation_index("writer"), Some(1));
+    assert_eq!(rotation_index(combo_name), Some(1));
 
     assert_eq!(
-        get_rotated_models(&models, Some("writer"), ComboStrategy::RoundRobin),
+        get_rotated_models(&models, Some(combo_name), ComboStrategy::RoundRobin),
         vec!["b", "c", "a"]
     );
-    assert_eq!(rotation_index("writer"), Some(2));
+    assert_eq!(rotation_index(combo_name), Some(2));
 
     assert_eq!(
-        get_rotated_models(&models, Some("writer"), ComboStrategy::Fallback),
+        get_rotated_models(&models, Some(combo_name), ComboStrategy::Fallback),
         vec!["a", "b", "c"]
     );
 }
@@ -88,14 +91,15 @@ fn fallback_error_rules_retry_for_transient_gateway_statuses() {
 
 #[tokio::test]
 async fn combo_strategy_stops_after_first_success() {
-    reset_combo_rotation(None);
+    let combo_name = "writer-stops-after-success";
+    reset_combo_rotation(Some(combo_name));
     let models = vec!["a".to_string(), "b".to_string(), "c".to_string()];
     let attempts = std::sync::Arc::new(parking_lot::Mutex::new(Vec::new()));
     let seen = attempts.clone();
 
     let result = execute_combo_strategy(
         &models,
-        Some("writer"),
+        Some(combo_name),
         ComboStrategy::Fallback,
         move |model| {
             let seen = seen.clone();
@@ -129,12 +133,13 @@ async fn combo_strategy_stops_after_first_success() {
 
 #[tokio::test]
 async fn combo_strategy_round_robin_uses_rotated_order() {
-    reset_combo_rotation(None);
+    let combo_name = "writer-round-robin-rotated";
+    reset_combo_rotation(Some(combo_name));
     let models = vec!["a".to_string(), "b".to_string(), "c".to_string()];
 
     let first = execute_combo_strategy(
         &models,
-        Some("writer"),
+        Some(combo_name),
         ComboStrategy::RoundRobin,
         |model| {
             let model = model.to_string();
@@ -144,7 +149,7 @@ async fn combo_strategy_round_robin_uses_rotated_order() {
     .await;
     let second = execute_combo_strategy(
         &models,
-        Some("writer"),
+        Some(combo_name),
         ComboStrategy::RoundRobin,
         |model| {
             let model = model.to_string();
@@ -159,14 +164,15 @@ async fn combo_strategy_round_robin_uses_rotated_order() {
 
 #[tokio::test]
 async fn combo_strategy_returns_earliest_retry_after_on_exhaustion() {
-    reset_combo_rotation(None);
+    let combo_name = "writer-earliest-retry-after";
+    reset_combo_rotation(Some(combo_name));
     let models = vec!["a".to_string(), "b".to_string()];
     let early = Utc::now() + Duration::seconds(30);
     let late = Utc::now() + Duration::seconds(90);
 
     let error = execute_combo_strategy(
         &models,
-        Some("writer"),
+        Some(combo_name),
         ComboStrategy::Fallback,
         move |model| {
             let retry_after = if model == "a" { late } else { early };


### PR DESCRIPTION
## Summary

Follow-up đến PR #5 (đã merged). Combo fallback dispatch fix landed trên `main` ở commit 29f5090, **nhưng** rust CI optional check trên PR #5 đã red vì 2 test ở `tests/combo.rs` flake — không phải do combo dispatch fix mà là do test isolation pre-existing.

**Root cause:** `COMBO_ROTATION_STATE` là `Lazy<Mutex<HashMap<String, usize>>>` global, key bằng combo name. 4 tests trong `tests/combo.rs` đều dùng cùng key `"writer"` và gọi `reset_combo_rotation(None)` — tức là wipe sạch toàn bộ HashMap. Khi `cargo test` chạy parallel (mặc định 1 thread per test), 2 test rotate state (`round_robin_rotation_advances_state`, `combo_strategy_round_robin_uses_rotated_order`) clobber state của nhau:

```
round_robin_rotation_advances_state ... FAILED
  left:  ["b", "c", "a"]
  right: ["a", "b", "c"]      ← rotation index đã ở 1 khi test bắt đầu
combo_strategy_round_robin_uses_rotated_order ... FAILED
  left:  Ok("a")
  right: Ok("b")              ← test khác reset state giữa first/second call
```

Reproduce locally: ~40% runs fail (4/10 cụ thể).

**Fix:** Mỗi test dùng combo name riêng + `reset_combo_rotation(Some(name))` để chỉ reset slot của test đó, không động vào state của test khác.

| Test | Combo name mới |
|---|---|
| `round_robin_rotation_advances_state` | `writer-rotation-advances` |
| `combo_strategy_stops_after_first_success` | `writer-stops-after-success` |
| `combo_strategy_round_robin_uses_rotated_order` | `writer-round-robin-rotated` |
| `combo_strategy_returns_earliest_retry_after_on_exhaustion` | `writer-earliest-retry-after` |

**Verified locally** (rustc 1.95):
- `cargo test --test combo` × 30 lần liên tiếp → 30/30 pass
- `cargo test --lib --tests` → 49/49 suites pass, 0 failures
- `cargo fmt --all --check` → clean

Diff scope: chỉ `tests/combo.rs` (+19/-13). Production code không đổi.

## Review & Testing Checklist for Human

(green risk — test-only change, không ảnh hưởng production code)

- [ ] **Run `cargo test --test combo` vài lần** trên local hoặc CI để confirm hết flake (trước fix: ~40% fail; sau fix: 30/30 pass).
- [ ] **Sanity-check naming convention** — nếu repo có pattern combo name khác cho test fixtures, đổi cho khớp.

### Notes

PR #5 đã merge với rust optional CI check failing (job 75228946532) — failure log chính là 2 test này. Optional nên không block merge, nhưng main vẫn đỏ nếu tự nhiên CI re-run. PR này clean main lại.

Production combo fallback dispatch fix (`chat.rs` re-resolve provider mỗi vòng iter `combo_model`) đã land trên main qua PR #5 (commit 29f5090) — không cần redo.

Link to Devin session: https://app.devin.ai/sessions/d34bd5e9988e468dbf2a3bd12a34720e
Requested by: @quangdang46