### PR TITLE
fix(dashboard): unblank cli-tools / usage / quota / mitm / proxy-pools

### DIFF
--- a/web/src/components/CLIToolsPageClient.tsx
+++ b/web/src/components/CLIToolsPageClient.tsx
@@ -7,7 +7,7 @@ import { getModelsByProviderId, PROVIDER_ID_TO_ALIAS } from "@/shared/constants/
 import { ClaudeToolCard, CodexToolCard, DroidToolCard, OpenClawToolCard, HermesToolCard, DefaultToolCard, OpenCodeToolCard, CoworkToolCard, MitmLinkCard } from "./cli-tools";
 import { MITM_TOOLS } from "@/shared/constants/cliTools";
 
-const CLOUD_URL = process.env.NEXT_PUBLIC_CLOUD_URL;
+const CLOUD_URL: string | undefined = (import.meta.env as Record<string, string | undefined>)?.PUBLIC_CLOUD_URL;
 
 
 const STATUS_ENDPOINTS: Record<string, string> = {

--- a/web/src/components/ProxyPoolsPageClient.tsx
+++ b/web/src/components/ProxyPoolsPageClient.tsx
@@ -6,8 +6,8 @@ import { Card, Button, Badge } from "@/shared/components";
 interface Pool {
   id: string;
   name: string;
-  description?: string;
-  active: boolean;
+  proxyUrl?: string;
+  isActive?: boolean;
 }
 
 export default function ProxyPoolsPageClient() {
@@ -23,7 +23,7 @@ export default function ProxyPoolsPageClient() {
       const res = await fetch("/api/proxy-pools");
       if (res.ok) {
         const data = await res.json();
-        setPools(data.pools || []);
+        setPools(data.proxyPools || data.pools || []);
       }
     } catch (error) {
       console.error("Failed to fetch proxy pools:", error);
@@ -57,10 +57,10 @@ export default function ProxyPoolsPageClient() {
               <div className="flex items-center justify-between">
                 <div>
                   <h3 className="font-semibold">{pool.name}</h3>
-                  <p className="text-sm text-text-muted">{pool.description || "No description"}</p>
+                  <p className="text-sm text-text-muted">{pool.proxyUrl || "No proxy URL"}</p>
                 </div>
-                <Badge variant={pool.active ? "success" : "neutral"}>
-                  {pool.active ? "Active" : "Inactive"}
+                <Badge variant={pool.isActive ? "success" : "neutral"}>
+                  {pool.isActive ? "Active" : "Inactive"}
                 </Badge>
               </div>
             </Card>

--- a/web/src/components/cli-tools/ClaudeToolCard.tsx
+++ b/web/src/components/cli-tools/ClaudeToolCard.tsx
@@ -6,7 +6,7 @@ import { Card, Button, ModelSelectModal, ManualConfigModal, Tooltip } from "@/sh
 // import Image from "next/image";
 import EndpointPresetControl from "./EndpointPresetControl";
 
-const CLOUD_URL = process.env.NEXT_PUBLIC_CLOUD_URL;
+const CLOUD_URL: string | undefined = (import.meta.env as Record<string, string | undefined>)?.PUBLIC_CLOUD_URL;
 
 interface DefaultModel {
   alias: string;

--- a/web/src/components/cli-tools/DroidToolCard.tsx
+++ b/web/src/components/cli-tools/DroidToolCard.tsx
@@ -6,7 +6,7 @@ import { Card, Button, ModelSelectModal, ManualConfigModal } from "@/shared/comp
 // import Image from "next/image";
 import EndpointPresetControl from "./EndpointPresetControl";
 
-const CLOUD_URL = process.env.NEXT_PUBLIC_CLOUD_URL;
+const CLOUD_URL: string | undefined = (import.meta.env as Record<string, string | undefined>)?.PUBLIC_CLOUD_URL;
 
 interface Tool {
   name: string;

--- a/web/src/components/usage/ProviderLimits/index.tsx
+++ b/web/src/components/usage/ProviderLimits/index.tsx
@@ -69,7 +69,7 @@ export default function ProviderLimits() {
   // Fetch all provider connections
   const fetchConnections = useCallback(async () => {
     try {
-      const response = await fetch("/api/providers/client");
+      const response = await fetch("/api/providers");
       if (!response.ok) throw new Error("Failed to fetch connections");
 
       const data = await response.json();
@@ -375,12 +375,8 @@ export default function ProviderLimits() {
     };
   }, [autoRefresh, refreshAll]);
 
-  // Filter only supported providers
-  const filteredConnections = connections.filter(
-    (conn) =>
-      USAGE_SUPPORTED_PROVIDERS.includes(conn.provider) &&
-      conn.authType === "oauth",
-  );
+  // Filter only supported providers (OAuth or whitelisted apikey)
+  const filteredConnections = connections.filter(isUsageEligible);
 
   const providerFilteredConnections = filteredConnections.filter(
     (conn) => providerFilter === "all" || conn.provider === providerFilter,

--- a/web/src/components/usage/ProviderTopology.tsx
+++ b/web/src/components/usage/ProviderTopology.tsx
@@ -5,9 +5,8 @@ import {
   ReactFlow,
   Handle,
   Position,
-  Node,
-  Edge,
 } from "@xyflow/react";
+import type { Node, Edge } from "@xyflow/react";
 import "@xyflow/react/dist/style.css";
 import { AI_PROVIDERS } from "@/shared/constants/providers";
 


### PR DESCRIPTION
## Summary

Trang `/dashboard/cli-tools`, `/dashboard/usage`, `/dashboard/quota`, `/dashboard/mitm` (và bonus `/dashboard/proxy-pools`) chỉ render header trống. Đây không phải do thiếu seed data — đây là 4 FE bug độc lập có cùng triệu chứng. Xem chi tiết trong commit message + comment đính kèm sau khi PR mở.

## Review & Testing Checklist for Human
- [ ] Xác nhận `import.meta.env.PUBLIC_CLOUD_URL` đúng convention bạn muốn dùng cho cloud sync (alternative: dùng setting từ DB qua `/api/settings.cloudUrl`).
- [ ] Verify ProviderLimits với một OAuth connection thật (Claude/Codex).
- [ ] Verify Proxy Pools UI: badge Active/Inactive hiển thị đúng theo `isActive`.
- [ ] Quick smoke test: load 5 page (cli-tools, usage, quota, mitm, proxy-pools) trên empty DB → tất cả phải render header + empty state thay vì màn trắng.

### Notes
Không động vào BE Rust hay test suite. tsc --noEmit ra ~2700 lỗi preexisting trên main → repo chưa enforce typecheck CI.