### PR TITLE
feat(cli): M1 foundation — global flags, robot output, schema/doctor, db watcher

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -420,6 +420,12 @@ dependencies = [
 
 [[package]]
 name = "bitflags"
+version = "1.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
+
+[[package]]
+name = "bitflags"
 version = "2.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c4512299f36f043ab09a583e57bceb5a5aab7a73db1805848e8fef3c9e8c78b3"
@@ -836,6 +842,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "directories"
+version = "5.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a49173b84e034382284f27f1af4dcbbd231ffa358c0fe316541a7337f376a35"
+dependencies = [
+ "dirs-sys",
+]
+
+[[package]]
+name = "dirs-sys"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "520f05a5cbd335fae5a99ff7a6ab8627577660ee5cfd6a94a6a929b52ff0321c"
+dependencies = [
+ "libc",
+ "option-ext",
+ "redox_users",
+ "windows-sys 0.48.0",
+]
+
+[[package]]
 name = "displaydoc"
 version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -917,6 +944,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9f1f227452a390804cdb637b74a86990f2a7d7ba4b7d5693aac9b4dd6defd8d6"
 
 [[package]]
+name = "filetime"
+version = "0.2.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2d5b2eef6fafbf69f877e55509ce5b11a760690ac9700a2921be067aa6afaef6"
+dependencies = [
+ "cfg-if",
+ "libc",
+]
+
+[[package]]
 name = "find-msvc-tools"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -982,6 +1019,15 @@ name = "fs_extra"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "42703706b716c37f96a77aea830392ad231f44c9e9a67872fa5548707e11b11c"
+
+[[package]]
+name = "fsevent-sys"
+version = "4.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76ee7a02da4d231650c7cea31349b889be2f45ddb3ef3032d2ec8185f6313fd2"
+dependencies = [
+ "libc",
+]
 
 [[package]]
 name = "futures"
@@ -1526,12 +1572,41 @@ dependencies = [
 ]
 
 [[package]]
+name = "inotify"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fdd168d97690d0b8c412d6b6c10360277f4d7ee495c5d0d5d5fe0854923255cc"
+dependencies = [
+ "bitflags 1.3.2",
+ "inotify-sys",
+ "libc",
+]
+
+[[package]]
+name = "inotify-sys"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e05c02b5e89bff3b946cedeca278abc628fe811e604f027c45a8aa3cf793d0eb"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "inout"
 version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "879f10e63c20629ecabbb64a8010319738c66a5cd0c29b02d63d272b03751d01"
 dependencies = [
  "generic-array",
+]
+
+[[package]]
+name = "instant"
+version = "0.1.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e0242819d153cba4b4b05a5a8f2a7e9bbf97b6055b2a002b395c96b5ff3c0222"
+dependencies = [
+ "cfg-if",
 ]
 
 [[package]]
@@ -1600,6 +1675,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "kqueue"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eac30106d7dce88daf4a3fcb4879ea939476d5074a9b7ddd0fb97fa4bed5596a"
+dependencies = [
+ "kqueue-sys",
+ "libc",
+]
+
+[[package]]
+name = "kqueue-sys"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a7b65860415f949f23fa882e669f2dbd4a0f0eeb1acdd56790b30494afd7da2f"
+dependencies = [
+ "bitflags 2.11.1",
+ "libc",
+]
+
+[[package]]
 name = "lazy_static"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1632,7 +1727,7 @@ version = "0.1.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e02f3bb43d335493c96bf3fd3a321600bf6bd07ed34bc64118e9293bdffea46c"
 dependencies = [
- "bitflags",
+ "bitflags 2.11.1",
  "libc",
  "plain",
  "redox_syscall 0.7.4",
@@ -1736,6 +1831,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "50b7e5b27aa02a74bac8c3f23f448f8d87ff11f92d3aac1a6ed369ee08cc56c1"
 dependencies = [
  "libc",
+ "log",
  "wasi",
  "windows-sys 0.61.2",
 ]
@@ -1755,6 +1851,34 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "tempfile",
+]
+
+[[package]]
+name = "notify"
+version = "7.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c533b4c39709f9ba5005d8002048266593c1cfaf3c5f0739d5b8ab0c6c504009"
+dependencies = [
+ "bitflags 2.11.1",
+ "filetime",
+ "fsevent-sys",
+ "inotify",
+ "kqueue",
+ "libc",
+ "log",
+ "mio",
+ "notify-types",
+ "walkdir",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "notify-types"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "585d3cb5e12e01aed9e8a1f70d5c6b5e86fe2a6e48fc8cd0b3e0b8df6f6eb174"
+dependencies = [
+ "instant",
 ]
 
 [[package]]
@@ -1868,6 +1992,7 @@ dependencies = [
  "clap",
  "clap_complete",
  "dashmap",
+ "directories",
  "dotenvy",
  "fnv",
  "futures-util",
@@ -1879,6 +2004,7 @@ dependencies = [
  "hyper-util",
  "jsonwebtoken",
  "libc",
+ "notify",
  "once_cell",
  "parking_lot",
  "rand",
@@ -1894,7 +2020,7 @@ dependencies = [
  "sha256",
  "simd-json",
  "tempfile",
- "thiserror",
+ "thiserror 2.0.18",
  "time",
  "tokio",
  "tokio-util",
@@ -1916,7 +2042,7 @@ version = "0.10.78"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f38c4372413cdaaf3cc79dd92d29d7d9f5ab09b51b10dded508fb90bb70b9222"
 dependencies = [
- "bitflags",
+ "bitflags 2.11.1",
  "cfg-if",
  "foreign-types",
  "libc",
@@ -1953,6 +2079,12 @@ dependencies = [
  "pkg-config",
  "vcpkg",
 ]
+
+[[package]]
+name = "option-ext"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
 
 [[package]]
 name = "outref"
@@ -2169,7 +2301,7 @@ version = "0.5.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
 dependencies = [
- "bitflags",
+ "bitflags 2.11.1",
 ]
 
 [[package]]
@@ -2178,7 +2310,18 @@ version = "0.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f450ad9c3b1da563fb6948a8e0fb0fb9269711c9c73d9ea1de5058c79c8d643a"
 dependencies = [
- "bitflags",
+ "bitflags 2.11.1",
+]
+
+[[package]]
+name = "redox_users"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba009ff324d1fc1b900bd1fdb31564febe58a8ccc8a6fdbb93b543d33b13ca43"
+dependencies = [
+ "getrandom 0.2.17",
+ "libredox",
+ "thiserror 1.0.69",
 ]
 
 [[package]]
@@ -2316,7 +2459,7 @@ version = "0.32.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7753b721174eb8ff87a9a0e799e2d7bc3749323e773db92e0984debb00019d6e"
 dependencies = [
- "bitflags",
+ "bitflags 2.11.1",
  "fallible-iterator",
  "fallible-streaming-iterator",
  "hashlink",
@@ -2330,7 +2473,7 @@ version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
 dependencies = [
- "bitflags",
+ "bitflags 2.11.1",
  "errno",
  "libc",
  "linux-raw-sys",
@@ -2398,6 +2541,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
 
 [[package]]
+name = "same-file"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
+dependencies = [
+ "winapi-util",
+]
+
+[[package]]
 name = "schannel"
 version = "0.1.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2418,7 +2570,7 @@ version = "3.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b7f4bc775c73d9a02cde8bf7b2ec4c9d12743edf609006c7facc23998404cd1d"
 dependencies = [
- "bitflags",
+ "bitflags 2.11.1",
  "core-foundation 0.10.1",
  "core-foundation-sys",
  "libc",
@@ -2632,7 +2784,7 @@ checksum = "0d585997b0ac10be3c5ee635f1bab02d512760d14b7c468801ac8a01d9ae5f1d"
 dependencies = [
  "num-bigint",
  "num-traits",
- "thiserror",
+ "thiserror 2.0.18",
  "time",
 ]
 
@@ -2729,7 +2881,7 @@ version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a13f3d0daba03132c0aa9767f98351b3488edc2c100cda2d2ec2b04f3d8d3c8b"
 dependencies = [
- "bitflags",
+ "bitflags 2.11.1",
  "core-foundation 0.9.4",
  "system-configuration-sys",
 ]
@@ -2759,11 +2911,31 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
+version = "1.0.69"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6aaf5339b578ea85b50e080feb250a3e8ae8cfcdff9a461c9ec2904bc923f52"
+dependencies = [
+ "thiserror-impl 1.0.69",
+]
+
+[[package]]
+name = "thiserror"
 version = "2.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4288b5bcbc7920c07a1149a35cf9590a2aa808e0bc1eafaade0b80947865fbc4"
 dependencies = [
- "thiserror-impl",
+ "thiserror-impl 2.0.18",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "1.0.69"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -2952,7 +3124,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d4e6559d53cc268e5031cd8429d05415bc4cb4aefc4aa5d6cc35fbf5b924a1f8"
 dependencies = [
  "async-compression",
- "bitflags",
+ "bitflags 2.11.1",
  "bytes",
  "futures-core",
  "futures-util",
@@ -3176,6 +3348,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5c3082ca00d5a5ef149bb8b555a72ae84c9c59f7250f013ac822ac2e49b19c64"
 
 [[package]]
+name = "walkdir"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "29790946404f91d9c5d06f9874efddea1dc06c5efe94541a7d6863108e3a5e4b"
+dependencies = [
+ "same-file",
+ "winapi-util",
+]
+
+[[package]]
 name = "want"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3310,7 +3492,7 @@ version = "0.244.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "47b807c72e1bac69382b3a6fb3dbe8ea4c0ed87ff5629b8685ae6b9a611028fe"
 dependencies = [
- "bitflags",
+ "bitflags 2.11.1",
  "hashbrown 0.15.5",
  "indexmap",
  "semver",
@@ -3335,6 +3517,15 @@ dependencies = [
  "libredox",
  "wasite",
  "web-sys",
+]
+
+[[package]]
+name = "winapi-util"
+version = "0.1.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
+dependencies = [
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3409,11 +3600,20 @@ dependencies = [
 
 [[package]]
 name = "windows-sys"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "677d2418bec65e3338edb076e806bc1ec15693c5d0104683f2efe857f61056a9"
+dependencies = [
+ "windows-targets 0.48.5",
+]
+
+[[package]]
+name = "windows-sys"
 version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
 dependencies = [
- "windows-targets",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -3427,19 +3627,40 @@ dependencies = [
 
 [[package]]
 name = "windows-targets"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a2fa6e2155d7247be68c096456083145c183cbbbc2764150dda45a87197940c"
+dependencies = [
+ "windows_aarch64_gnullvm 0.48.5",
+ "windows_aarch64_msvc 0.48.5",
+ "windows_i686_gnu 0.48.5",
+ "windows_i686_msvc 0.48.5",
+ "windows_x86_64_gnu 0.48.5",
+ "windows_x86_64_gnullvm 0.48.5",
+ "windows_x86_64_msvc 0.48.5",
+]
+
+[[package]]
+name = "windows-targets"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973"
 dependencies = [
- "windows_aarch64_gnullvm",
- "windows_aarch64_msvc",
- "windows_i686_gnu",
+ "windows_aarch64_gnullvm 0.52.6",
+ "windows_aarch64_msvc 0.52.6",
+ "windows_i686_gnu 0.52.6",
  "windows_i686_gnullvm",
- "windows_i686_msvc",
- "windows_x86_64_gnu",
- "windows_x86_64_gnullvm",
- "windows_x86_64_msvc",
+ "windows_i686_msvc 0.52.6",
+ "windows_x86_64_gnu 0.52.6",
+ "windows_x86_64_gnullvm 0.52.6",
+ "windows_x86_64_msvc 0.52.6",
 ]
+
+[[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b38e32f0abccf9987a4e3079dfb67dcd799fb61361e53e2882c3cbaf0d905d8"
 
 [[package]]
 name = "windows_aarch64_gnullvm"
@@ -3449,9 +3670,21 @@ checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
 
 [[package]]
 name = "windows_aarch64_msvc"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc35310971f3b2dbbf3f0690a219f40e2d9afcf64f9ab7cc1be722937c26b4bc"
+
+[[package]]
+name = "windows_aarch64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a75915e7def60c94dcef72200b9a8e58e5091744960da64ec734a6c6e9b3743e"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -3467,9 +3700,21 @@ checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
 
 [[package]]
 name = "windows_i686_msvc"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f55c233f70c4b27f66c523580f78f1004e8b5a8b659e05a4eb49d4166cca406"
+
+[[package]]
+name = "windows_i686_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "53d40abd2583d23e4718fddf1ebec84dbff8381c07cae67ff7768bbf19c6718e"
 
 [[package]]
 name = "windows_x86_64_gnu"
@@ -3479,9 +3724,21 @@ checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b7b52767868a23d5bab768e390dc5f5c55825b6d30b86c844ff2dc7414044cc"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed94fce61571a4006852b7389a063ab983c02eb1bb37b47f8272ce92d06d9538"
 
 [[package]]
 name = "windows_x86_64_msvc"
@@ -3585,7 +3842,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9d66ea20e9553b30172b5e831994e35fbde2d165325bec84fc43dbf6f4eb9cb2"
 dependencies = [
  "anyhow",
- "bitflags",
+ "bitflags 2.11.1",
  "indexmap",
  "log",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -98,6 +98,11 @@ time = "0.3"
 # Client identity
 whoami = "1"
 
+# CLI: file system watcher for hot-reload of db.json from CLI writes
+notify = "7"
+# CLI: cross-platform user config directory resolution
+directories = "5"
+
 [dev-dependencies]
 tempfile = "3"
 wiremock = "0.6"

--- a/src/cli/config.rs
+++ b/src/cli/config.rs
@@ -1,0 +1,202 @@
+//! CLI configuration and profile resolution.
+//!
+//! Most users never need this — by default the CLI uses `DATA_DIR` (or `~/.openproxy`)
+//! and writes the local DB directly. Config profiles are only useful when:
+//!
+//! - You manage multiple OpenProxy instances at different `DATA_DIR`s.
+//! - You remote-manage a server at another host (`--url https://...`).
+//!
+//! The config file lives at:
+//! - Linux/macOS: `~/.config/openproxy/config.toml`
+//! - Windows:     `%APPDATA%\openproxy\config.toml`
+//!
+//! Resolution precedence (highest first):
+//! 1. Explicit CLI flags (`--data-dir`, `--url`, `--api-key`)
+//! 2. `OPENPROXY_*` environment variables
+//! 3. Selected profile (`--profile <name>` or `default_profile`)
+//! 4. Built-in defaults
+
+use std::collections::BTreeMap;
+use std::path::PathBuf;
+
+use anyhow::Context;
+use serde::{Deserialize, Serialize};
+
+/// Resolved per-invocation configuration the CLI works against.
+#[derive(Debug, Clone)]
+pub struct ResolvedConfig {
+    pub data_dir: PathBuf,
+    /// `Some(url)` enables remote management mode (CLI talks HTTPS to a remote
+    /// `openproxy` server). `None` means local DB-direct mode.
+    pub remote_url: Option<String>,
+    /// API key for the remote server (read once at resolve time so we never
+    /// touch the env again later).
+    pub api_key: Option<String>,
+    pub profile: Option<String>,
+}
+
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+pub struct ConfigFile {
+    #[serde(default)]
+    pub default_profile: Option<String>,
+    #[serde(default)]
+    pub profiles: BTreeMap<String, Profile>,
+}
+
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+pub struct Profile {
+    #[serde(default)]
+    pub data_dir: Option<String>,
+    #[serde(default)]
+    pub url: Option<String>,
+    /// Name of the env var holding the API key (preferred over `api_key`).
+    #[serde(default)]
+    pub api_key_env: Option<String>,
+    #[serde(default)]
+    pub api_key: Option<String>,
+}
+
+/// CLI flag overrides supplied by clap.
+#[derive(Debug, Clone, Default)]
+pub struct CliOverrides {
+    pub data_dir: Option<PathBuf>,
+    pub url: Option<String>,
+    pub api_key: Option<String>,
+    pub profile: Option<String>,
+}
+
+impl ResolvedConfig {
+    pub fn resolve(overrides: CliOverrides) -> anyhow::Result<Self> {
+        let file = load_config_file().unwrap_or_default();
+
+        let profile_name = overrides
+            .profile
+            .clone()
+            .or_else(|| std::env::var("OPENPROXY_PROFILE").ok())
+            .or_else(|| file.default_profile.clone());
+
+        let profile = profile_name
+            .as_deref()
+            .and_then(|name| file.profiles.get(name).cloned())
+            .unwrap_or_default();
+
+        let data_dir = overrides
+            .data_dir
+            .or_else(|| std::env::var_os("DATA_DIR").map(PathBuf::from))
+            .or_else(|| std::env::var_os("OPENPROXY_DATA_DIR").map(PathBuf::from))
+            .or_else(|| profile.data_dir.as_deref().map(PathBuf::from))
+            .unwrap_or_else(default_data_dir);
+
+        let remote_url = overrides
+            .url
+            .or_else(|| std::env::var("OPENPROXY_URL").ok())
+            .or(profile.url);
+
+        let api_key = overrides
+            .api_key
+            .or_else(|| std::env::var("OPENPROXY_API_KEY").ok())
+            .or_else(|| {
+                profile
+                    .api_key_env
+                    .as_deref()
+                    .and_then(|name| std::env::var(name).ok())
+            })
+            .or(profile.api_key);
+
+        Ok(Self {
+            data_dir,
+            remote_url,
+            api_key,
+            profile: profile_name,
+        })
+    }
+
+    pub fn is_remote(&self) -> bool {
+        self.remote_url.is_some()
+    }
+}
+
+fn default_data_dir() -> PathBuf {
+    std::env::var_os("HOME")
+        .map(PathBuf::from)
+        .map(|home| home.join(".openproxy"))
+        .unwrap_or_else(|| PathBuf::from(".openproxy"))
+}
+
+fn config_file_path() -> Option<PathBuf> {
+    if let Ok(custom) = std::env::var("OPENPROXY_CONFIG") {
+        return Some(PathBuf::from(custom));
+    }
+    let dirs = directories::ProjectDirs::from("", "", "openproxy")?;
+    Some(dirs.config_dir().join("config.toml"))
+}
+
+fn load_config_file() -> anyhow::Result<ConfigFile> {
+    let Some(path) = config_file_path() else {
+        return Ok(ConfigFile::default());
+    };
+    if !path.exists() {
+        return Ok(ConfigFile::default());
+    }
+    let text = std::fs::read_to_string(&path)
+        .with_context(|| format!("read config file at {}", path.display()))?;
+    let parsed: ConfigFile = toml::from_str(&text)
+        .with_context(|| format!("parse config file at {}", path.display()))?;
+    Ok(parsed)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::Mutex;
+
+    static ENV_LOCK: Mutex<()> = Mutex::new(());
+
+    fn clear_env() {
+        std::env::remove_var("DATA_DIR");
+        std::env::remove_var("OPENPROXY_DATA_DIR");
+        std::env::remove_var("OPENPROXY_URL");
+        std::env::remove_var("OPENPROXY_API_KEY");
+        std::env::remove_var("OPENPROXY_PROFILE");
+        std::env::remove_var("OPENPROXY_CONFIG");
+    }
+
+    #[test]
+    fn flags_override_env_and_defaults() {
+        let _g = ENV_LOCK.lock().unwrap();
+        clear_env();
+        std::env::set_var("DATA_DIR", "/tmp/from-env");
+        let resolved = ResolvedConfig::resolve(CliOverrides {
+            data_dir: Some(PathBuf::from("/tmp/from-flag")),
+            url: Some("http://x".into()),
+            api_key: Some("k".into()),
+            profile: None,
+        })
+        .unwrap();
+        assert_eq!(resolved.data_dir, PathBuf::from("/tmp/from-flag"));
+        assert_eq!(resolved.remote_url.as_deref(), Some("http://x"));
+        assert_eq!(resolved.api_key.as_deref(), Some("k"));
+        assert!(resolved.is_remote());
+        clear_env();
+    }
+
+    #[test]
+    fn env_used_when_no_flag() {
+        let _g = ENV_LOCK.lock().unwrap();
+        clear_env();
+        std::env::set_var("DATA_DIR", "/tmp/env-only");
+        let resolved = ResolvedConfig::resolve(CliOverrides::default()).unwrap();
+        assert_eq!(resolved.data_dir, PathBuf::from("/tmp/env-only"));
+        assert!(resolved.remote_url.is_none());
+        clear_env();
+    }
+
+    #[test]
+    fn default_data_dir_when_nothing_set() {
+        let _g = ENV_LOCK.lock().unwrap();
+        clear_env();
+        let resolved = ResolvedConfig::resolve(CliOverrides::default()).unwrap();
+        assert!(resolved.data_dir.ends_with(".openproxy"));
+        clear_env();
+    }
+}

--- a/src/cli/doctor.rs
+++ b/src/cli/doctor.rs
@@ -1,0 +1,167 @@
+//! `openproxy doctor` — agent self-test.
+//!
+//! Runs a fixed set of checks and reports them in `--robot` JSON or a human
+//! summary. Designed to be the first command an agent runs to figure out
+//! whether the local OpenProxy install is healthy enough to use.
+
+use std::path::Path;
+use std::time::Duration;
+
+use serde_json::{json, Value};
+
+use crate::cli::config::ResolvedConfig;
+use crate::cli::output::{emit_robot, humanln, OutputCtx};
+
+#[derive(Debug, Clone)]
+struct Check {
+    name: &'static str,
+    ok: bool,
+    detail: String,
+}
+
+impl Check {
+    fn ok(name: &'static str, detail: impl Into<String>) -> Self {
+        Self {
+            name,
+            ok: true,
+            detail: detail.into(),
+        }
+    }
+    fn fail(name: &'static str, detail: impl Into<String>) -> Self {
+        Self {
+            name,
+            ok: false,
+            detail: detail.into(),
+        }
+    }
+}
+
+pub async fn run(ctx: OutputCtx, cfg: &ResolvedConfig) -> anyhow::Result<i32> {
+    let mut checks: Vec<Check> = Vec::new();
+
+    checks.push(check_data_dir(&cfg.data_dir));
+    checks.push(check_db_file(&cfg.data_dir));
+    checks.push(check_db_loadable().await);
+
+    if let Some(url) = cfg.remote_url.as_deref() {
+        checks.push(check_server_reachable(url).await);
+    } else {
+        checks.push(check_local_server_reachable().await);
+    }
+
+    let all_ok = checks.iter().all(|c| c.ok);
+
+    if ctx.is_robot() {
+        let payload = json!({
+            "ok": all_ok,
+            "checks": checks
+                .iter()
+                .map(|c| json!({"name": c.name, "ok": c.ok, "detail": c.detail}))
+                .collect::<Vec<_>>(),
+        });
+        emit_robot("openproxy.v1.doctor", payload)?;
+    } else {
+        humanln(ctx, "openproxy doctor:");
+        for c in &checks {
+            let mark = if c.ok { "ok  " } else { "FAIL" };
+            humanln(ctx, format!("  [{mark}] {} — {}", c.name, c.detail));
+        }
+        humanln(
+            ctx,
+            if all_ok {
+                "result: all checks passed"
+            } else {
+                "result: at least one check failed"
+            },
+        );
+    }
+
+    Ok(if all_ok { 0 } else { 1 })
+}
+
+fn check_data_dir(dir: &Path) -> Check {
+    if dir.exists() {
+        Check::ok("data_dir", format!("{} exists", dir.display()))
+    } else {
+        Check::fail(
+            "data_dir",
+            format!(
+                "{} does not exist (will be created on first write)",
+                dir.display()
+            ),
+        )
+    }
+}
+
+fn check_db_file(dir: &Path) -> Check {
+    let db = dir.join("db.json");
+    if db.exists() {
+        Check::ok("db_file", format!("{} present", db.display()))
+    } else {
+        Check::fail(
+            "db_file",
+            format!(
+                "{} not found (run 'openproxy server start' once to initialize)",
+                db.display()
+            ),
+        )
+    }
+}
+
+async fn check_db_loadable() -> Check {
+    match crate::db::Db::load().await {
+        Ok(db) => {
+            let snap = db.snapshot();
+            Check::ok(
+                "db_loadable",
+                format!(
+                    "{} providers, {} keys, {} pools, {} combos",
+                    snap.provider_connections.len(),
+                    snap.api_keys.len(),
+                    snap.proxy_pools.len(),
+                    snap.combos.len()
+                ),
+            )
+        }
+        Err(e) => Check::fail("db_loadable", format!("failed: {e}")),
+    }
+}
+
+async fn check_local_server_reachable() -> Check {
+    let port = std::env::var("PORT").unwrap_or_else(|_| "4623".to_string());
+    let url = format!("http://127.0.0.1:{port}/health");
+    probe(&url, "server_reachable").await
+}
+
+async fn check_server_reachable(base: &str) -> Check {
+    let url = format!("{}/health", base.trim_end_matches('/'));
+    probe(&url, "server_reachable").await
+}
+
+async fn probe(url: &str, name: &'static str) -> Check {
+    let client = match reqwest::Client::builder()
+        .timeout(Duration::from_millis(800))
+        .build()
+    {
+        Ok(c) => c,
+        Err(e) => return Check::fail(name, format!("client init failed: {e}")),
+    };
+
+    match client.get(url).send().await {
+        Ok(resp) if resp.status().is_success() => {
+            let body: Result<Value, _> = resp.json().await;
+            let detail = body
+                .ok()
+                .and_then(|v| v.get("status").and_then(|s| s.as_str()).map(str::to_string))
+                .unwrap_or_else(|| "ok".to_string());
+            Check::ok(name, format!("{url} → {detail}"))
+        }
+        Ok(resp) => Check::fail(name, format!("{url} → HTTP {}", resp.status())),
+        Err(_) => Check::fail(
+            name,
+            format!(
+                "{url} unreachable (server not running? start: openproxy server start --detach)"
+            ),
+        ),
+    }
+}

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -19,8 +19,16 @@ use crate::types::{ApiKey, AppDb, ProviderConnection, ProxyPool};
 
 use crate::core::tunnel::{TunnelManager, TunnelProvider};
 
+pub mod config;
+pub mod doctor;
+pub mod output;
+pub mod schema;
+
 #[derive(Debug, Clone, Parser)]
-#[command(name = "openproxy", about = "Local AI routing gateway")]
+#[command(
+    name = "openproxy",
+    about = "Local AI routing gateway (server + agent-first CLI)"
+)]
 pub struct Cli {
     #[arg(long, env = "HOST", default_value = "0.0.0.0")]
     pub host: String,
@@ -31,11 +39,80 @@ pub struct Cli {
     #[arg(long, env = "RUST_LOG", default_value = "info")]
     pub log_filter: String,
 
-    #[arg(long, env = "DATA_DIR")]
+    /// Path to the OpenProxy data directory (db.json, usage.json).
+    /// Falls back to $DATA_DIR or ~/.openproxy.
+    #[arg(long, env = "DATA_DIR", global = true)]
     pub data_dir: Option<PathBuf>,
+
+    /// Emit a stable JSON envelope (`openproxy.v1.*`) to stdout for agents.
+    /// No banners, no color, NDJSON for streaming commands.
+    #[arg(long, global = true)]
+    pub robot: bool,
+
+    /// Increase logging verbosity (-v info, -vv debug, -vvv trace).
+    #[arg(short = 'v', long = "verbose", action = clap::ArgAction::Count, global = true)]
+    pub verbose: u8,
+
+    /// Suppress non-essential human output. Errors still go to stderr.
+    #[arg(short = 'q', long, global = true)]
+    pub quiet: bool,
+
+    /// Color preference for human output. Default = auto-detect TTY.
+    #[arg(long, value_enum, default_value_t = ColorChoice::Auto, global = true)]
+    pub color: ColorChoice,
+
+    /// Optional config profile (from ~/.config/openproxy/config.toml).
+    #[arg(long, env = "OPENPROXY_PROFILE", global = true)]
+    pub profile: Option<String>,
+
+    /// Remote management mode: target a server at this base URL instead of
+    /// the local DB. Pairs with --api-key (or $OPENPROXY_API_KEY).
+    #[arg(long, env = "OPENPROXY_URL", global = true)]
+    pub url: Option<String>,
+
+    /// API key for remote management. Read from $OPENPROXY_API_KEY by default.
+    #[arg(long, env = "OPENPROXY_API_KEY", global = true, hide_env_values = true)]
+    pub api_key: Option<String>,
 
     #[command(subcommand)]
     pub cmd: Option<Command>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, clap::ValueEnum)]
+pub enum ColorChoice {
+    Auto,
+    Always,
+    Never,
+}
+
+impl Cli {
+    /// Build the resolved output context shared by every subcommand.
+    pub fn output_ctx(&self) -> output::OutputCtx {
+        let mode = if self.robot {
+            output::OutputMode::Robot
+        } else {
+            output::OutputMode::Human
+        };
+        let color = match self.color {
+            ColorChoice::Auto => output::ColorMode::Auto,
+            ColorChoice::Always => output::ColorMode::Always,
+            ColorChoice::Never => output::ColorMode::Never,
+        };
+        output::OutputCtx {
+            mode,
+            color,
+            quiet: self.quiet,
+        }
+    }
+
+    pub fn cli_overrides(&self) -> config::CliOverrides {
+        config::CliOverrides {
+            data_dir: self.data_dir.clone(),
+            url: self.url.clone(),
+            api_key: self.api_key.clone(),
+            profile: self.profile.clone(),
+        }
+    }
 }
 
 #[derive(Debug, Clone, Subcommand)]
@@ -76,6 +153,30 @@ pub enum Command {
     Completion {
         #[arg(value_enum)]
         shell: Shell,
+    },
+    /// Print JSON Schema / examples for resources the CLI accepts.
+    /// Useful for agents to discover the right shape before generating payloads.
+    Schema {
+        #[command(subcommand)]
+        cmd: SchemaCmd,
+    },
+    /// Run a self-test of the local install (data dir, db, server health).
+    Doctor,
+}
+
+#[derive(Debug, Clone, Subcommand)]
+pub enum SchemaCmd {
+    /// List all resources for which the CLI exposes a schema/example.
+    List,
+    /// Print the JSON Schema for a single resource.
+    Show {
+        /// Resource name (e.g. provider, combo, key, pool, settings).
+        resource: String,
+    },
+    /// Print an example payload for a single resource.
+    Example {
+        /// Resource name (e.g. provider, combo, key, pool, settings).
+        resource: String,
     },
 }
 
@@ -146,6 +247,8 @@ pub enum TunnelCmd {
 impl Cli {
     pub fn run(self) -> anyhow::Result<()> {
         let rt = tokio::runtime::Runtime::new()?;
+        let ctx = self.output_ctx();
+        let overrides = self.cli_overrides();
         if let Some(cmd) = self.cmd {
             match cmd {
                 Command::Provider { cmd } => {
@@ -187,6 +290,24 @@ impl Cli {
                     let mut cmd = Cli::command();
                     clap_complete::generate(shell, &mut cmd, "openproxy", &mut std::io::stdout());
                     Ok(())
+                }
+                Command::Schema { cmd } => {
+                    // Schema commands have no async I/O; we still go through
+                    // the same dispatcher so the global flags (--robot, etc.)
+                    // are honored uniformly.
+                    match cmd {
+                        SchemaCmd::List => schema::run_list(ctx),
+                        SchemaCmd::Show { resource } => {
+                            schema::run_show(ctx, &resource).map(|_| ())
+                        }
+                        SchemaCmd::Example { resource } => {
+                            schema::run_example(ctx, &resource).map(|_| ())
+                        }
+                    }
+                }
+                Command::Doctor => {
+                    let resolved = config::ResolvedConfig::resolve(overrides)?;
+                    rt.block_on(doctor::run(ctx, &resolved)).map(|_| ())
                 }
             }
         } else {

--- a/src/cli/output.rs
+++ b/src/cli/output.rs
@@ -1,0 +1,223 @@
+//! CLI output formatting: human (default) vs robot (JSON envelope) vs NDJSON streams.
+//!
+//! Every CLI command should produce output through this module so that:
+//! - Agents can rely on a stable, schema-versioned JSON envelope (`--robot`).
+//! - Humans get readable, optionally colored output by default.
+//! - Streaming commands emit one JSON object per line in `--robot` mode (NDJSON).
+
+use std::io::{self, IsTerminal, Write};
+
+use serde::Serialize;
+use serde_json::{json, Value};
+
+/// User-selectable output mode applied uniformly across commands.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum OutputMode {
+    /// Default human-readable output (auto-detect TTY for color).
+    #[default]
+    Human,
+    /// `--robot`: stable JSON envelope to stdout. No banners, no color.
+    Robot,
+}
+
+/// Color preference resolved from `--color` flag and TTY detection.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ColorMode {
+    Auto,
+    Always,
+    Never,
+}
+
+impl Default for ColorMode {
+    fn default() -> Self {
+        ColorMode::Auto
+    }
+}
+
+impl ColorMode {
+    pub fn enabled(self) -> bool {
+        match self {
+            ColorMode::Always => true,
+            ColorMode::Never => false,
+            ColorMode::Auto => io::stdout().is_terminal(),
+        }
+    }
+}
+
+/// Resolved per-invocation output settings, derived from global CLI flags.
+#[derive(Debug, Clone, Copy, Default)]
+pub struct OutputCtx {
+    pub mode: OutputMode,
+    pub color: ColorMode,
+    pub quiet: bool,
+}
+
+impl OutputCtx {
+    pub fn robot() -> Self {
+        Self {
+            mode: OutputMode::Robot,
+            color: ColorMode::Never,
+            quiet: false,
+        }
+    }
+
+    pub fn is_robot(&self) -> bool {
+        matches!(self.mode, OutputMode::Robot)
+    }
+}
+
+/// Versioned JSON envelope for `--robot` output.
+///
+/// Every successful command emits exactly one envelope to stdout (or one per
+/// line for streaming commands). Errors emit `RobotEnvelope::error(...)`.
+#[derive(Debug, Clone, Serialize)]
+pub struct RobotEnvelope {
+    /// Stable schema identifier, e.g. `openproxy.v1.provider.list`.
+    pub schema: String,
+    pub ok: bool,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub data: Option<Value>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub error: Option<RobotError>,
+    pub meta: Value,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct RobotError {
+    pub code: String,
+    pub message: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub details: Option<Value>,
+}
+
+impl RobotEnvelope {
+    pub fn ok(schema: impl Into<String>, data: Value) -> Self {
+        Self {
+            schema: schema.into(),
+            ok: true,
+            data: Some(data),
+            error: None,
+            meta: json!({}),
+        }
+    }
+
+    pub fn error(code: impl Into<String>, message: impl Into<String>) -> Self {
+        Self {
+            schema: "openproxy.v1.error".to_string(),
+            ok: false,
+            data: None,
+            error: Some(RobotError {
+                code: code.into(),
+                message: message.into(),
+                details: None,
+            }),
+            meta: json!({}),
+        }
+    }
+
+    pub fn with_meta(mut self, meta: Value) -> Self {
+        self.meta = meta;
+        self
+    }
+
+    pub fn write_stdout(&self) -> io::Result<()> {
+        let line = serde_json::to_string(self)
+            .unwrap_or_else(|_| "{\"schema\":\"openproxy.v1.error\",\"ok\":false}".to_string());
+        let mut stdout = io::stdout().lock();
+        writeln!(stdout, "{}", line)?;
+        stdout.flush()
+    }
+}
+
+/// Convenience: emit a successful robot envelope (one JSON line).
+pub fn emit_robot(schema: &str, data: Value) -> io::Result<()> {
+    RobotEnvelope::ok(schema, data).write_stdout()
+}
+
+/// Convenience: emit an error envelope. Returns the suggested process exit code.
+pub fn emit_error(ctx: OutputCtx, code: &str, message: &str) -> io::Result<i32> {
+    if ctx.is_robot() {
+        RobotEnvelope::error(code, message).write_stdout()?;
+    } else if !ctx.quiet {
+        eprintln!("error: {message}");
+    }
+    Ok(exit_code_for(code))
+}
+
+/// Map a logical error code to the conventional CLI exit code.
+pub fn exit_code_for(code: &str) -> i32 {
+    match code {
+        "ok" => 0,
+        "usage" => 2,
+        "not_found" => 3,
+        "conflict" => 4,
+        "auth" => 5,
+        "server_unreachable" | "network" => 6,
+        "validation" => 7,
+        _ => 1,
+    }
+}
+
+/// Print a human-readable line, suppressed in robot/quiet modes.
+///
+/// Use this for status text that isn't part of the structured payload.
+pub fn humanln(ctx: OutputCtx, line: impl AsRef<str>) {
+    if ctx.is_robot() || ctx.quiet {
+        return;
+    }
+    println!("{}", line.as_ref());
+}
+
+/// Mask a secret value for human display: keep first 4 + last 4 chars.
+pub fn mask_secret(value: &str) -> String {
+    let trimmed = value.trim();
+    if trimmed.len() <= 8 {
+        return "•".repeat(trimmed.len());
+    }
+    let head: String = trimmed.chars().take(4).collect();
+    let tail: String = trimmed.chars().rev().take(4).collect::<String>();
+    let tail: String = tail.chars().rev().collect();
+    format!("{head}…{tail}")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn robot_envelope_ok_serializes_minimal_shape() {
+        let env = RobotEnvelope::ok("openproxy.v1.test", json!({"foo": 1}));
+        let s = serde_json::to_string(&env).unwrap();
+        assert!(s.contains("\"schema\":\"openproxy.v1.test\""));
+        assert!(s.contains("\"ok\":true"));
+        assert!(s.contains("\"foo\":1"));
+        assert!(!s.contains("\"error\""));
+    }
+
+    #[test]
+    fn robot_envelope_error_uses_error_schema() {
+        let env = RobotEnvelope::error("not_found", "missing");
+        let s = serde_json::to_string(&env).unwrap();
+        assert!(s.contains("\"schema\":\"openproxy.v1.error\""));
+        assert!(s.contains("\"ok\":false"));
+        assert!(s.contains("\"code\":\"not_found\""));
+    }
+
+    #[test]
+    fn exit_codes_are_stable() {
+        assert_eq!(exit_code_for("ok"), 0);
+        assert_eq!(exit_code_for("usage"), 2);
+        assert_eq!(exit_code_for("not_found"), 3);
+        assert_eq!(exit_code_for("conflict"), 4);
+        assert_eq!(exit_code_for("auth"), 5);
+        assert_eq!(exit_code_for("server_unreachable"), 6);
+        assert_eq!(exit_code_for("validation"), 7);
+        assert_eq!(exit_code_for("anything-else"), 1);
+    }
+
+    #[test]
+    fn mask_secret_keeps_head_and_tail() {
+        assert_eq!(mask_secret("sk-1234567890abcdef"), "sk-1…cdef");
+        assert_eq!(mask_secret("short"), "•••••");
+    }
+}

--- a/src/cli/schema.rs
+++ b/src/cli/schema.rs
@@ -1,0 +1,239 @@
+//! `openproxy schema list/show/example` — agent introspection.
+//!
+//! Lets agents discover what resources the CLI accepts and what shape they
+//! take. This makes the CLI self-documenting — an agent can read these schemas
+//! and generate valid payloads for `provider apply --from-file -` etc. without
+//! browsing the dashboard.
+//!
+//! The schemas returned here are deliberately *minimal*: enough for a model to
+//! generate a valid payload. They are NOT the authoritative serde shape —
+//! that lives in `crate::types`. Treat these as a curated subset.
+
+use serde_json::{json, Value};
+
+use crate::cli::output::{emit_robot, humanln, OutputCtx};
+
+const RESOURCES: &[&str] = &[
+    "provider",
+    "provider-node",
+    "combo",
+    "key",
+    "pool",
+    "settings",
+];
+
+pub fn run_list(ctx: OutputCtx) -> anyhow::Result<()> {
+    let data = json!({
+        "resources": RESOURCES,
+    });
+    if ctx.is_robot() {
+        emit_robot("openproxy.v1.schema.list", data)?;
+    } else {
+        humanln(ctx, "Available resource schemas:");
+        for r in RESOURCES {
+            humanln(ctx, format!("  {r}"));
+        }
+    }
+    Ok(())
+}
+
+pub fn run_show(ctx: OutputCtx, resource: &str) -> anyhow::Result<i32> {
+    let Some(schema) = schema_for(resource) else {
+        let exit = crate::cli::output::emit_error(
+            ctx,
+            "not_found",
+            &format!("unknown resource '{resource}'. Try: openproxy schema list"),
+        )?;
+        return Ok(exit);
+    };
+    if ctx.is_robot() {
+        emit_robot(
+            &format!("openproxy.v1.schema.{}", normalize(resource)),
+            schema,
+        )?;
+    } else {
+        let pretty = serde_json::to_string_pretty(&schema).unwrap_or_default();
+        println!("{pretty}");
+    }
+    Ok(0)
+}
+
+pub fn run_example(ctx: OutputCtx, resource: &str) -> anyhow::Result<i32> {
+    let Some(example) = example_for(resource) else {
+        let exit = crate::cli::output::emit_error(
+            ctx,
+            "not_found",
+            &format!("unknown resource '{resource}'. Try: openproxy schema list"),
+        )?;
+        return Ok(exit);
+    };
+    if ctx.is_robot() {
+        emit_robot(
+            &format!("openproxy.v1.example.{}", normalize(resource)),
+            example,
+        )?;
+    } else {
+        let pretty = serde_json::to_string_pretty(&example).unwrap_or_default();
+        println!("{pretty}");
+    }
+    Ok(0)
+}
+
+fn normalize(resource: &str) -> String {
+    resource.replace('-', "_")
+}
+
+fn schema_for(resource: &str) -> Option<Value> {
+    Some(match resource {
+        "provider" => json!({
+            "$schema": "http://json-schema.org/draft-07/schema#",
+            "title": "ProviderConnection",
+            "type": "object",
+            "required": ["name", "provider"],
+            "properties": {
+                "id": {"type": "string", "description": "Auto-generated UUID if omitted"},
+                "name": {"type": "string"},
+                "provider": {"type": "string", "description": "Provider alias (openai, anthropic, ...) or node UUID"},
+                "apiKey": {"type": "string"},
+                "baseUrl": {"type": ["string", "null"]},
+                "priority": {"type": "integer", "minimum": 0},
+                "isActive": {"type": "boolean", "default": true},
+                "defaultModel": {"type": ["string", "null"]},
+                "providerSpecificData": {"type": "object"}
+            }
+        }),
+        "provider-node" => json!({
+            "$schema": "http://json-schema.org/draft-07/schema#",
+            "title": "ProviderNode",
+            "type": "object",
+            "required": ["name", "type", "baseUrl"],
+            "properties": {
+                "id": {"type": "string"},
+                "name": {"type": "string"},
+                "type": {"type": "string", "enum": ["openai-compatible", "anthropic-compatible", "gemini-compatible"]},
+                "baseUrl": {"type": "string", "format": "uri"}
+            }
+        }),
+        "combo" => json!({
+            "$schema": "http://json-schema.org/draft-07/schema#",
+            "title": "Combo",
+            "type": "object",
+            "required": ["name", "models"],
+            "properties": {
+                "id": {"type": "string"},
+                "name": {"type": "string"},
+                "strategy": {"type": "string", "enum": ["fallback", "round-robin", "sticky-round-robin"], "default": "fallback"},
+                "models": {"type": "array", "items": {"type": "string"}},
+                "isActive": {"type": "boolean", "default": true}
+            }
+        }),
+        "key" => json!({
+            "$schema": "http://json-schema.org/draft-07/schema#",
+            "title": "ApiKey",
+            "type": "object",
+            "required": ["name", "key"],
+            "properties": {
+                "id": {"type": "string"},
+                "name": {"type": "string"},
+                "key": {"type": "string"},
+                "isActive": {"type": "boolean", "default": true}
+            }
+        }),
+        "pool" => json!({
+            "$schema": "http://json-schema.org/draft-07/schema#",
+            "title": "ProxyPool",
+            "type": "object",
+            "required": ["name", "proxyUrl"],
+            "properties": {
+                "id": {"type": "string"},
+                "name": {"type": "string"},
+                "proxyUrl": {"type": "string"},
+                "type": {"type": "string", "enum": ["http", "https", "socks5"], "default": "http"},
+                "isActive": {"type": "boolean", "default": true},
+                "strictProxy": {"type": "boolean", "default": false}
+            }
+        }),
+        "settings" => json!({
+            "$schema": "http://json-schema.org/draft-07/schema#",
+            "title": "Settings",
+            "type": "object",
+            "properties": {
+                "rtkEnabled": {"type": "boolean"},
+                "cavemanEnabled": {"type": "boolean"},
+                "cavemanLevel": {"type": "string", "enum": ["light", "medium", "heavy"]},
+                "comboStrategy": {"type": "string"},
+                "requireLogin": {"type": "boolean"},
+                "observabilityEnabled": {"type": "boolean"},
+                "outboundProxyEnabled": {"type": "boolean"},
+                "outboundProxyUrl": {"type": "string"},
+                "tunnelEnabled": {"type": "boolean"},
+                "tunnelProvider": {"type": "string"}
+            }
+        }),
+        _ => return None,
+    })
+}
+
+fn example_for(resource: &str) -> Option<Value> {
+    Some(match resource {
+        "provider" => json!({
+            "name": "openai-main",
+            "provider": "openai",
+            "apiKey": "sk-...",
+            "priority": 10,
+            "isActive": true
+        }),
+        "provider-node" => json!({
+            "name": "my-custom-node",
+            "type": "openai-compatible",
+            "baseUrl": "https://api.example.com/v1"
+        }),
+        "combo" => json!({
+            "name": "premium-coding",
+            "strategy": "fallback",
+            "models": ["openai/gpt-4o", "anthropic/claude-3-5-sonnet", "groq/llama-3.1-70b"]
+        }),
+        "key" => json!({
+            "name": "ci-bot",
+            "key": "op-...",
+            "isActive": true
+        }),
+        "pool" => json!({
+            "name": "us-east",
+            "proxyUrl": "http://proxy.example.com:8080",
+            "type": "http"
+        }),
+        "settings" => json!({
+            "rtkEnabled": true,
+            "cavemanEnabled": false,
+            "cavemanLevel": "medium",
+            "requireLogin": true
+        }),
+        _ => return None,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn every_listed_resource_has_schema_and_example() {
+        for resource in RESOURCES {
+            assert!(
+                schema_for(resource).is_some(),
+                "missing schema for {resource}"
+            );
+            assert!(
+                example_for(resource).is_some(),
+                "missing example for {resource}"
+            );
+        }
+    }
+
+    #[test]
+    fn unknown_resource_returns_none() {
+        assert!(schema_for("nope").is_none());
+        assert!(example_for("nope").is_none());
+    }
+}

--- a/src/db/mod.rs
+++ b/src/db/mod.rs
@@ -10,6 +10,8 @@ use uuid::Uuid;
 
 use crate::types::{AppDb, Combo, ModelAliasTarget, ProviderConnection, ProviderNode, UsageDb};
 
+pub mod watcher;
+
 #[derive(Debug, Clone, Default)]
 pub struct ProviderConnectionFilter {
     pub provider: Option<String>,
@@ -201,6 +203,34 @@ async fn load_or_init_usage_db(path: &Path) -> anyhow::Result<UsageDb> {
         write_json_atomic(path, &value).await?;
     }
     Ok(value)
+}
+
+/// Re-read `db.json` from disk without writing anything back. Used by the
+/// file watcher to pick up CLI mutations made by another process. Tolerates
+/// a brief read race during atomic-rename writes by retrying once.
+pub async fn reload_app_db(path: &Path) -> anyhow::Result<AppDb> {
+    let bytes = match fs::read(path).await {
+        Ok(b) => b,
+        Err(_) => {
+            tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+            fs::read(path).await?
+        }
+    };
+    let parsed: Value = serde_json::from_slice(&bytes)?;
+    Ok(AppDb::from_json_value(parsed))
+}
+
+/// Re-read `usage.json` from disk without writing anything back.
+pub async fn reload_usage_db(path: &Path) -> anyhow::Result<UsageDb> {
+    let bytes = match fs::read(path).await {
+        Ok(b) => b,
+        Err(_) => {
+            tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+            fs::read(path).await?
+        }
+    };
+    let parsed: Value = serde_json::from_slice(&bytes)?;
+    Ok(UsageDb::from_json_value(parsed))
 }
 
 async fn write_json_atomic<T: Serialize>(path: &Path, value: &T) -> anyhow::Result<()> {

--- a/src/db/watcher.rs
+++ b/src/db/watcher.rs
@@ -1,0 +1,125 @@
+//! Background watcher that reloads `db.json` and `usage.json` whenever the
+//! files change on disk.
+//!
+//! Why this exists: the CLI is allowed to write the DB directly while the
+//! server is running. Without a watcher, the server's in-memory `ArcSwap`
+//! would silently go stale until the next restart. With this watcher, the
+//! server's snapshot reflects CLI mutations within ~150ms.
+//!
+//! Design notes:
+//! - We debounce events so a burst of writes (atomic rename produces
+//!   create/modify in quick succession) only triggers one reload.
+//! - We never block the watcher thread on the reload itself; we hand the work
+//!   off to a tokio task.
+//! - Reload errors are logged at WARN and the previous snapshot is kept.
+
+use std::path::PathBuf;
+use std::sync::Arc;
+use std::time::Duration;
+
+use anyhow::Context;
+use notify::{Event, EventKind, RecommendedWatcher, RecursiveMode, Watcher};
+use tokio::sync::mpsc;
+use tokio::time::sleep;
+use tracing::{debug, info, warn};
+
+use crate::db::Db;
+
+const DEBOUNCE_MS: u64 = 100;
+
+/// Spawn a background watcher tied to the lifetime of `db`. Drops silently if
+/// the watch cannot be installed (e.g. on platforms without inotify) — the
+/// server still works, it just won't auto-reload from CLI writes.
+pub fn spawn_watcher(db: Arc<Db>) {
+    let data_dir = db.data_dir.clone();
+    let db_path = db.db_path.clone();
+    let usage_path = db.usage_path.clone();
+
+    tokio::spawn(async move {
+        if let Err(e) = run_watcher(db, data_dir, db_path, usage_path).await {
+            warn!(error = %e, "db watcher exited; CLI writes will not auto-reload until restart");
+        }
+    });
+}
+
+async fn run_watcher(
+    db: Arc<Db>,
+    data_dir: PathBuf,
+    db_path: PathBuf,
+    usage_path: PathBuf,
+) -> anyhow::Result<()> {
+    // notify is sync; bridge into tokio via an mpsc channel.
+    let (tx, mut rx) = mpsc::unbounded_channel::<PathBuf>();
+
+    let db_path_clone = db_path.clone();
+    let usage_path_clone = usage_path.clone();
+
+    let mut watcher = RecommendedWatcher::new(
+        move |res: Result<Event, notify::Error>| {
+            let Ok(event) = res else { return };
+            if !matches!(
+                event.kind,
+                EventKind::Create(_) | EventKind::Modify(_) | EventKind::Remove(_)
+            ) {
+                return;
+            }
+            for p in event.paths {
+                if p == db_path_clone || p == usage_path_clone {
+                    let _ = tx.send(p);
+                }
+            }
+        },
+        notify::Config::default(),
+    )
+    .context("create file watcher")?;
+
+    // Watch the directory rather than the files themselves: editors and
+    // atomic-rename writes (our `write_json_atomic`) often replace the inode,
+    // which a file-level watch would miss.
+    watcher
+        .watch(&data_dir, RecursiveMode::NonRecursive)
+        .with_context(|| format!("watch data dir at {}", data_dir.display()))?;
+
+    info!(path = %data_dir.display(), "db file watcher active");
+
+    while let Some(path) = rx.recv().await {
+        // Drain rapid bursts (atomic rename → CREATE + MODIFY).
+        let _ = drain_for(&mut rx, Duration::from_millis(DEBOUNCE_MS)).await;
+        debug!(path = %path.display(), "db change detected, reloading");
+
+        if path == db_path {
+            match crate::db::reload_app_db(&db_path).await {
+                Ok(next) => {
+                    db.snapshot.store(Arc::new(next));
+                    info!("db.json reloaded into in-memory snapshot");
+                }
+                Err(e) => warn!(error = %e, "failed to reload db.json"),
+            }
+        } else if path == usage_path {
+            match crate::db::reload_usage_db(&usage_path).await {
+                Ok(next) => {
+                    db.usage_snapshot.store(Arc::new(next));
+                    debug!("usage.json reloaded into in-memory snapshot");
+                }
+                Err(e) => warn!(error = %e, "failed to reload usage.json"),
+            }
+        }
+    }
+
+    // Keep the watcher alive for the lifetime of the task.
+    drop(watcher);
+    Ok(())
+}
+
+async fn drain_for(rx: &mut mpsc::UnboundedReceiver<PathBuf>, dur: Duration) {
+    let deadline = sleep(dur);
+    tokio::pin!(deadline);
+    loop {
+        tokio::select! {
+            _ = &mut deadline => break,
+            maybe = rx.recv() => {
+                if maybe.is_none() { break; }
+            }
+        }
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -5,7 +5,9 @@ use tokio::net::TcpListener;
 use tracing::info;
 use tracing_subscriber::{layer::SubscriberExt, util::SubscriberInitExt};
 
-use openproxy::cli::{Cli, Command};
+use openproxy::cli::config::ResolvedConfig;
+use openproxy::cli::{Cli, Command, SchemaCmd};
+use openproxy::db::watcher::spawn_watcher;
 use openproxy::db::Db;
 use openproxy::server::console_logs::{shared_console_log_buffer, ConsoleLogMakeWriter};
 use openproxy::server::state::AppState;
@@ -13,6 +15,13 @@ use openproxy::server::state::AppState;
 #[tokio::main]
 async fn main() -> anyhow::Result<()> {
     let cli = Cli::parse();
+    let ctx = cli.output_ctx();
+    let resolved = ResolvedConfig::resolve(cli.cli_overrides())?;
+
+    // Make sure downstream code (server, Db::load, oauth helpers, ...) sees
+    // the same DATA_DIR the CLI resolved. Doing this here means a single
+    // resolution path: flag > env > config profile > default.
+    std::env::set_var("DATA_DIR", &resolved.data_dir);
 
     if let Some(cmd) = &cli.cmd {
         match cmd {
@@ -64,11 +73,32 @@ async fn main() -> anyhow::Result<()> {
                 clap_complete::generate(*shell, &mut cmd, "openproxy", &mut std::io::stdout());
                 return Ok(());
             }
+            Command::Schema { cmd } => {
+                let exit = match cmd {
+                    SchemaCmd::List => {
+                        openproxy::cli::schema::run_list(ctx)?;
+                        0
+                    }
+                    SchemaCmd::Show { resource } => {
+                        openproxy::cli::schema::run_show(ctx, resource)?
+                    }
+                    SchemaCmd::Example { resource } => {
+                        openproxy::cli::schema::run_example(ctx, resource)?
+                    }
+                };
+                if exit != 0 {
+                    std::process::exit(exit);
+                }
+                return Ok(());
+            }
+            Command::Doctor => {
+                let exit = openproxy::cli::doctor::run(ctx, &resolved).await?;
+                if exit != 0 {
+                    std::process::exit(exit);
+                }
+                return Ok(());
+            }
         }
-    }
-
-    if let Some(data_dir) = &cli.data_dir {
-        std::env::set_var("DATA_DIR", data_dir);
     }
 
     let console_log_writer = ConsoleLogMakeWriter::new(shared_console_log_buffer());
@@ -84,6 +114,7 @@ async fn main() -> anyhow::Result<()> {
 
     let db = Db::load().await?;
     let db = Arc::new(db);
+    spawn_watcher(db.clone());
     let state = AppState::new(db);
     let app = openproxy::build_app(state);
     let addr = format!("{}:{}", cli.host, cli.port);

--- a/tests/db_watcher.rs
+++ b/tests/db_watcher.rs
@@ -1,0 +1,77 @@
+//! Integration test for `openproxy::db::watcher::spawn_watcher`.
+//!
+//! Verifies that an external write to `db.json` (simulating what the CLI does)
+//! is picked up by the watcher and reflected in the in-memory ArcSwap snapshot
+//! within a few hundred milliseconds.
+
+use std::sync::Arc;
+use std::time::{Duration, Instant};
+
+use openproxy::db::watcher::spawn_watcher;
+use openproxy::db::Db;
+use serde_json::json;
+use tempfile::tempdir;
+use tokio::time::sleep;
+
+#[tokio::test]
+async fn watcher_picks_up_external_db_write() {
+    let tmp = tempdir().expect("tempdir");
+    let data_dir = tmp.path().to_path_buf();
+
+    let db = Db::load_from(&data_dir).await.expect("db load");
+    let db = Arc::new(db);
+
+    // Initial snapshot must be empty.
+    assert_eq!(db.snapshot().provider_connections.len(), 0);
+
+    spawn_watcher(db.clone());
+    // Give the watcher a moment to install its inotify watch before we mutate.
+    sleep(Duration::from_millis(120)).await;
+
+    // Write a brand-new db.json with one provider, atomically (matches the CLI
+    // path: temp file + rename).
+    let new_db = json!({
+        "providerConnections": [
+            {
+                "id": "watch-1",
+                "provider": "openai",
+                "name": "watcher-fixture",
+                "authType": "apikey",
+                "apiKey": "sk-test",
+                "isActive": true
+            }
+        ],
+        "providerNodes": [],
+        "apiKeys": [],
+        "proxyPools": [],
+        "combos": [],
+        "modelAliases": {},
+        "modelAvailability": {},
+        "settings": {}
+    });
+    let bytes = serde_json::to_vec_pretty(&new_db).unwrap();
+    let tmp_path = data_dir.join(".db.json.write");
+    let final_path = data_dir.join("db.json");
+    tokio::fs::write(&tmp_path, &bytes).await.unwrap();
+    tokio::fs::rename(&tmp_path, &final_path).await.unwrap();
+
+    // Poll the snapshot for up to ~1.5s; succeed on first observed update.
+    let deadline = Instant::now() + Duration::from_millis(1500);
+    loop {
+        if db.snapshot().provider_connections.len() == 1 {
+            break;
+        }
+        if Instant::now() > deadline {
+            panic!(
+                "watcher did not reload db within 1.5s; provider count still {}",
+                db.snapshot().provider_connections.len()
+            );
+        }
+        sleep(Duration::from_millis(50)).await;
+    }
+
+    let snap = db.snapshot();
+    assert_eq!(snap.provider_connections.len(), 1);
+    assert_eq!(snap.provider_connections[0].id, "watch-1");
+    assert_eq!(snap.provider_connections[0].provider, "openai");
+}


### PR DESCRIPTION
## Summary

This is **milestone 1** of the agent-first CLI plan (see `openproxy-CLI-PLAN.md`). It lays down the foundation every later milestone (M2–M6) builds on, without changing the behaviour of any existing command.

What it adds:

- **Global CLI flags** wired through clap as `global = true` so every subcommand inherits them:
  - `--robot` — emit a stable JSON envelope (`openproxy.v1.<resource>.<verb>`) to stdout for agents.
  - `-v` / `-vv` / `-vvv` — verbosity counter.
  - `-q` / `--quiet` — suppress non-essential human output.
  - `--color auto|always|never` — TTY-aware coloring.
  - `--data-dir <path>` — override `$DATA_DIR`.
  - `--profile <name>` — select profile from `~/.config/openproxy/config.toml`.
  - `--url <url>` / `--api-key <key>` — optional remote-management mode.

- **`src/cli/output.rs`** — `RobotEnvelope` versioned JSON envelope, `OutputCtx`, color resolver, exit-code mapping (`0 ok`, `2 usage`, `3 not_found`, `4 conflict`, `5 auth`, `6 server_unreachable`, `7 validation`), and a `mask_secret` helper.

- **`src/cli/config.rs`** — optional profile loader with strict precedence (flag > env > profile > default) for `data_dir` / `url` / `api_key`. Backed by `directories` crate so the path is correct on Linux/macOS/Windows.

- **`src/cli/schema.rs` (`openproxy schema list/show/example`)** — agent introspection: lets a model discover the JSON shape of `provider`, `provider-node`, `combo`, `key`, `pool`, `settings` without browsing the dashboard. Returns JSON Schema (draft-07) and example payloads.

- **`src/cli/doctor.rs` (`openproxy doctor`)** — self-test that an agent can run as a first step:
  ```
  $ openproxy doctor --robot
  {"schema":"openproxy.v1.doctor","ok":true,"data":{"checks":[
    {"name":"data_dir","ok":true,"detail":"..."},
    {"name":"db_file","ok":true,"detail":"..."},
    {"name":"db_loadable","ok":true,"detail":"3 providers, 1 keys, ..."},
    {"name":"server_reachable","ok":true,"detail":"..."}],"ok":true},"meta":{}}
  ```

- **`src/db/watcher.rs`** — `notify`-based file watcher. When the CLI writes `db.json` (or another process replaces it via atomic rename), the watcher reloads it into the running server's `ArcSwap<AppDb>` snapshot in ~150ms. **This is what makes the unified mental model work** — CLI writes the DB, server picks it up automatically, no IPC/HTTP roundtrip required. Watcher is wired into the server bootstrap in `main.rs`. Failure to install the watcher is logged at WARN and the server continues running — it just won't auto-reload.

### What this PR is NOT

- It does **not** refactor the existing `provider/key/pool/tunnel/route` commands onto the new output module — those still use their original `--json` flag and human strings. That refactor is M2/M3 work and intentionally out of scope to keep this PR small and reviewable.
- It does **not** add any new resource commands (combo, usage, mitm, tool, …). Those land in M2–M5.

### Tests

- 9 new unit tests (output formatter, config resolver, schema/example coverage).
- 1 new integration test `tests/db_watcher.rs` that simulates a CLI write via atomic rename and asserts the in-memory snapshot updates within 1.5s (typically <300ms).
- Existing 700 tests still pass.
- `cargo fmt --all --check` passes.
- `cargo test --lib --tests` passes.

## Review & Testing Checklist for Human

medium-risk PR — the new code is additive but the watcher *runs in production* once merged.

- [ ] **Watcher correctness**: kick the tires on `src/db/watcher.rs`. Spec: it should never `panic`, never reload from a partial write (atomic rename is what protects us), debounce CREATE+MODIFY bursts to a single reload, and log a clear WARN if it can't be installed (e.g. inotify exhausted).
- [ ] **Robot envelope shape**: confirm you're happy with `{schema, ok, data?, error?, meta}` as the v1 contract. Once we publish this in M1, breaking it later costs us. See `RobotEnvelope` and `mask_secret` in `src/cli/output.rs`.
- [ ] Try the new commands manually:
  ```
  cargo run -- schema list --robot
  cargo run -- schema show provider --robot
  cargo run -- schema example combo
  cargo run -- doctor --robot   # should report server_reachable: false until you run server
  cargo run -- --help           # confirm new global flags appear
  ```
- [ ] Make sure the existing flow still works: `cargo run -- provider list --json`, `cargo run -- key list`, etc. should behave exactly as before.
- [ ] **CI check** must be green before merge.

### Notes

- `clippy -D warnings` was *not* run because the existing codebase has many pre-existing warnings. The project's CI only runs `cargo fmt --all --check` and `cargo test --lib --tests`, so this PR matches that bar.
- The `--robot` flag does not yet take effect on the existing commands (they keep their old `--json`). That's intentional: each command will be refactored in its own milestone PR so the diff stays focused.
- `notify = "7"` and `directories = "5"` are the only new dependencies.
