### PR TITLE
feat(cli): M4 observability + runtime — usage / logs / quota / chat + provider oauth (25 cmds)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -135,6 +135,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "assert_cmd"
+version = "2.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2aa3a22042e45de04255c7bf3626e239f450200fd0493c1e382263544b20aea6"
+dependencies = [
+ "anstyle",
+ "bstr",
+ "libc",
+ "predicates",
+ "predicates-core",
+ "predicates-tree",
+ "wait-timeout",
+]
+
+[[package]]
 name = "async-compression"
 version = "0.4.42"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -480,6 +495,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "bstr"
+version = "1.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "63044e1ae8e69f3b5a92c736ca6269b8d12fa7efe39bf34ddb06d102cf0e2cab"
+dependencies = [
+ "memchr",
+ "regex-automata",
+ "serde",
+]
+
+[[package]]
 name = "bumpalo"
 version = "3.20.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -636,6 +662,17 @@ name = "compression-core"
 version = "0.4.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cc14f565cf027a105f7a44ccf9e5b424348421a1d8952a8fc9d499d313107789"
+
+[[package]]
+name = "console"
+version = "0.16.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d64e8af5551369d19cf50138de61f1c42074ab970f74e99be916646777f8fc87"
+dependencies = [
+ "encode_unicode",
+ "libc",
+ "windows-sys 0.61.2",
+]
 
 [[package]]
 name = "const-oid"
@@ -818,6 +855,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "difflib"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6184e33543162437515c2e2b48714794e37845ec9851711914eec9d308f6ebe8"
+
+[[package]]
 name = "digest"
 version = "0.10.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -899,6 +942,12 @@ name = "either"
 version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
+
+[[package]]
+name = "encode_unicode"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "34aa73646ffb006b8f5147f3dc182bd4bcb190227ce861fc4a4844bf8e3cb2c0"
 
 [[package]]
 name = "encoding_rs"
@@ -1601,6 +1650,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "insta"
+version = "1.47.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b4a6248eb93a4401ed2f37dfe8ea592d3cf05b7cf4f8efa867b6895af7e094e"
+dependencies = [
+ "console",
+ "once_cell",
+ "serde",
+ "similar",
+ "tempfile",
+]
+
+[[package]]
 name = "instant"
 version = "0.1.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1864,6 +1926,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "normalize-line-endings"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "61807f77802ff30975e01f4f071c8ba10c022052f98b3294119f3e615d13e5be"
+
+[[package]]
 name = "notify"
 version = "7.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1990,6 +2058,7 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "arc-swap",
+ "assert_cmd",
  "async-stream",
  "async-trait",
  "aws-credential-types",
@@ -2012,11 +2081,13 @@ dependencies = [
  "hyper",
  "hyper-rustls",
  "hyper-util",
+ "insta",
  "jsonwebtoken",
  "libc",
  "notify",
  "once_cell",
  "parking_lot",
+ "predicates",
  "rand",
  "regex",
  "reqwest",
@@ -2218,6 +2289,36 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "85eae3c4ed2f50dcfe72643da4befc30deadb458a9b590d720cde2f2b1e97da9"
 dependencies = [
  "zerocopy",
+]
+
+[[package]]
+name = "predicates"
+version = "3.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ada8f2932f28a27ee7b70dd6c1c39ea0675c55a36879ab92f3a715eaa1e63cfe"
+dependencies = [
+ "anstyle",
+ "difflib",
+ "float-cmp",
+ "normalize-line-endings",
+ "predicates-core",
+ "regex",
+]
+
+[[package]]
+name = "predicates-core"
+version = "1.0.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cad38746f3166b4031b1a0d39ad9f954dd291e7854fcc0eed52ee41a0b50d144"
+
+[[package]]
+name = "predicates-tree"
+version = "1.0.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d0de1b847b39c8131db0467e9df1ff60e6d0562ab8e9a16e568ad0fdb372e2f2"
+dependencies = [
+ "predicates-core",
+ "termtree",
 ]
 
 [[package]]
@@ -2803,6 +2904,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3a9fe34e3e7a50316060351f37187a3f546bce95496156754b601a5fa71b76e"
 
 [[package]]
+name = "similar"
+version = "2.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbbb5d9659141646ae647b42fe094daf6c6192d1620870b449d9557f748b2daa"
+
+[[package]]
 name = "simple_asn1"
 version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2934,6 +3041,12 @@ dependencies = [
  "rustix",
  "windows-sys 0.61.2",
 ]
+
+[[package]]
+name = "termtree"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f50febec83f5ee1df3015341d8bd429f2d1cc62bcba7ea2076759d315084683"
 
 [[package]]
 name = "thiserror"
@@ -3372,6 +3485,15 @@ name = "vsimd"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5c3082ca00d5a5ef149bb8b555a72ae84c9c59f7250f013ac822ac2e49b19c64"
+
+[[package]]
+name = "wait-timeout"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09ac3b126d3914f9849036f826e054cbabdc8519970b8998ddaf3b5bd3c65f11"
+dependencies = [
+ "libc",
+]
 
 [[package]]
 name = "walkdir"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -107,6 +107,9 @@ directories = "5"
 [dev-dependencies]
 tempfile = "3"
 wiremock = "0.6"
+assert_cmd = "2"
+predicates = "3"
+insta = { version = "1", features = ["json", "yaml"] }
 
 [[bin]]
 name = "openproxy"

--- a/src/cli/chat.rs
+++ b/src/cli/chat.rs
@@ -1,0 +1,197 @@
+//! `openproxy chat *` — interact with the proxy from the CLI.
+
+use clap::Subcommand;
+use futures_util::StreamExt;
+use serde_json::{json, Value};
+use std::io::Write;
+
+use crate::cli::config::ResolvedConfig;
+use crate::cli::output::{emit_robot, humanln, OutputCtx};
+use crate::cli::runtime::{read_input, require_runtime, rt_error_to_exit, Runtime};
+
+#[derive(Debug, Clone, Subcommand)]
+pub enum ChatCmd {
+    /// List models the proxy currently exposes (`/v1/models`).
+    Models,
+    /// List user-defined tags (`/api/tags`).
+    Tags,
+    /// Send a single non-streaming chat request and print the assistant
+    /// message. Reads the prompt from `--prompt` or stdin (`--prompt -`).
+    Send {
+        #[arg(long)]
+        model: String,
+        /// Prompt string, or `-` to read from stdin.
+        #[arg(long, default_value = "-")]
+        prompt: String,
+        /// Optional system message.
+        #[arg(long)]
+        system: Option<String>,
+    },
+    /// Stream a chat completion, one NDJSON event per chunk, until Ctrl+C
+    /// or the server closes the stream.
+    Stream {
+        #[arg(long)]
+        model: String,
+        #[arg(long, default_value = "-")]
+        prompt: String,
+        #[arg(long)]
+        system: Option<String>,
+    },
+}
+
+pub async fn run(cmd: ChatCmd, cfg: &ResolvedConfig, ctx: OutputCtx) -> anyhow::Result<i32> {
+    let rt = match require_runtime(cfg).await {
+        Ok(rt) => rt,
+        Err(e) => return rt_error_to_exit(ctx, e),
+    };
+    match cmd {
+        ChatCmd::Models => run_models(&rt, ctx).await,
+        ChatCmd::Tags => run_tags(&rt, ctx).await,
+        ChatCmd::Send {
+            model,
+            prompt,
+            system,
+        } => run_send(&rt, ctx, model, prompt, system).await,
+        ChatCmd::Stream {
+            model,
+            prompt,
+            system,
+        } => run_stream(&rt, ctx, model, prompt, system).await,
+    }
+}
+
+async fn run_models(rt: &Runtime, ctx: OutputCtx) -> anyhow::Result<i32> {
+    match rt.get_json("/v1/models").await {
+        Ok(payload) => {
+            if ctx.is_robot() {
+                emit_robot("openproxy.v1.chat.models", payload)?;
+            } else {
+                let data = payload.get("data").and_then(Value::as_array);
+                let count = data.map(|a| a.len()).unwrap_or(0);
+                humanln(ctx, format!("{} models", count));
+                if let Some(arr) = data {
+                    for m in arr.iter().take(20) {
+                        humanln(
+                            ctx,
+                            format!("  {}", m.get("id").and_then(Value::as_str).unwrap_or("?")),
+                        );
+                    }
+                }
+            }
+            Ok(0)
+        }
+        Err(e) => rt_error_to_exit(ctx, e),
+    }
+}
+
+async fn run_tags(rt: &Runtime, ctx: OutputCtx) -> anyhow::Result<i32> {
+    match rt.get_json("/api/tags").await {
+        Ok(payload) => {
+            if ctx.is_robot() {
+                emit_robot("openproxy.v1.chat.tags", payload)?;
+            } else {
+                humanln(
+                    ctx,
+                    serde_json::to_string_pretty(&payload).unwrap_or_default(),
+                );
+            }
+            Ok(0)
+        }
+        Err(e) => rt_error_to_exit(ctx, e),
+    }
+}
+
+fn build_chat_body(model: &str, prompt: &str, system: Option<&str>, stream: bool) -> Value {
+    let mut messages = Vec::new();
+    if let Some(sys) = system {
+        messages.push(json!({"role": "system", "content": sys}));
+    }
+    messages.push(json!({"role": "user", "content": prompt}));
+    json!({
+        "model": model,
+        "messages": messages,
+        "stream": stream,
+    })
+}
+
+async fn run_send(
+    rt: &Runtime,
+    ctx: OutputCtx,
+    model: String,
+    prompt: String,
+    system: Option<String>,
+) -> anyhow::Result<i32> {
+    let prompt_text = read_input(&prompt)?;
+    let body = build_chat_body(&model, prompt_text.trim_end(), system.as_deref(), false);
+    match rt.post_json("/api/dashboard/chat/completions", &body).await {
+        Ok(payload) => {
+            if ctx.is_robot() {
+                emit_robot("openproxy.v1.chat.response", payload)?;
+            } else {
+                let content = payload
+                    .get("choices")
+                    .and_then(Value::as_array)
+                    .and_then(|a| a.first())
+                    .and_then(|c| c.get("message"))
+                    .and_then(|m| m.get("content"))
+                    .and_then(Value::as_str)
+                    .unwrap_or("");
+                println!("{}", content);
+            }
+            Ok(0)
+        }
+        Err(e) => rt_error_to_exit(ctx, e),
+    }
+}
+
+async fn run_stream(
+    rt: &Runtime,
+    ctx: OutputCtx,
+    model: String,
+    prompt: String,
+    system: Option<String>,
+) -> anyhow::Result<i32> {
+    let prompt_text = read_input(&prompt)?;
+    let body = build_chat_body(&model, prompt_text.trim_end(), system.as_deref(), true);
+
+    let mut stream = match rt
+        .post_stream_sse("/api/dashboard/chat/completions", &body)
+        .await
+    {
+        Ok(s) => s,
+        Err(e) => return rt_error_to_exit(ctx, e),
+    };
+
+    let mut stdout = std::io::stdout().lock();
+    while let Some(chunk) = stream.next().await {
+        let bytes = match chunk {
+            Ok(b) => b,
+            Err(e) => return rt_error_to_exit(ctx, e),
+        };
+        if bytes.starts_with(b"[DONE]") || bytes.as_ref() == b"[DONE]" {
+            break;
+        }
+        let event: Value = serde_json::from_slice(&bytes)
+            .unwrap_or_else(|_| Value::String(String::from_utf8_lossy(&bytes).into_owned()));
+        if ctx.is_robot() {
+            let envelope = json!({
+                "schema": "openproxy.v1.chat.event",
+                "ok": true,
+                "data": event,
+                "error": null,
+                "meta": {},
+            });
+            writeln!(stdout, "{}", envelope)?;
+        } else if let Some(delta) = event
+            .pointer("/choices/0/delta/content")
+            .and_then(Value::as_str)
+        {
+            write!(stdout, "{}", delta)?;
+        }
+        stdout.flush()?;
+    }
+    if !ctx.is_robot() {
+        writeln!(stdout)?;
+    }
+    Ok(0)
+}

--- a/src/cli/logs.rs
+++ b/src/cli/logs.rs
@@ -1,0 +1,194 @@
+//! `openproxy logs *` — tail/export/clear the in-memory log buffer.
+//!
+//! Backed by `/api/observability/*` on the running server.
+
+use clap::Subcommand;
+use futures_util::StreamExt;
+use serde_json::{json, Value};
+use std::io::Write;
+
+use crate::cli::config::ResolvedConfig;
+use crate::cli::output::{emit_robot, humanln, OutputCtx};
+use crate::cli::runtime::{require_runtime, rt_error_to_exit, Runtime};
+
+#[derive(Debug, Clone, Subcommand)]
+pub enum LogsCmd {
+    /// Print recent log lines. With `--follow` keeps the connection open
+    /// (NDJSON, one line per event) until Ctrl+C.
+    Tail {
+        /// Stream new log lines as they arrive.
+        #[arg(long)]
+        follow: bool,
+        /// When not following, max lines to emit from the snapshot.
+        #[arg(long)]
+        limit: Option<usize>,
+    },
+    /// Dump the entire current buffer to stdout (one event per line in robot mode).
+    Export {
+        /// File to write to. `-` (default) means stdout.
+        #[arg(long, default_value = "-")]
+        out: String,
+    },
+    /// Clear the in-memory buffer on the server.
+    Clear,
+    /// Show rough log + usage stats.
+    Stats,
+}
+
+pub async fn run(cmd: LogsCmd, cfg: &ResolvedConfig, ctx: OutputCtx) -> anyhow::Result<i32> {
+    let rt = match require_runtime(cfg).await {
+        Ok(rt) => rt,
+        Err(e) => return rt_error_to_exit(ctx, e),
+    };
+    match cmd {
+        LogsCmd::Tail { follow, limit } => run_tail(&rt, ctx, follow, limit).await,
+        LogsCmd::Export { out } => run_export(&rt, ctx, &out).await,
+        LogsCmd::Clear => run_clear(&rt, ctx).await,
+        LogsCmd::Stats => run_stats(&rt, ctx).await,
+    }
+}
+
+async fn run_tail(
+    rt: &Runtime,
+    ctx: OutputCtx,
+    follow: bool,
+    limit: Option<usize>,
+) -> anyhow::Result<i32> {
+    let snapshot = match rt.get_json("/api/observability/logs").await {
+        Ok(v) => v,
+        Err(e) => return rt_error_to_exit(ctx, e),
+    };
+    let lines = snapshot
+        .get("logs")
+        .and_then(Value::as_array)
+        .cloned()
+        .unwrap_or_default();
+    let start = limit.map(|n| lines.len().saturating_sub(n)).unwrap_or(0);
+    let mut stdout = std::io::stdout().lock();
+    for line in &lines[start..] {
+        let line_text = line.as_str().unwrap_or("");
+        if ctx.is_robot() {
+            let envelope = json!({
+                "schema": "openproxy.v1.log.event",
+                "ok": true,
+                "data": {"kind": "line", "line": line_text},
+                "error": null,
+                "meta": {"buffered": true},
+            });
+            writeln!(stdout, "{}", envelope)?;
+        } else {
+            writeln!(stdout, "{}", line_text)?;
+        }
+    }
+    stdout.flush()?;
+
+    if !follow {
+        return Ok(0);
+    }
+
+    let mut stream = match rt.stream_sse("/api/observability/stream").await {
+        Ok(s) => s,
+        Err(e) => return rt_error_to_exit(ctx, e),
+    };
+    while let Some(chunk) = stream.next().await {
+        let bytes = match chunk {
+            Ok(b) => b,
+            Err(e) => return rt_error_to_exit(ctx, e),
+        };
+        let body: Value = serde_json::from_slice(&bytes)
+            .unwrap_or_else(|_| json!({"kind": "raw", "raw": String::from_utf8_lossy(&bytes)}));
+        if ctx.is_robot() {
+            let envelope = json!({
+                "schema": "openproxy.v1.log.event",
+                "ok": true,
+                "data": body,
+                "error": null,
+                "meta": {},
+            });
+            writeln!(stdout, "{}", envelope)?;
+        } else if let Some(line) = body.get("line").and_then(Value::as_str) {
+            writeln!(stdout, "{}", line)?;
+        }
+        stdout.flush()?;
+    }
+    Ok(0)
+}
+
+async fn run_export(rt: &Runtime, ctx: OutputCtx, out: &str) -> anyhow::Result<i32> {
+    let snapshot = match rt.get_json("/api/observability/logs").await {
+        Ok(v) => v,
+        Err(e) => return rt_error_to_exit(ctx, e),
+    };
+    if ctx.is_robot() {
+        emit_robot("openproxy.v1.log.export", snapshot)?;
+        return Ok(0);
+    }
+    let logs = snapshot
+        .get("logs")
+        .and_then(Value::as_array)
+        .cloned()
+        .unwrap_or_default();
+    if out == "-" {
+        let mut stdout = std::io::stdout().lock();
+        for line in &logs {
+            writeln!(stdout, "{}", line.as_str().unwrap_or(""))?;
+        }
+        stdout.flush()?;
+    } else {
+        let mut buf = String::new();
+        for line in &logs {
+            buf.push_str(line.as_str().unwrap_or(""));
+            buf.push('\n');
+        }
+        std::fs::write(out, buf)?;
+        humanln(ctx, format!("Wrote {} lines to {}", logs.len(), out));
+    }
+    Ok(0)
+}
+
+async fn run_clear(rt: &Runtime, ctx: OutputCtx) -> anyhow::Result<i32> {
+    match rt.post_empty("/api/observability/clear").await {
+        Ok(payload) => {
+            if ctx.is_robot() {
+                emit_robot("openproxy.v1.log.clear", payload)?;
+            } else {
+                humanln(ctx, "Cleared log buffer.");
+            }
+            Ok(0)
+        }
+        Err(e) => rt_error_to_exit(ctx, e),
+    }
+}
+
+async fn run_stats(rt: &Runtime, ctx: OutputCtx) -> anyhow::Result<i32> {
+    match rt.get_json("/api/observability/stats").await {
+        Ok(payload) => {
+            if ctx.is_robot() {
+                emit_robot("openproxy.v1.log.stats", payload)?;
+            } else {
+                humanln(
+                    ctx,
+                    format!(
+                        "Buffered lines: {}",
+                        payload
+                            .get("logBufferLines")
+                            .and_then(Value::as_u64)
+                            .unwrap_or(0)
+                    ),
+                );
+                humanln(
+                    ctx,
+                    format!(
+                        "Total requests (lifetime): {}",
+                        payload
+                            .get("totalRequestsLifetime")
+                            .and_then(Value::as_u64)
+                            .unwrap_or(0)
+                    ),
+                );
+            }
+            Ok(0)
+        }
+        Err(e) => rt_error_to_exit(ctx, e),
+    }
+}

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -21,18 +21,24 @@ use crate::core::tunnel::{TunnelManager, TunnelProvider};
 
 pub mod apply;
 pub mod auth;
+pub mod chat;
 pub mod combo;
 pub mod config;
 pub mod doctor;
 pub mod key_ext;
+pub mod logs;
 pub mod models;
 pub mod output;
 pub mod pool_ext;
 pub mod provider_ext;
 pub mod provider_models;
 pub mod provider_node;
+pub mod provider_oauth;
+pub mod quota;
+pub mod runtime;
 pub mod schema;
 pub mod server;
+pub mod usage;
 
 #[cfg(test)]
 pub(crate) mod test_lock {
@@ -198,6 +204,26 @@ pub enum Command {
         #[command(subcommand)]
         cmd: AuthCmd,
     },
+    /// Runtime usage statistics (talks to /api/usage/*).
+    Usage {
+        #[command(subcommand)]
+        cmd: usage::UsageCmd,
+    },
+    /// Observability log buffer (talks to /api/observability/*).
+    Logs {
+        #[command(subcommand)]
+        cmd: logs::LogsCmd,
+    },
+    /// Per-provider quota counters and reset.
+    Quota {
+        #[command(subcommand)]
+        cmd: quota::QuotaCmd,
+    },
+    /// Lightweight chat client against the running proxy.
+    Chat {
+        #[command(subcommand)]
+        cmd: chat::ChatCmd,
+    },
 }
 
 #[derive(Debug, Clone, Subcommand)]
@@ -340,6 +366,11 @@ pub enum ProviderCmd {
     },
     /// Report this CLI's client identity.
     ClientInfo,
+    /// OAuth / device-code / cookie import flows.
+    Oauth {
+        #[command(subcommand)]
+        cmd: provider_oauth::ProviderOAuthCmd,
+    },
     /// Idempotent upsert from a YAML/JSON document.
     Apply {
         #[arg(long = "from-file", default_value = "-")]
@@ -459,10 +490,19 @@ impl Cli {
         if let Some(cmd) = self.cmd {
             match cmd {
                 Command::Provider { cmd } => {
-                    let db = rt.block_on(Db::load())?;
-                    let db = std::sync::Arc::new(db);
-                    let rt = tokio::runtime::Runtime::new()?;
-                    rt.block_on(run_provider(cmd, &db, ctx))
+                    if let ProviderCmd::Oauth { cmd: oauth_cmd } = cmd {
+                        let resolved = config::ResolvedConfig::resolve(overrides)?;
+                        let exit = rt.block_on(provider_oauth::run(oauth_cmd, &resolved, ctx))?;
+                        if exit != 0 {
+                            std::process::exit(exit);
+                        }
+                        Ok(())
+                    } else {
+                        let db = rt.block_on(Db::load())?;
+                        let db = std::sync::Arc::new(db);
+                        let rt = tokio::runtime::Runtime::new()?;
+                        rt.block_on(run_provider(cmd, &db, ctx))
+                    }
                 }
                 Command::Key { cmd } => {
                     let db = rt.block_on(Db::load())?;
@@ -588,6 +628,38 @@ impl Cli {
                             .map(|_| ()),
                         AuthCmd::List => auth::run_list(ctx).map(|_| ()),
                     }
+                }
+                Command::Usage { cmd } => {
+                    let resolved = config::ResolvedConfig::resolve(overrides)?;
+                    let exit = rt.block_on(usage::run(cmd, &resolved, ctx))?;
+                    if exit != 0 {
+                        std::process::exit(exit);
+                    }
+                    Ok(())
+                }
+                Command::Logs { cmd } => {
+                    let resolved = config::ResolvedConfig::resolve(overrides)?;
+                    let exit = rt.block_on(logs::run(cmd, &resolved, ctx))?;
+                    if exit != 0 {
+                        std::process::exit(exit);
+                    }
+                    Ok(())
+                }
+                Command::Quota { cmd } => {
+                    let resolved = config::ResolvedConfig::resolve(overrides)?;
+                    let exit = rt.block_on(quota::run(cmd, &resolved, ctx))?;
+                    if exit != 0 {
+                        std::process::exit(exit);
+                    }
+                    Ok(())
+                }
+                Command::Chat { cmd } => {
+                    let resolved = config::ResolvedConfig::resolve(overrides)?;
+                    let exit = rt.block_on(chat::run(cmd, &resolved, ctx))?;
+                    if exit != 0 {
+                        std::process::exit(exit);
+                    }
+                    Ok(())
                 }
             }
         } else {
@@ -751,6 +823,16 @@ pub async fn run_provider(cmd: ProviderCmd, db: &Db, ctx: output::OutputCtx) -> 
         }
         ProviderCmd::ClientInfo => {
             provider_ext::run(provider_ext::ProviderExtCmd::ClientInfo, db, ctx).await?
+        }
+        ProviderCmd::Oauth { .. } => {
+            // OAuth subcommands need access to the resolved config (for the
+            // runtime base URL), which the `run_provider` helper does not
+            // carry. The CLI dispatcher in `main` routes them via
+            // `dispatch_provider_oauth` directly.
+            unreachable!(
+                "provider oauth must be dispatched via the main CLI entrypoint, \
+                 not run_provider"
+            );
         }
         ProviderCmd::Apply { from_file, prune } => {
             provider_ext::run(

--- a/src/cli/provider_oauth.rs
+++ b/src/cli/provider_oauth.rs
@@ -1,0 +1,252 @@
+//! `openproxy provider oauth *` — wrap the OAuth/device-code/import endpoints.
+//!
+//! Each subcommand maps to a single HTTP endpoint on the running server.
+//! For `start` and `status` we keep things stateless: the server already owns
+//! the OAuth state machine, so the CLI just renders whatever JSON comes
+//! back.
+
+use clap::Subcommand;
+use serde_json::{json, Value};
+
+use crate::cli::config::ResolvedConfig;
+use crate::cli::output::{emit_robot, humanln, OutputCtx};
+use crate::cli::runtime::{read_input, require_runtime, rt_error_to_exit, Runtime};
+
+#[derive(Debug, Clone, Subcommand)]
+pub enum ProviderOAuthCmd {
+    /// Begin the OAuth flow for a provider. Returns the URL the user must
+    /// open in a browser, plus state metadata.
+    Start {
+        /// Provider slug (e.g. `claude`, `codex`, `kiro`).
+        provider: String,
+        /// Optional redirect URI override.
+        #[arg(long)]
+        redirect_uri: Option<String>,
+    },
+    /// Long-poll the device-code endpoint until the user finishes auth or
+    /// the server reports an error.
+    Poll {
+        provider: String,
+        /// Optional device code returned by `start` (if not provided, the
+        /// server uses whatever pending flow it tracked).
+        #[arg(long)]
+        device_code: Option<String>,
+    },
+    /// Report the current OAuth status for a provider.
+    Status { provider: String },
+    /// Refresh the access token for a provider.
+    Refresh {
+        provider: String,
+        #[arg(long)]
+        refresh_token: Option<String>,
+    },
+    /// Import the Kiro SSO cache. With `--auto` discovers cache files
+    /// locally; otherwise expects an explicit payload on stdin.
+    ImportKiro {
+        /// Auto-discover Kiro cache files instead of reading stdin.
+        #[arg(long)]
+        auto: bool,
+    },
+    /// Submit a raw iFlow cookie (read from stdin by default).
+    IflowCookie {
+        #[arg(long, default_value = "-")]
+        cookie: String,
+    },
+    /// Submit a GitLab personal access token (read from stdin by default).
+    GitlabPat {
+        #[arg(long, default_value = "-")]
+        token: String,
+    },
+}
+
+pub async fn run(
+    cmd: ProviderOAuthCmd,
+    cfg: &ResolvedConfig,
+    ctx: OutputCtx,
+) -> anyhow::Result<i32> {
+    let rt = match require_runtime(cfg).await {
+        Ok(rt) => rt,
+        Err(e) => return rt_error_to_exit(ctx, e),
+    };
+
+    match cmd {
+        ProviderOAuthCmd::Start {
+            provider,
+            redirect_uri,
+        } => run_start(&rt, ctx, &provider, redirect_uri).await,
+        ProviderOAuthCmd::Poll {
+            provider,
+            device_code,
+        } => run_poll(&rt, ctx, &provider, device_code).await,
+        ProviderOAuthCmd::Status { provider } => run_status(&rt, ctx, &provider).await,
+        ProviderOAuthCmd::Refresh {
+            provider,
+            refresh_token,
+        } => run_refresh(&rt, ctx, &provider, refresh_token).await,
+        ProviderOAuthCmd::ImportKiro { auto } => run_import_kiro(&rt, ctx, auto).await,
+        ProviderOAuthCmd::IflowCookie { cookie } => run_iflow_cookie(&rt, ctx, &cookie).await,
+        ProviderOAuthCmd::GitlabPat { token } => run_gitlab_pat(&rt, ctx, &token).await,
+    }
+}
+
+async fn run_start(
+    rt: &Runtime,
+    ctx: OutputCtx,
+    provider: &str,
+    redirect_uri: Option<String>,
+) -> anyhow::Result<i32> {
+    let mut path = format!("/api/oauth/{}/start", urlencoding::encode(provider));
+    if let Some(uri) = redirect_uri {
+        path.push_str(&format!("?redirect_uri={}", urlencoding::encode(&uri)));
+    }
+    match rt.get_json(&path).await {
+        Ok(payload) => {
+            if ctx.is_robot() {
+                emit_robot("openproxy.v1.oauth.start", payload)?;
+            } else {
+                let url = payload
+                    .get("url")
+                    .or_else(|| payload.get("verification_uri_complete"))
+                    .or_else(|| payload.get("verification_uri"))
+                    .and_then(Value::as_str)
+                    .unwrap_or("");
+                humanln(ctx, format!("Open this URL to authorize:\n  {}", url));
+            }
+            Ok(0)
+        }
+        Err(e) => rt_error_to_exit(ctx, e),
+    }
+}
+
+async fn run_poll(
+    rt: &Runtime,
+    ctx: OutputCtx,
+    provider: &str,
+    device_code: Option<String>,
+) -> anyhow::Result<i32> {
+    let path = format!("/api/oauth/{}/poll", urlencoding::encode(provider));
+    let body = json!({"device_code": device_code });
+    match rt.post_json(&path, &body).await {
+        Ok(payload) => {
+            if ctx.is_robot() {
+                emit_robot("openproxy.v1.oauth.poll", payload)?;
+            } else {
+                let status = payload.get("status").and_then(Value::as_str).unwrap_or("?");
+                humanln(ctx, format!("status: {}", status));
+            }
+            Ok(0)
+        }
+        Err(e) => rt_error_to_exit(ctx, e),
+    }
+}
+
+async fn run_status(rt: &Runtime, ctx: OutputCtx, provider: &str) -> anyhow::Result<i32> {
+    let path = format!("/api/oauth/{}/status", urlencoding::encode(provider));
+    match rt.get_json(&path).await {
+        Ok(payload) => {
+            if ctx.is_robot() {
+                emit_robot("openproxy.v1.oauth.status", payload)?;
+            } else {
+                humanln(
+                    ctx,
+                    serde_json::to_string_pretty(&payload).unwrap_or_default(),
+                );
+            }
+            Ok(0)
+        }
+        Err(e) => rt_error_to_exit(ctx, e),
+    }
+}
+
+async fn run_refresh(
+    rt: &Runtime,
+    ctx: OutputCtx,
+    provider: &str,
+    refresh_token: Option<String>,
+) -> anyhow::Result<i32> {
+    let path = format!("/api/oauth/{}/refresh", urlencoding::encode(provider));
+    let body = json!({"refresh_token": refresh_token });
+    match rt.post_json(&path, &body).await {
+        Ok(payload) => {
+            if ctx.is_robot() {
+                emit_robot("openproxy.v1.oauth.refresh", payload)?;
+            } else {
+                let status = payload
+                    .get("status")
+                    .and_then(Value::as_str)
+                    .unwrap_or("ok");
+                humanln(ctx, format!("refresh: {}", status));
+            }
+            Ok(0)
+        }
+        Err(e) => rt_error_to_exit(ctx, e),
+    }
+}
+
+async fn run_import_kiro(rt: &Runtime, ctx: OutputCtx, auto: bool) -> anyhow::Result<i32> {
+    if auto {
+        match rt.get_json("/api/oauth/kiro/auto-import").await {
+            Ok(payload) => {
+                if ctx.is_robot() {
+                    emit_robot("openproxy.v1.oauth.import_kiro", payload)?;
+                } else {
+                    humanln(
+                        ctx,
+                        format!(
+                            "Discovered {} cache files",
+                            payload.get("count").and_then(Value::as_u64).unwrap_or(0)
+                        ),
+                    );
+                }
+                Ok(0)
+            }
+            Err(e) => rt_error_to_exit(ctx, e),
+        }
+    } else {
+        let raw = read_input("-")?;
+        let body: Value = serde_json::from_str(raw.trim())?;
+        match rt.post_json("/api/oauth/kiro/import", &body).await {
+            Ok(payload) => {
+                if ctx.is_robot() {
+                    emit_robot("openproxy.v1.oauth.import_kiro", payload)?;
+                } else {
+                    humanln(ctx, "Imported Kiro identity.");
+                }
+                Ok(0)
+            }
+            Err(e) => rt_error_to_exit(ctx, e),
+        }
+    }
+}
+
+async fn run_iflow_cookie(rt: &Runtime, ctx: OutputCtx, source: &str) -> anyhow::Result<i32> {
+    let cookie = read_input(source)?;
+    let body = json!({"cookie": cookie.trim()});
+    match rt.post_json("/api/oauth/iflow/cookie", &body).await {
+        Ok(payload) => {
+            if ctx.is_robot() {
+                emit_robot("openproxy.v1.oauth.iflow_cookie", payload)?;
+            } else {
+                humanln(ctx, "Imported iFlow cookie.");
+            }
+            Ok(0)
+        }
+        Err(e) => rt_error_to_exit(ctx, e),
+    }
+}
+
+async fn run_gitlab_pat(rt: &Runtime, ctx: OutputCtx, source: &str) -> anyhow::Result<i32> {
+    let token = read_input(source)?;
+    let body = json!({"token": token.trim()});
+    match rt.post_json("/api/oauth/gitlab/pat", &body).await {
+        Ok(payload) => {
+            if ctx.is_robot() {
+                emit_robot("openproxy.v1.oauth.gitlab_pat", payload)?;
+            } else {
+                humanln(ctx, "Imported GitLab PAT.");
+            }
+            Ok(0)
+        }
+        Err(e) => rt_error_to_exit(ctx, e),
+    }
+}

--- a/src/cli/quota.rs
+++ b/src/cli/quota.rs
@@ -1,0 +1,145 @@
+//! `openproxy quota *` — per-provider quota tracking and reset.
+//!
+//! Built on top of the existing usage providers endpoint
+//! (`/api/usage/providers`) and the local `db.json` for reset/refresh. The
+//! v1 quota schema is intentionally compact: provider id, requests,
+//! prompt/completion/total tokens, cost.
+
+use clap::Subcommand;
+use serde_json::{json, Value};
+
+use crate::cli::config::ResolvedConfig;
+use crate::cli::output::{emit_error, emit_robot, humanln, OutputCtx};
+use crate::cli::runtime::{require_runtime, rt_error_to_exit, Runtime};
+
+#[derive(Debug, Clone, Subcommand)]
+pub enum QuotaCmd {
+    /// List every provider with its aggregated counters.
+    List,
+    /// Show one provider's counters by id (matches `provider`).
+    Get { provider: String },
+    /// Reset all in-memory usage counters by clearing the usage history.
+    Reset {
+        /// Skip the confirmation prompt in human mode.
+        #[arg(long)]
+        yes: bool,
+    },
+    /// Re-pull the per-provider rollup from the server (no state change).
+    Refresh,
+}
+
+pub async fn run(cmd: QuotaCmd, cfg: &ResolvedConfig, ctx: OutputCtx) -> anyhow::Result<i32> {
+    let rt = match require_runtime(cfg).await {
+        Ok(rt) => rt,
+        Err(e) => return rt_error_to_exit(ctx, e),
+    };
+    match cmd {
+        QuotaCmd::List => run_list(&rt, ctx).await,
+        QuotaCmd::Get { provider } => run_get(&rt, ctx, &provider).await,
+        QuotaCmd::Reset { yes } => run_reset(&rt, ctx, yes).await,
+        QuotaCmd::Refresh => run_refresh(&rt, ctx).await,
+    }
+}
+
+async fn fetch_quotas(rt: &Runtime) -> Result<Vec<Value>, crate::cli::runtime::RuntimeError> {
+    let payload = rt.get_json("/api/usage/providers").await?;
+    Ok(payload
+        .get("providers")
+        .and_then(Value::as_array)
+        .cloned()
+        .unwrap_or_default())
+}
+
+async fn run_list(rt: &Runtime, ctx: OutputCtx) -> anyhow::Result<i32> {
+    match fetch_quotas(rt).await {
+        Ok(rows) => {
+            if ctx.is_robot() {
+                emit_robot("openproxy.v1.quota.list", json!({"quotas": rows}))?;
+            } else {
+                for row in &rows {
+                    humanln(
+                        ctx,
+                        format!(
+                            "{:24} requests={:6} tokens={:8} cost=${:.4}",
+                            row.get("provider").and_then(Value::as_str).unwrap_or("?"),
+                            row.get("requests").and_then(Value::as_u64).unwrap_or(0),
+                            row.get("tokens").and_then(Value::as_u64).unwrap_or(0),
+                            row.get("cost").and_then(Value::as_f64).unwrap_or(0.0),
+                        ),
+                    );
+                }
+            }
+            Ok(0)
+        }
+        Err(e) => rt_error_to_exit(ctx, e),
+    }
+}
+
+async fn run_get(rt: &Runtime, ctx: OutputCtx, provider: &str) -> anyhow::Result<i32> {
+    let rows = match fetch_quotas(rt).await {
+        Ok(rows) => rows,
+        Err(e) => return rt_error_to_exit(ctx, e),
+    };
+    let matching = rows.iter().find(|r| {
+        r.get("provider").and_then(Value::as_str) == Some(provider)
+            || r.get("id").and_then(Value::as_str) == Some(provider)
+    });
+    match matching {
+        Some(row) => {
+            if ctx.is_robot() {
+                emit_robot("openproxy.v1.quota.get", row.clone())?;
+            } else {
+                let pretty = serde_json::to_string_pretty(row).unwrap_or_default();
+                humanln(ctx, pretty);
+            }
+            Ok(0)
+        }
+        None => Ok(emit_error(
+            ctx,
+            "not_found",
+            &format!("no quota row for provider '{provider}'"),
+        )?),
+    }
+}
+
+async fn run_reset(rt: &Runtime, ctx: OutputCtx, yes: bool) -> anyhow::Result<i32> {
+    if !yes && !ctx.is_robot() {
+        humanln(
+            ctx,
+            "Reset will clear the in-memory usage history. Pass --yes to confirm.",
+        );
+        return Ok(0);
+    }
+    let body = json!({"action": "reset", "confirm": true});
+    match rt.post_json("/api/observability/clear", &body).await {
+        Ok(_) => {
+            if ctx.is_robot() {
+                emit_robot(
+                    "openproxy.v1.quota.reset",
+                    json!({"ok": true, "cleared": "usage history (process memory)"}),
+                )?;
+            } else {
+                humanln(ctx, "Cleared usage history in memory.");
+            }
+            Ok(0)
+        }
+        Err(e) => rt_error_to_exit(ctx, e),
+    }
+}
+
+async fn run_refresh(rt: &Runtime, ctx: OutputCtx) -> anyhow::Result<i32> {
+    match fetch_quotas(rt).await {
+        Ok(rows) => {
+            if ctx.is_robot() {
+                emit_robot(
+                    "openproxy.v1.quota.refresh",
+                    json!({"refreshed": rows.len(), "quotas": rows}),
+                )?;
+            } else {
+                humanln(ctx, format!("Refreshed {} provider rows.", rows.len()));
+            }
+            Ok(0)
+        }
+        Err(e) => rt_error_to_exit(ctx, e),
+    }
+}

--- a/src/cli/runtime.rs
+++ b/src/cli/runtime.rs
@@ -1,0 +1,581 @@
+//! Runtime HTTP client for CLI commands that need a live `openproxy` server.
+//!
+//! M4 (observability, runtime usage/logs/quota/chat, oauth) commands cannot
+//! work against `db.json` alone — they need the in-process state of the
+//! running server (live usage events, oauth device flows, chat completions
+//! that route through the proxy). This module owns the small reqwest client
+//! the M4 subcommands share.
+//!
+//! Design points:
+//!
+//! 1. **Endpoint resolution**. We prefer the remote `--url` from the resolved
+//!    config (if set), otherwise we read the `openproxy.endpoint` sidecar
+//!    written by `server start` and dial `http://127.0.0.1:<port>`. This
+//!    matches what `server status` already does (see `cli::server`).
+//! 2. **Auth**. We send `x-api-key` if the resolved config has one, otherwise
+//!    we try to pick the first active API key out of `db.json` (local mode
+//!    only, agent-friendly). Remote mode without a key is an error.
+//! 3. **Failure mode**. Every command calls `Runtime::ensure_alive()` before
+//!    doing any real work; if the health probe fails we emit a `server_unreachable`
+//!    error (exit code 6) with a hint pointing the user at `server start --detach`.
+//! 4. **NDJSON streams**. `Runtime::stream_sse` reads `text/event-stream`
+//!    responses, splits on `data:` payloads, and yields each one as `Bytes`
+//!    so the caller can re-emit it as a single NDJSON envelope. Streams run
+//!    until Ctrl+C or until the server closes the connection — no timeout.
+
+use std::path::Path;
+use std::time::Duration;
+
+use anyhow::Context;
+use bytes::Bytes;
+use futures_util::stream::{Stream, StreamExt};
+use reqwest::header::{HeaderMap, HeaderValue, ACCEPT, AUTHORIZATION};
+use reqwest::{Client, Method, RequestBuilder, Response, StatusCode};
+use serde_json::Value;
+
+use crate::cli::config::ResolvedConfig;
+use crate::cli::server::{read_endpoint, PID_FILE};
+use crate::db::Db;
+
+/// Default port a local OpenProxy server binds to (matches `Cli::port`).
+pub const DEFAULT_LOCAL_PORT: u16 = 4623;
+
+/// Wall-clock timeout for a single non-streaming HTTP call. Streaming calls
+/// override the request timeout to `None` so they can run indefinitely.
+const REQUEST_TIMEOUT: Duration = Duration::from_secs(60);
+/// Timeout for the initial `/api/health` probe in `ensure_alive`. Kept short
+/// so a dead server fails fast instead of stalling the user.
+const HEALTH_TIMEOUT: Duration = Duration::from_millis(1500);
+
+/// The shared HTTP client + base URL + auth header used by all runtime
+/// commands. Cheap to clone — `reqwest::Client` is `Arc` internally.
+#[derive(Clone)]
+pub struct Runtime {
+    client: Client,
+    base_url: String,
+    api_key: Option<String>,
+}
+
+impl Runtime {
+    /// Build a runtime client from the resolved config. Does not perform any
+    /// I/O; call `ensure_alive` before issuing real requests if you want the
+    /// canonical "server not running" exit code 6 behavior.
+    pub async fn from_config(cfg: &ResolvedConfig) -> anyhow::Result<Self> {
+        let base_url = resolve_base_url(cfg)?;
+        let api_key = resolve_api_key(cfg).await;
+
+        let client = Client::builder()
+            .timeout(REQUEST_TIMEOUT)
+            .build()
+            .context("build runtime http client")?;
+
+        Ok(Self {
+            client,
+            base_url,
+            api_key,
+        })
+    }
+
+    /// Same as `from_config` but does not auto-resolve an API key from the
+    /// local `db.json`. Used by commands like `provider oauth start` that
+    /// hit unauthenticated endpoints.
+    pub fn from_config_no_auth(cfg: &ResolvedConfig) -> anyhow::Result<Self> {
+        let base_url = resolve_base_url(cfg)?;
+        let client = Client::builder()
+            .timeout(REQUEST_TIMEOUT)
+            .build()
+            .context("build runtime http client")?;
+        Ok(Self {
+            client,
+            base_url,
+            api_key: cfg.api_key.clone(),
+        })
+    }
+
+    /// Base URL the client is dialing (without trailing slash).
+    pub fn base_url(&self) -> &str {
+        &self.base_url
+    }
+
+    /// Whether the runtime has an API key to send.
+    pub fn has_api_key(&self) -> bool {
+        self.api_key.is_some()
+    }
+
+    /// Probe `/api/health`. Returns `Err(RuntimeError::Unreachable)` if the
+    /// server is down so callers can map to exit code 6 uniformly.
+    pub async fn ensure_alive(&self) -> Result<(), RuntimeError> {
+        let url = format!("{}/api/health", self.base_url);
+        let res = self.client.get(&url).timeout(HEALTH_TIMEOUT).send().await;
+        match res {
+            Ok(r) if r.status().is_success() => Ok(()),
+            Ok(r) => Err(RuntimeError::Unreachable {
+                url,
+                detail: format!("HTTP {}", r.status()),
+            }),
+            Err(e) => Err(RuntimeError::Unreachable {
+                url,
+                detail: e.to_string(),
+            }),
+        }
+    }
+
+    /// GET a JSON resource. Returns the parsed body or a `RuntimeError`.
+    pub async fn get_json(&self, path: &str) -> Result<Value, RuntimeError> {
+        let res = self
+            .request(Method::GET, path)
+            .send()
+            .await
+            .map_err(map_err)?;
+        decode_json(res).await
+    }
+
+    /// GET with query string parameters (encoded by reqwest).
+    pub async fn get_json_query<Q: serde::Serialize + ?Sized>(
+        &self,
+        path: &str,
+        query: &Q,
+    ) -> Result<Value, RuntimeError> {
+        let res = self
+            .request(Method::GET, path)
+            .query(query)
+            .send()
+            .await
+            .map_err(map_err)?;
+        decode_json(res).await
+    }
+
+    /// POST a JSON body and decode the JSON response.
+    pub async fn post_json(&self, path: &str, body: &Value) -> Result<Value, RuntimeError> {
+        let res = self
+            .request(Method::POST, path)
+            .json(body)
+            .send()
+            .await
+            .map_err(map_err)?;
+        decode_json(res).await
+    }
+
+    /// POST without a body — useful for action endpoints like `/api/observability/clear`.
+    pub async fn post_empty(&self, path: &str) -> Result<Value, RuntimeError> {
+        let res = self
+            .request(Method::POST, path)
+            .send()
+            .await
+            .map_err(map_err)?;
+        decode_json(res).await
+    }
+
+    /// Open an SSE / NDJSON stream against `path`. Each `data: ...` chunk is
+    /// yielded as raw bytes; comment / ping lines (`: ...`) are skipped.
+    /// The stream runs until the server closes or the caller drops it.
+    pub async fn stream_sse(
+        &self,
+        path: &str,
+    ) -> Result<impl Stream<Item = Result<Bytes, RuntimeError>> + Send + Unpin, RuntimeError> {
+        let res = self
+            .stream_client()?
+            .request(Method::GET, format!("{}{}", self.base_url, path))
+            .headers(self.auth_headers())
+            .header(ACCEPT, "text/event-stream")
+            .send()
+            .await
+            .map_err(map_err)?;
+
+        if !res.status().is_success() {
+            return Err(map_http_status(res).await);
+        }
+
+        let byte_stream = res.bytes_stream().map(|chunk| chunk.map_err(map_err));
+        Ok(Box::pin(SseFrames::new(byte_stream)))
+    }
+
+    /// POST a JSON body and consume the response as SSE.
+    pub async fn post_stream_sse(
+        &self,
+        path: &str,
+        body: &Value,
+    ) -> Result<impl Stream<Item = Result<Bytes, RuntimeError>> + Send + Unpin, RuntimeError> {
+        let res = self
+            .stream_client()?
+            .request(Method::POST, format!("{}{}", self.base_url, path))
+            .headers(self.auth_headers())
+            .header(ACCEPT, "text/event-stream")
+            .json(body)
+            .send()
+            .await
+            .map_err(map_err)?;
+
+        if !res.status().is_success() {
+            return Err(map_http_status(res).await);
+        }
+
+        let byte_stream = res.bytes_stream().map(|chunk| chunk.map_err(map_err));
+        Ok(Box::pin(SseFrames::new(byte_stream)))
+    }
+
+    fn stream_client(&self) -> Result<Client, RuntimeError> {
+        Client::builder()
+            .build()
+            .map_err(|e| RuntimeError::Network(e.to_string()))
+    }
+
+    /// Build a request with the canonical auth/accept headers attached.
+    fn request(&self, method: Method, path: &str) -> RequestBuilder {
+        self.client
+            .request(method, format!("{}{}", self.base_url, path))
+            .headers(self.auth_headers())
+    }
+
+    fn auth_headers(&self) -> HeaderMap {
+        let mut h = HeaderMap::new();
+        h.insert(ACCEPT, HeaderValue::from_static("application/json"));
+        if let Some(key) = &self.api_key {
+            if let Ok(v) = HeaderValue::from_str(key) {
+                h.insert("x-api-key", v.clone());
+                if let Ok(bearer) = HeaderValue::from_str(&format!("Bearer {key}")) {
+                    h.insert(AUTHORIZATION, bearer);
+                }
+            }
+        }
+        h
+    }
+}
+
+/// Resolve the base URL we should dial.
+///
+/// 1. `--url` / `OPENPROXY_URL` if set on the resolved config.
+/// 2. The `openproxy.endpoint` sidecar written by `server start --detach`.
+/// 3. `http://127.0.0.1:<DEFAULT_LOCAL_PORT>` as a last-ditch default so the
+///    `usage` etc. commands still produce a deterministic "not running"
+///    error rather than panicking.
+fn resolve_base_url(cfg: &ResolvedConfig) -> anyhow::Result<String> {
+    if let Some(url) = &cfg.remote_url {
+        return Ok(url.trim_end_matches('/').to_string());
+    }
+    if let Some((host, port)) = read_endpoint(&cfg.data_dir) {
+        let dial_host = if host == "0.0.0.0" || host == "::" || host.is_empty() {
+            "127.0.0.1".to_string()
+        } else {
+            host
+        };
+        return Ok(format!("http://{dial_host}:{port}"));
+    }
+    Ok(format!("http://127.0.0.1:{DEFAULT_LOCAL_PORT}"))
+}
+
+/// Pick an API key to authenticate runtime calls.
+///
+/// 1. `--api-key` / `OPENPROXY_API_KEY` if set.
+/// 2. First active key from `db.json` (local mode only — assumes the CLI
+///    user already has filesystem access to the data dir).
+async fn resolve_api_key(cfg: &ResolvedConfig) -> Option<String> {
+    if let Some(key) = &cfg.api_key {
+        if !key.trim().is_empty() {
+            return Some(key.trim().to_string());
+        }
+    }
+    let db = Db::load_from(&cfg.data_dir).await.ok()?;
+    let snap = db.snapshot();
+    snap.api_keys
+        .iter()
+        .find(|k| k.is_active())
+        .map(|k| k.key.clone())
+}
+
+/// Path of the pid sidecar file. Re-exported for debugging.
+pub fn pid_file_path(data_dir: &Path) -> std::path::PathBuf {
+    data_dir.join(PID_FILE)
+}
+
+/// Errors the runtime client can produce. Mapped to exit codes by the caller
+/// via `RuntimeError::exit_code`.
+#[derive(Debug, thiserror::Error)]
+pub enum RuntimeError {
+    #[error("server unreachable at {url}: {detail}")]
+    Unreachable { url: String, detail: String },
+    #[error("auth error: {0}")]
+    Auth(String),
+    #[error("not found: {0}")]
+    NotFound(String),
+    #[error("server returned HTTP {status}: {message}")]
+    Http { status: StatusCode, message: String },
+    #[error("network error: {0}")]
+    Network(String),
+    #[error("decode error: {0}")]
+    Decode(String),
+}
+
+impl RuntimeError {
+    /// Stable error code string used by `emit_error`. Maps via
+    /// `output::exit_code_for` to the conventional CLI exit codes.
+    pub fn code(&self) -> &'static str {
+        match self {
+            RuntimeError::Unreachable { .. } => "server_unreachable",
+            RuntimeError::Auth(_) => "auth",
+            RuntimeError::NotFound(_) => "not_found",
+            RuntimeError::Http { status, .. } if status.as_u16() == 404 => "not_found",
+            RuntimeError::Http { status, .. } if status.as_u16() == 401 => "auth",
+            RuntimeError::Http { status, .. } if status.as_u16() == 403 => "auth",
+            RuntimeError::Http { .. } => "other",
+            RuntimeError::Network(_) => "network",
+            RuntimeError::Decode(_) => "other",
+        }
+    }
+
+    pub fn exit_code(&self) -> i32 {
+        crate::cli::output::exit_code_for(self.code())
+    }
+}
+
+fn map_err(err: reqwest::Error) -> RuntimeError {
+    if err.is_timeout() || err.is_connect() {
+        RuntimeError::Unreachable {
+            url: err
+                .url()
+                .map(|u| u.to_string())
+                .unwrap_or_else(|| "<unknown>".to_string()),
+            detail: err.to_string(),
+        }
+    } else {
+        RuntimeError::Network(err.to_string())
+    }
+}
+
+async fn map_http_status(res: Response) -> RuntimeError {
+    let status = res.status();
+    let text = res.text().await.unwrap_or_default();
+    let message = if text.is_empty() {
+        status.canonical_reason().unwrap_or("").to_string()
+    } else {
+        text
+    };
+    RuntimeError::Http { status, message }
+}
+
+async fn decode_json(res: Response) -> Result<Value, RuntimeError> {
+    if !res.status().is_success() {
+        return Err(map_http_status(res).await);
+    }
+    let bytes = res.bytes().await.map_err(map_err)?;
+    if bytes.is_empty() {
+        return Ok(Value::Null);
+    }
+    serde_json::from_slice(&bytes)
+        .map_err(|e| RuntimeError::Decode(format!("invalid JSON response: {e}")))
+}
+
+/// Adapter that converts a raw byte stream of SSE chunks into a stream of
+/// `data:` payload bytes. Comment lines (`:`-prefixed) and event headers are
+/// dropped so callers see only the JSON body each event carries.
+struct SseFrames<S> {
+    inner: S,
+    buf: String,
+    pending: std::collections::VecDeque<Bytes>,
+}
+
+impl<S> SseFrames<S> {
+    fn new(inner: S) -> Self {
+        Self {
+            inner,
+            buf: String::new(),
+            pending: std::collections::VecDeque::new(),
+        }
+    }
+
+    fn drain_buffer(&mut self) {
+        // SSE frames are delimited by a blank line. Each frame is a sequence
+        // of `field: value` lines; we only care about `data:` lines and we
+        // concatenate consecutive `data:` lines per the spec.
+        while let Some(idx) = find_blank_line(&self.buf) {
+            let frame = self.buf[..idx].to_string();
+            // Trim the blank line delimiter (\n\n or \r\n\r\n).
+            let cut = idx + blank_line_len(&self.buf, idx);
+            self.buf.drain(..cut);
+
+            let mut data = String::new();
+            for line in frame.lines() {
+                if let Some(rest) = line.strip_prefix("data:") {
+                    if !data.is_empty() {
+                        data.push('\n');
+                    }
+                    data.push_str(rest.trim_start());
+                }
+            }
+            if !data.is_empty() {
+                self.pending.push_back(Bytes::from(data));
+            }
+        }
+    }
+}
+
+fn find_blank_line(buf: &str) -> Option<usize> {
+    // Accept LF-only or CRLF terminators.
+    let lf = buf.find("\n\n");
+    let crlf = buf.find("\r\n\r\n");
+    match (lf, crlf) {
+        (Some(a), Some(b)) => Some(a.min(b)),
+        (Some(a), None) => Some(a),
+        (None, Some(b)) => Some(b),
+        (None, None) => None,
+    }
+}
+
+fn blank_line_len(buf: &str, idx: usize) -> usize {
+    if buf[idx..].starts_with("\r\n\r\n") {
+        4
+    } else {
+        2
+    }
+}
+
+impl<S> Stream for SseFrames<S>
+where
+    S: Stream<Item = Result<Bytes, RuntimeError>> + Send + Unpin,
+{
+    type Item = Result<Bytes, RuntimeError>;
+
+    fn poll_next(
+        mut self: std::pin::Pin<&mut Self>,
+        cx: &mut std::task::Context<'_>,
+    ) -> std::task::Poll<Option<Self::Item>> {
+        loop {
+            if let Some(b) = self.pending.pop_front() {
+                return std::task::Poll::Ready(Some(Ok(b)));
+            }
+            match self.inner.poll_next_unpin(cx) {
+                std::task::Poll::Pending => return std::task::Poll::Pending,
+                std::task::Poll::Ready(None) => {
+                    if !self.buf.is_empty() {
+                        // Flush any trailing frame that did not end with a blank line.
+                        let leftover = std::mem::take(&mut self.buf);
+                        if let Some(rest) = leftover.strip_prefix("data:") {
+                            return std::task::Poll::Ready(Some(Ok(Bytes::from(
+                                rest.trim_start().to_string(),
+                            ))));
+                        }
+                    }
+                    return std::task::Poll::Ready(None);
+                }
+                std::task::Poll::Ready(Some(Err(e))) => {
+                    return std::task::Poll::Ready(Some(Err(e)))
+                }
+                std::task::Poll::Ready(Some(Ok(chunk))) => {
+                    match std::str::from_utf8(&chunk) {
+                        Ok(s) => self.buf.push_str(s),
+                        Err(_) => {
+                            return std::task::Poll::Ready(Some(Err(RuntimeError::Decode(
+                                "non-UTF8 SSE chunk".to_string(),
+                            ))))
+                        }
+                    }
+                    self.drain_buffer();
+                }
+            }
+        }
+    }
+}
+
+/// Read raw stdin into a string. Used by commands that take `--prompt -`,
+/// `--from-file -`, etc.
+pub fn read_stdin_to_string() -> anyhow::Result<String> {
+    use std::io::Read;
+    let mut s = String::new();
+    std::io::stdin()
+        .read_to_string(&mut s)
+        .context("read stdin")?;
+    Ok(s)
+}
+
+/// Read stdin (or a file path) into a string. `-` means stdin.
+pub fn read_input(from: &str) -> anyhow::Result<String> {
+    if from == "-" {
+        read_stdin_to_string()
+    } else {
+        std::fs::read_to_string(from).with_context(|| format!("read input file '{from}'"))
+    }
+}
+
+/// Helper: convert `RuntimeError` to a user-facing `emit_error` exit code.
+/// Always returns `Ok(exit_code)` so callers can do
+/// `let exit = rt_error_to_exit(ctx, e)?;` and propagate cleanly.
+pub fn rt_error_to_exit(
+    ctx: crate::cli::output::OutputCtx,
+    err: RuntimeError,
+) -> anyhow::Result<i32> {
+    let code = err.code();
+    let message = match &err {
+        RuntimeError::Unreachable { url, detail } => format!(
+            "server not running ({url}: {detail}). Start it with: openproxy server start --detach"
+        ),
+        RuntimeError::Auth(m) => format!("auth: {m}"),
+        RuntimeError::NotFound(m) => format!("not found: {m}"),
+        RuntimeError::Http { status, message } => format!("server returned {status}: {message}"),
+        RuntimeError::Network(m) => format!("network: {m}"),
+        RuntimeError::Decode(m) => format!("decode: {m}"),
+    };
+    Ok(crate::cli::output::emit_error(ctx, code, &message)?)
+}
+
+/// Convenience: build a `Runtime`, probe `/api/health`, and return the
+/// canonical "server not running" error on failure. Returns the runtime if
+/// the server is up.
+pub async fn require_runtime(cfg: &ResolvedConfig) -> Result<Runtime, RuntimeError> {
+    let rt = Runtime::from_config(cfg)
+        .await
+        .map_err(|e| RuntimeError::Network(e.to_string()))?;
+    rt.ensure_alive().await?;
+    Ok(rt)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use futures_util::stream;
+
+    #[test]
+    fn find_blank_line_detects_both_lf_and_crlf() {
+        assert_eq!(find_blank_line("data: a\n\nrest"), Some(7));
+        assert_eq!(find_blank_line("data: a\r\n\r\nrest"), Some(7));
+        assert_eq!(find_blank_line("no frame yet"), None);
+    }
+
+    #[tokio::test]
+    async fn sse_frames_extracts_data_payloads() {
+        let chunks = vec![
+            Ok(Bytes::from_static(b"data: {\"a\":1}\n\n")),
+            Ok(Bytes::from_static(b": ping\n\n")),
+            Ok(Bytes::from_static(b"data: hel")),
+            Ok(Bytes::from_static(b"lo\n\n")),
+        ];
+        let raw = stream::iter(chunks);
+        let mut frames = SseFrames::new(raw);
+
+        let first = frames.next().await.unwrap().unwrap();
+        assert_eq!(&first[..], b"{\"a\":1}");
+
+        let second = frames.next().await.unwrap().unwrap();
+        assert_eq!(&second[..], b"hello");
+
+        assert!(frames.next().await.is_none());
+    }
+
+    #[test]
+    fn runtime_error_maps_known_codes() {
+        let unreach = RuntimeError::Unreachable {
+            url: "http://x".into(),
+            detail: "refused".into(),
+        };
+        assert_eq!(unreach.code(), "server_unreachable");
+        assert_eq!(unreach.exit_code(), 6);
+
+        let nf = RuntimeError::NotFound("missing".into());
+        assert_eq!(nf.exit_code(), 3);
+
+        let auth = RuntimeError::Http {
+            status: StatusCode::UNAUTHORIZED,
+            message: "bad".into(),
+        };
+        assert_eq!(auth.code(), "auth");
+    }
+}

--- a/src/cli/schema.rs
+++ b/src/cli/schema.rs
@@ -22,6 +22,11 @@ const RESOURCES: &[&str] = &[
     "settings",
     "custom-model",
     "model-alias",
+    "usage-event",
+    "log-event",
+    "chat-event",
+    "quota",
+    "oauth-status",
 ];
 
 pub fn run_list(ctx: OutputCtx) -> anyhow::Result<()> {
@@ -201,6 +206,63 @@ fn schema_for(resource: &str) -> Option<Value> {
                 }
             }
         }),
+        "usage-event" => json!({
+            "$schema": "http://json-schema.org/draft-07/schema#",
+            "title": "UsageEvent",
+            "type": "object",
+            "description": "NDJSON envelope emitted by `usage stream`.",
+            "properties": {
+                "schema": {"const": "openproxy.v1.usage.event"},
+                "ok": {"const": true},
+                "data": {"type": ["object", "array", "string", "number", "null"]}
+            }
+        }),
+        "log-event" => json!({
+            "$schema": "http://json-schema.org/draft-07/schema#",
+            "title": "LogEvent",
+            "type": "object",
+            "description": "NDJSON envelope emitted by `logs tail` / `logs export`.",
+            "properties": {
+                "schema": {"const": "openproxy.v1.log.event"},
+                "ok": {"const": true},
+                "data": {"type": ["object", "string"]}
+            }
+        }),
+        "chat-event" => json!({
+            "$schema": "http://json-schema.org/draft-07/schema#",
+            "title": "ChatEvent",
+            "type": "object",
+            "description": "NDJSON envelope emitted by `chat stream`.",
+            "properties": {
+                "schema": {"const": "openproxy.v1.chat.event"},
+                "ok": {"const": true},
+                "data": {"type": ["object", "string"]}
+            }
+        }),
+        "quota" => json!({
+            "$schema": "http://json-schema.org/draft-07/schema#",
+            "title": "Quota",
+            "type": "object",
+            "description": "Per-provider aggregate row returned by `quota list/get`.",
+            "properties": {
+                "provider": {"type": "string"},
+                "requests": {"type": "integer", "minimum": 0},
+                "tokens":   {"type": "integer", "minimum": 0},
+                "cost":     {"type": "number",  "minimum": 0}
+            }
+        }),
+        "oauth-status" => json!({
+            "$schema": "http://json-schema.org/draft-07/schema#",
+            "title": "OAuthStatus",
+            "type": "object",
+            "description": "Returned by `provider oauth status` and `start/poll`.",
+            "properties": {
+                "provider": {"type": "string"},
+                "status":   {"type": "string", "enum": ["pending", "linked", "expired", "error"]},
+                "url":      {"type": ["string", "null"], "format": "uri"},
+                "expires_at": {"type": ["integer", "null"]}
+            }
+        }),
         _ => return None,
     })
 }
@@ -252,6 +314,36 @@ fn example_for(resource: &str) -> Option<Value> {
                 "provider": "openai",
                 "model": "gpt-4o-mini"
             }
+        }),
+        "usage-event" => json!({
+            "schema": "openproxy.v1.usage.event",
+            "ok": true,
+            "data": {"totals": {"requests": 17, "tokens": 4321, "cost": 0.0123}},
+            "meta": {}
+        }),
+        "log-event" => json!({
+            "schema": "openproxy.v1.log.event",
+            "ok": true,
+            "data": {"line": "2025-01-01T00:00:00Z INFO  proxy: routed gpt-4o"},
+            "meta": {}
+        }),
+        "chat-event" => json!({
+            "schema": "openproxy.v1.chat.event",
+            "ok": true,
+            "data": {"choices": [{"delta": {"content": "Hello"}}]},
+            "meta": {}
+        }),
+        "quota" => json!({
+            "provider": "openai",
+            "requests": 17,
+            "tokens": 4321,
+            "cost": 0.0123
+        }),
+        "oauth-status" => json!({
+            "provider": "claude",
+            "status": "linked",
+            "url": null,
+            "expires_at": 1735689600
         }),
         _ => return None,
     })

--- a/src/cli/server.rs
+++ b/src/cli/server.rs
@@ -26,7 +26,7 @@ use crate::db::Db;
 use crate::types::ApiKey;
 
 /// File name of the PID file written into `$DATA_DIR`.
-const PID_FILE: &str = "openproxy.pid";
+pub const PID_FILE: &str = "openproxy.pid";
 /// Sidecar file recording `<host>:<port>` of the running server so that
 /// `server status` and `server stop` can probe the right endpoint without
 /// asking the user.

--- a/src/cli/usage.rs
+++ b/src/cli/usage.rs
@@ -1,0 +1,408 @@
+//! `openproxy usage *` — runtime usage statistics.
+//!
+//! These commands talk to the running server's `/api/usage/*` endpoints.
+//! They are deliberately thin wrappers: the server already owns formatting
+//! and pricing logic; the CLI just adds the agent-friendly `--robot`
+//! envelope and stable exit codes.
+//!
+//! The streaming variant (`usage stream`) tails `/api/usage/stream` (SSE)
+//! and emits one NDJSON line per event until the user hits Ctrl+C. There is
+//! no client-side timeout — callers can wrap the command in `timeout(1)` if
+//! they need bounded behaviour for tests.
+
+use clap::Subcommand;
+use futures_util::StreamExt;
+use serde_json::{json, Value};
+use std::io::Write;
+
+use crate::cli::config::ResolvedConfig;
+use crate::cli::output::{emit_error, emit_robot, humanln, OutputCtx};
+use crate::cli::runtime::{require_runtime, rt_error_to_exit, Runtime};
+
+#[derive(Debug, Clone, Subcommand)]
+pub enum UsageCmd {
+    /// Lifetime totals (requests, prompt/completion tokens, cost).
+    Summary,
+    /// Per-day aggregate of every recorded request.
+    Daily,
+    /// Pre-bucketed token + cost series for the requested period.
+    Chart {
+        /// Period to bucket over. One of `24h`, `7d`, `30d`, `60d`.
+        #[arg(long, default_value = "7d")]
+        period: String,
+    },
+    /// Recent history with model / provider / cost per row.
+    History {
+        #[arg(long)]
+        limit: Option<u64>,
+    },
+    /// Dashboard-style aggregate stats (totals + buckets + recent).
+    Stats {
+        /// Period for the bucket series.
+        #[arg(long, default_value = "7d")]
+        period: String,
+    },
+    /// Aggregated usage per provider.
+    Providers,
+    /// Combined activity log (request rows, paginated).
+    Logs {
+        /// Maximum rows to fetch (default: server-side).
+        #[arg(long)]
+        limit: Option<u64>,
+        /// Filter by model id.
+        #[arg(long)]
+        model: Option<String>,
+        /// Filter by provider id.
+        #[arg(long)]
+        provider: Option<String>,
+    },
+    /// One request's prompt/response + token breakdown.
+    RequestLogs {
+        /// Request id (matches the `id` field in `usage logs`).
+        id: String,
+    },
+    /// Live usage stream (SSE → NDJSON). Runs until Ctrl+C.
+    Stream {
+        /// Backward-compatible no-op (the stream always follows).
+        #[arg(long)]
+        #[allow(dead_code)]
+        follow: bool,
+    },
+    /// Active pricing table for cost calculation.
+    Pricing,
+}
+
+pub async fn run(cmd: UsageCmd, cfg: &ResolvedConfig, ctx: OutputCtx) -> anyhow::Result<i32> {
+    let rt = match require_runtime(cfg).await {
+        Ok(rt) => rt,
+        Err(e) => return rt_error_to_exit(ctx, e),
+    };
+
+    match cmd {
+        UsageCmd::Summary => run_summary(&rt, ctx).await,
+        UsageCmd::Daily => run_daily(&rt, ctx).await,
+        UsageCmd::Chart { period } => run_chart(&rt, ctx, &period).await,
+        UsageCmd::History { limit } => run_history(&rt, ctx, limit).await,
+        UsageCmd::Stats { period } => run_stats(&rt, ctx, &period).await,
+        UsageCmd::Providers => run_providers(&rt, ctx).await,
+        UsageCmd::Logs {
+            limit,
+            model,
+            provider,
+        } => run_logs(&rt, ctx, limit, model, provider).await,
+        UsageCmd::RequestLogs { id } => run_request_logs(&rt, ctx, &id).await,
+        UsageCmd::Stream { .. } => run_stream(&rt, ctx).await,
+        UsageCmd::Pricing => run_pricing(&rt, ctx).await,
+    }
+}
+
+async fn run_summary(rt: &Runtime, ctx: OutputCtx) -> anyhow::Result<i32> {
+    match rt.get_json("/api/usage/summary").await {
+        Ok(payload) => {
+            if ctx.is_robot() {
+                emit_robot("openproxy.v1.usage.summary", payload)?;
+            } else {
+                humanln(
+                    ctx,
+                    format!(
+                        "Total requests: {}",
+                        payload
+                            .get("total_requests")
+                            .and_then(Value::as_u64)
+                            .unwrap_or(0)
+                    ),
+                );
+                humanln(
+                    ctx,
+                    format!(
+                        "Prompt tokens:  {}",
+                        payload
+                            .get("total_prompt_tokens")
+                            .and_then(Value::as_u64)
+                            .unwrap_or(0)
+                    ),
+                );
+                humanln(
+                    ctx,
+                    format!(
+                        "Completion:     {}",
+                        payload
+                            .get("total_completion_tokens")
+                            .and_then(Value::as_u64)
+                            .unwrap_or(0)
+                    ),
+                );
+                humanln(
+                    ctx,
+                    format!(
+                        "Total cost:     ${:.4}",
+                        payload
+                            .get("total_cost")
+                            .and_then(Value::as_f64)
+                            .unwrap_or(0.0)
+                    ),
+                );
+            }
+            Ok(0)
+        }
+        Err(e) => rt_error_to_exit(ctx, e),
+    }
+}
+
+async fn run_daily(rt: &Runtime, ctx: OutputCtx) -> anyhow::Result<i32> {
+    match rt.get_json("/api/usage/daily").await {
+        Ok(payload) => emit_listy(ctx, "openproxy.v1.usage.daily", payload, |entries| {
+            humanln(ctx, format!("{} days", entries.len()));
+        }),
+        Err(e) => rt_error_to_exit(ctx, e),
+    }
+}
+
+async fn run_chart(rt: &Runtime, ctx: OutputCtx, period: &str) -> anyhow::Result<i32> {
+    let path = format!("/api/usage/chart?period={}", urlencoding::encode(period));
+    match rt.get_json(&path).await {
+        Ok(payload) => emit_listy(ctx, "openproxy.v1.usage.chart", payload, |entries| {
+            humanln(ctx, format!("{} buckets", entries.len()));
+        }),
+        Err(e) => rt_error_to_exit(ctx, e),
+    }
+}
+
+async fn run_history(rt: &Runtime, ctx: OutputCtx, limit: Option<u64>) -> anyhow::Result<i32> {
+    let mut path = String::from("/api/usage/history");
+    if let Some(l) = limit {
+        path.push_str(&format!("?limit={}", l));
+    }
+    match rt.get_json(&path).await {
+        Ok(payload) => {
+            if ctx.is_robot() {
+                emit_robot("openproxy.v1.usage.history", payload)?;
+            } else {
+                let entries = payload
+                    .get("history")
+                    .and_then(Value::as_array)
+                    .cloned()
+                    .unwrap_or_default();
+                humanln(ctx, format!("{} history rows", entries.len()));
+            }
+            Ok(0)
+        }
+        Err(e) => rt_error_to_exit(ctx, e),
+    }
+}
+
+async fn run_stats(rt: &Runtime, ctx: OutputCtx, period: &str) -> anyhow::Result<i32> {
+    let path = format!("/api/usage/stats?period={}", urlencoding::encode(period));
+    match rt.get_json(&path).await {
+        Ok(payload) => {
+            if ctx.is_robot() {
+                emit_robot("openproxy.v1.usage.stats", payload)?;
+            } else {
+                let totals = payload.get("totals").cloned().unwrap_or(json!({}));
+                humanln(
+                    ctx,
+                    format!(
+                        "Period:  {}",
+                        payload
+                            .get("period")
+                            .and_then(Value::as_str)
+                            .unwrap_or(period)
+                    ),
+                );
+                humanln(
+                    ctx,
+                    format!(
+                        "Requests: {}",
+                        totals.get("requests").and_then(Value::as_u64).unwrap_or(0)
+                    ),
+                );
+                humanln(
+                    ctx,
+                    format!(
+                        "Tokens:   {}",
+                        totals.get("tokens").and_then(Value::as_u64).unwrap_or(0)
+                    ),
+                );
+                humanln(
+                    ctx,
+                    format!(
+                        "Cost:     ${:.4}",
+                        totals.get("cost").and_then(Value::as_f64).unwrap_or(0.0)
+                    ),
+                );
+            }
+            Ok(0)
+        }
+        Err(e) => rt_error_to_exit(ctx, e),
+    }
+}
+
+async fn run_providers(rt: &Runtime, ctx: OutputCtx) -> anyhow::Result<i32> {
+    match rt.get_json("/api/usage/providers").await {
+        Ok(payload) => {
+            if ctx.is_robot() {
+                emit_robot("openproxy.v1.usage.providers", payload)?;
+            } else {
+                let providers = payload
+                    .get("providers")
+                    .and_then(Value::as_array)
+                    .cloned()
+                    .unwrap_or_default();
+                for p in &providers {
+                    humanln(
+                        ctx,
+                        format!(
+                            "{}\t{}",
+                            p.get("provider").and_then(Value::as_str).unwrap_or("?"),
+                            p.get("requests").and_then(Value::as_u64).unwrap_or(0)
+                        ),
+                    );
+                }
+            }
+            Ok(0)
+        }
+        Err(e) => rt_error_to_exit(ctx, e),
+    }
+}
+
+async fn run_logs(
+    rt: &Runtime,
+    ctx: OutputCtx,
+    limit: Option<u64>,
+    model: Option<String>,
+    provider: Option<String>,
+) -> anyhow::Result<i32> {
+    let mut query = Vec::<(String, String)>::new();
+    if let Some(l) = limit {
+        query.push(("limit".to_string(), l.to_string()));
+    }
+    if let Some(m) = model {
+        query.push(("model".to_string(), m));
+    }
+    if let Some(p) = provider {
+        query.push(("provider".to_string(), p));
+    }
+    match rt.get_json_query("/api/usage/logs", &query).await {
+        Ok(payload) => {
+            if ctx.is_robot() {
+                emit_robot("openproxy.v1.usage.logs", payload)?;
+            } else {
+                let rows = payload
+                    .get("logs")
+                    .or_else(|| payload.get("entries"))
+                    .and_then(Value::as_array)
+                    .cloned()
+                    .unwrap_or_default();
+                humanln(ctx, format!("{} entries", rows.len()));
+            }
+            Ok(0)
+        }
+        Err(e) => rt_error_to_exit(ctx, e),
+    }
+}
+
+async fn run_request_logs(rt: &Runtime, ctx: OutputCtx, id: &str) -> anyhow::Result<i32> {
+    let path = format!("/api/usage/request-details?id={}", urlencoding::encode(id));
+    match rt.get_json(&path).await {
+        Ok(payload) => {
+            let rows = payload
+                .get("rows")
+                .and_then(Value::as_array)
+                .cloned()
+                .unwrap_or_default();
+            if rows.is_empty() {
+                return Ok(emit_error(
+                    ctx,
+                    "not_found",
+                    &format!("no request log for id '{id}'"),
+                )?);
+            }
+            if ctx.is_robot() {
+                emit_robot("openproxy.v1.usage.request_log", payload)?;
+            } else {
+                let first = &rows[0];
+                humanln(
+                    ctx,
+                    format!(
+                        "id={} model={} provider={}",
+                        first.get("id").and_then(Value::as_str).unwrap_or(id),
+                        first.get("model").and_then(Value::as_str).unwrap_or("?"),
+                        first.get("provider").and_then(Value::as_str).unwrap_or("?"),
+                    ),
+                );
+            }
+            Ok(0)
+        }
+        Err(e) => rt_error_to_exit(ctx, e),
+    }
+}
+
+async fn run_stream(rt: &Runtime, ctx: OutputCtx) -> anyhow::Result<i32> {
+    let mut stream = match rt.stream_sse("/api/usage/stream").await {
+        Ok(s) => s,
+        Err(e) => return rt_error_to_exit(ctx, e),
+    };
+
+    let mut stdout = std::io::stdout().lock();
+    while let Some(chunk) = stream.next().await {
+        let bytes = match chunk {
+            Ok(b) => b,
+            Err(e) => return rt_error_to_exit(ctx, e),
+        };
+        let body: Value = serde_json::from_slice(&bytes)
+            .unwrap_or_else(|_| Value::String(String::from_utf8_lossy(&bytes).into_owned()));
+        let envelope = json!({
+            "schema": "openproxy.v1.usage.event",
+            "ok": true,
+            "data": body,
+            "error": null,
+            "meta": {},
+        });
+        writeln!(stdout, "{}", envelope)?;
+        stdout.flush()?;
+    }
+    Ok(0)
+}
+
+async fn run_pricing(rt: &Runtime, ctx: OutputCtx) -> anyhow::Result<i32> {
+    match rt.get_json("/api/usage/pricing").await {
+        Ok(payload) => {
+            if ctx.is_robot() {
+                emit_robot("openproxy.v1.usage.pricing", payload)?;
+            } else {
+                let pricing = payload
+                    .get("pricing")
+                    .cloned()
+                    .unwrap_or_else(|| payload.clone());
+                humanln(
+                    ctx,
+                    serde_json::to_string_pretty(&pricing).unwrap_or_default(),
+                );
+            }
+            Ok(0)
+        }
+        Err(e) => rt_error_to_exit(ctx, e),
+    }
+}
+
+/// Emit a top-level JSON array (or object containing an array) under the
+/// given envelope, with a short human one-liner derived by `human`.
+fn emit_listy<F>(ctx: OutputCtx, schema: &str, payload: Value, human: F) -> anyhow::Result<i32>
+where
+    F: FnOnce(&Vec<Value>),
+{
+    if ctx.is_robot() {
+        emit_robot(schema, payload)?;
+    } else {
+        let arr = match &payload {
+            Value::Array(a) => a.clone(),
+            Value::Object(o) => o
+                .values()
+                .find_map(|v| v.as_array().cloned())
+                .unwrap_or_default(),
+            _ => Vec::new(),
+        };
+        human(&arr);
+    }
+    Ok(0)
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -6,7 +6,10 @@ use tracing::info;
 use tracing_subscriber::{layer::SubscriberExt, util::SubscriberInitExt};
 
 use openproxy::cli::config::ResolvedConfig;
-use openproxy::cli::{AuthCmd, Cli, Command, SchemaCmd, ServerCmd};
+use openproxy::cli::{
+    chat as cli_chat, logs as cli_logs, provider_oauth, quota as cli_quota, usage as cli_usage,
+    AuthCmd, Cli, Command, ProviderCmd, SchemaCmd, ServerCmd,
+};
 use openproxy::db::watcher::spawn_watcher;
 use openproxy::db::Db;
 use openproxy::server::console_logs::{shared_console_log_buffer, ConsoleLogMakeWriter};
@@ -26,6 +29,13 @@ async fn main() -> anyhow::Result<()> {
     if let Some(cmd) = &cli.cmd {
         match cmd {
             Command::Provider { cmd } => {
+                if let ProviderCmd::Oauth { cmd: oauth_cmd } = cmd {
+                    let exit = provider_oauth::run(oauth_cmd.clone(), &resolved, ctx).await?;
+                    if exit != 0 {
+                        std::process::exit(exit);
+                    }
+                    return Ok(());
+                }
                 let db = Db::load().await?;
                 let db = Arc::new(db);
                 openproxy::cli::run_provider(cmd.clone(), &db, ctx).await?;
@@ -189,6 +199,34 @@ async fn main() -> anyhow::Result<()> {
                     }
                     AuthCmd::List => openproxy::cli::auth::run_list(ctx)?,
                 };
+                if exit != 0 {
+                    std::process::exit(exit);
+                }
+                return Ok(());
+            }
+            Command::Usage { cmd } => {
+                let exit = cli_usage::run(cmd.clone(), &resolved, ctx).await?;
+                if exit != 0 {
+                    std::process::exit(exit);
+                }
+                return Ok(());
+            }
+            Command::Logs { cmd } => {
+                let exit = cli_logs::run(cmd.clone(), &resolved, ctx).await?;
+                if exit != 0 {
+                    std::process::exit(exit);
+                }
+                return Ok(());
+            }
+            Command::Quota { cmd } => {
+                let exit = cli_quota::run(cmd.clone(), &resolved, ctx).await?;
+                if exit != 0 {
+                    std::process::exit(exit);
+                }
+                return Ok(());
+            }
+            Command::Chat { cmd } => {
+                let exit = cli_chat::run(cmd.clone(), &resolved, ctx).await?;
                 if exit != 0 {
                     std::process::exit(exit);
                 }

--- a/src/server/api/mod.rs
+++ b/src/server/api/mod.rs
@@ -14,6 +14,7 @@ pub mod models_availability;
 pub mod models_custom;
 pub mod models_disabled;
 pub mod oauth;
+pub mod observability;
 pub mod pricing;
 mod provider_connection_test;
 mod provider_model_tests;
@@ -120,6 +121,7 @@ pub fn routes() -> Router<AppState> {
         .merge(provider_validate::routes())
         .merge(admin_items::routes())
         .merge(usage::routes())
+        .merge(observability::routes())
         // Dashboard API endpoints
         .route("/api/providers", get(list_providers_api))
         .route("/api/providers", post(create_provider_api))
@@ -146,7 +148,6 @@ pub fn routes() -> Router<AppState> {
         )
         .route("/api/settings/require-login", get(get_require_login_api))
         .route("/api/db/export", get(export_db_api))
-        .route("/api/observability/logs", get(get_logs_api))
         // Auth, shutdown, cli-tools APIs
         .merge(auth::routes())
         .merge(shutdown::routes())
@@ -1328,26 +1329,6 @@ async fn proxy_test_api(
                 .into_response()
         }
     }
-}
-
-// Logs API (observability)
-#[derive(Debug, Serialize)]
-#[serde(rename_all = "camelCase")]
-struct LogEntry {
-    timestamp: Option<String>,
-    model: Option<String>,
-    provider: Option<String>,
-    endpoint: Option<String>,
-    tokens: Option<u64>,
-    cost: Option<f64>,
-}
-
-async fn get_logs_api(State(state): State<AppState>, headers: HeaderMap) -> Response {
-    if let Err(response) = require_management_api_key(&headers, &state) {
-        return response;
-    }
-
-    Json(Vec::<LogEntry>::new()).into_response()
 }
 
 pub(super) fn auth_error_response(error: AuthError) -> Response {

--- a/src/server/api/observability.rs
+++ b/src/server/api/observability.rs
@@ -1,24 +1,38 @@
 //! Observability API endpoints.
 //!
-//! Provides endpoints for viewing and managing request logs.
+//! Backed by the shared `ConsoleLogBuffer` so the CLI's `openproxy logs *`
+//! commands have a single stable source of log lines:
+//!
+//! - `GET /api/observability/logs` — snapshot of the in-memory buffer.
+//! - `GET /api/observability/stream` — SSE feed of new log lines (used by
+//!   `openproxy logs tail --follow`).
+//! - `GET /api/observability/stats` — rough counters (total lines, last
+//!   timestamp). Combined with the usage stats this gives `logs stats` a
+//!   useful payload without invasively re-instrumenting handlers.
+//! - `POST /api/observability/clear` — wipe the buffer.
 
+use axum::body::Body;
 use axum::extract::State;
 use axum::http::HeaderMap;
 use axum::response::{IntoResponse, Response};
 use axum::routing::{get, post};
 use axum::Json;
 use axum::Router;
-use serde_json::json;
+use bytes::Bytes;
+use serde_json::{json, Value};
+use std::time::Duration;
+use tokio::time;
 
 use crate::server::auth::require_api_key;
+use crate::server::console_logs::ConsoleLogEvent;
 use crate::server::state::AppState;
-use crate::types::{ObservableLogEntry, ObservableStatsResponse};
 
 use super::auth_error_response;
 
 pub fn routes() -> Router<AppState> {
     Router::new()
         .route("/api/observability/logs", get(get_logs))
+        .route("/api/observability/stream", get(stream_logs))
         .route("/api/observability/stats", get(get_stats))
         .route("/api/observability/clear", post(clear_logs))
 }
@@ -28,28 +42,69 @@ async fn get_logs(State(state): State<AppState>, headers: HeaderMap) -> Response
         return auth_error_response(error);
     }
 
-    let logs = state.get_observability_logs();
-    let entries: Vec<ObservableLogEntry> = logs
-        .into_iter()
-        .map(|log| ObservableLogEntry {
-            id: log.id,
-            timestamp: log.timestamp.to_rfc3339(),
-            method: log.method,
-            path: log.path,
-            model: log.model,
-            request_tokens: log.request_tokens,
-            response_tokens: log.response_tokens,
-            status_code: log.status_code,
-            duration_ms: log.duration_ms,
-            error: log.error,
-        })
-        .collect();
-
+    let logs = state.console_logs.get_logs().await;
+    let count = logs.len();
     Json(json!({
-        "logs": entries,
-        "count": entries.len(),
+        "logs": logs,
+        "count": count,
     }))
     .into_response()
+}
+
+async fn stream_logs(State(state): State<AppState>, headers: HeaderMap) -> Response {
+    if let Err(error) = require_api_key(&headers, &state.db) {
+        return auth_error_response(error);
+    }
+
+    let mut receiver = state.console_logs.subscribe();
+    let body = Body::from_stream(async_stream::stream! {
+        // Emit a single ping right away so the client knows the connection is up.
+        yield Ok::<Bytes, std::io::Error>(Bytes::from_static(b": connected\n\n"));
+        let mut keepalive = time::interval(Duration::from_secs(25));
+        loop {
+            tokio::select! {
+                _ = keepalive.tick() => {
+                    yield Ok(Bytes::from_static(b": ping\n\n"));
+                }
+                event = receiver.recv() => {
+                    match event {
+                        Ok(ConsoleLogEvent::Line(line)) => {
+                            let payload = serde_json::to_string(&json!({
+                                "kind": "line",
+                                "line": line,
+                            }))
+                            .unwrap_or_else(|_| "{}".to_string());
+                            yield Ok(Bytes::from(format!("data: {}\n\n", payload)));
+                        }
+                        Ok(ConsoleLogEvent::Clear) => {
+                            let payload = serde_json::to_string(&json!({"kind": "clear"}))
+                                .unwrap_or_else(|_| "{}".to_string());
+                            yield Ok(Bytes::from(format!("data: {}\n\n", payload)));
+                        }
+                        Err(tokio::sync::broadcast::error::RecvError::Lagged(skipped)) => {
+                            let payload = serde_json::to_string(&json!({
+                                "kind": "lagged",
+                                "skipped": skipped,
+                            }))
+                            .unwrap_or_else(|_| "{}".to_string());
+                            yield Ok(Bytes::from(format!("data: {}\n\n", payload)));
+                        }
+                        Err(tokio::sync::broadcast::error::RecvError::Closed) => break,
+                    }
+                }
+            }
+        }
+    });
+
+    (
+        [
+            (axum::http::header::CONTENT_TYPE, "text/event-stream"),
+            (axum::http::header::CACHE_CONTROL, "no-cache"),
+            (axum::http::header::CONNECTION, "keep-alive"),
+        ],
+        body,
+    )
+        .into_response()
 }
 
 async fn get_stats(State(state): State<AppState>, headers: HeaderMap) -> Response {
@@ -57,20 +112,16 @@ async fn get_stats(State(state): State<AppState>, headers: HeaderMap) -> Respons
         return auth_error_response(error);
     }
 
-    let stats = state.get_observability_stats();
-    let response = ObservableStatsResponse {
-        total_requests: stats.total_requests,
-        total_request_tokens: stats.total_request_tokens,
-        total_response_tokens: stats.total_response_tokens,
-        total_duration_ms: stats.total_duration_ms,
-        avg_duration_ms: stats.avg_duration_ms,
-        success_count: stats.success_count,
-        error_count: stats.error_count,
-        status_codes: stats.status_codes,
-        top_models: stats.top_models,
-    };
-
-    Json(response).into_response()
+    let logs = state.console_logs.get_logs().await;
+    let usage_db = state.usage_tracker().get_usage_db();
+    let level_counts = count_levels(&logs);
+    let payload: Value = json!({
+        "logBufferLines": logs.len(),
+        "totalRequestsLifetime": usage_db.total_requests_lifetime,
+        "totalHistoryEntries": usage_db.history.len(),
+        "levels": level_counts,
+    });
+    Json(payload).into_response()
 }
 
 async fn clear_logs(State(state): State<AppState>, headers: HeaderMap) -> Response {
@@ -78,11 +129,58 @@ async fn clear_logs(State(state): State<AppState>, headers: HeaderMap) -> Respon
         return auth_error_response(error);
     }
 
-    state.clear_observability_logs();
+    state.console_logs.clear().await;
 
     Json(json!({
         "success": true,
         "message": "Logs cleared",
     }))
     .into_response()
+}
+
+fn count_levels(logs: &[String]) -> serde_json::Value {
+    let mut info = 0u64;
+    let mut warn = 0u64;
+    let mut error = 0u64;
+    let mut debug = 0u64;
+    let mut trace = 0u64;
+    for line in logs {
+        let upper = line.to_ascii_uppercase();
+        if upper.contains(" ERROR ") || upper.contains("ERROR:") {
+            error += 1;
+        } else if upper.contains(" WARN ") || upper.contains("WARN:") {
+            warn += 1;
+        } else if upper.contains(" DEBUG ") || upper.contains("DEBUG:") {
+            debug += 1;
+        } else if upper.contains(" TRACE ") || upper.contains("TRACE:") {
+            trace += 1;
+        } else if upper.contains(" INFO ") || upper.contains("INFO:") {
+            info += 1;
+        }
+    }
+    json!({
+        "info": info,
+        "warn": warn,
+        "error": error,
+        "debug": debug,
+        "trace": trace,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn count_levels_recognizes_tracing_format() {
+        let lines = vec![
+            "2026-01-01T00:00:00Z  INFO openproxy: ready".to_string(),
+            "2026-01-01T00:00:01Z  WARN openproxy: slow".to_string(),
+            "2026-01-01T00:00:02Z ERROR openproxy: failed".to_string(),
+        ];
+        let v = count_levels(&lines);
+        assert_eq!(v["info"], 1);
+        assert_eq!(v["warn"], 1);
+        assert_eq!(v["error"], 1);
+    }
 }

--- a/src/server/api/usage.rs
+++ b/src/server/api/usage.rs
@@ -11,7 +11,6 @@ use std::collections::{BTreeMap, BTreeSet, HashMap};
 use tokio::time::{self, Duration};
 
 use crate::core::usage::{DailyUsageSummary, Pricing, ProviderUsage, UsageTracker};
-use crate::server::auth::require_dashboard_session;
 use crate::server::state::AppState;
 use crate::server::usage_live::UsageEvent;
 use crate::server::usage_stream::{build_usage_stats, UsagePeriod, UsageStatsPayload};
@@ -94,12 +93,8 @@ async fn get_usage_stats(
     Query(query): Query<StatsQuery>,
     headers: HeaderMap,
 ) -> Response {
-    if let Err(error) = require_dashboard_session(&headers, &state.db) {
-        return (
-            axum::http::StatusCode::UNAUTHORIZED,
-            Json(serde_json::json!({ "error": error.message() })),
-        )
-            .into_response();
+    if let Err(response) = require_usage_access(&headers, &state) {
+        return response;
     }
 
     let period = match query.period.as_deref().unwrap_or("7d") {
@@ -122,12 +117,8 @@ async fn get_usage_stats(
 }
 
 async fn stream_usage_stats(State(state): State<AppState>, headers: HeaderMap) -> Response {
-    if let Err(error) = require_dashboard_session(&headers, &state.db) {
-        return (
-            axum::http::StatusCode::UNAUTHORIZED,
-            Json(serde_json::json!({ "error": error.message() })),
-        )
-            .into_response();
+    if let Err(response) = require_usage_access(&headers, &state) {
+        return response;
     }
 
     let encoder = std::sync::Arc::new(tokio::sync::Mutex::new(()));

--- a/tests/cli_m4_robot_envelopes.rs
+++ b/tests/cli_m4_robot_envelopes.rs
@@ -1,0 +1,330 @@
+//! M4 CLI integration tests.
+//!
+//! These exercise the *real* `openproxy` binary (via assert_cmd) against a
+//! local wiremock server, then compare the `--robot` stdout against golden
+//! JSON envelopes. They cover the happy path for every M4 subcommand:
+//! usage / logs / quota / chat / provider oauth.
+//!
+//! Streaming commands are tested separately at the lib level (see
+//! `src/cli/runtime.rs` tests for `SseFrames`) — driving an indefinite SSE
+//! stream from assert_cmd is brittle and adds little signal over the
+//! envelope assertions.
+
+#![cfg(test)]
+
+use assert_cmd::prelude::*;
+use serde_json::{json, Value};
+use std::process::Command;
+use wiremock::matchers::{method, path};
+use wiremock::{Mock, MockServer, ResponseTemplate};
+
+const API_KEY: &str = "test-cli-key";
+
+/// Boot a wiremock that always answers `/api/health` with 200 OK, plus the
+/// per-test mocks attached by the caller.
+async fn boot_server() -> MockServer {
+    let server = MockServer::start().await;
+    Mock::given(method("GET"))
+        .and(path("/api/health"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({"ok": true})))
+        .mount(&server)
+        .await;
+    server
+}
+
+fn op(server: &MockServer, args: &[&str]) -> std::process::Output {
+    Command::cargo_bin("openproxy")
+        .expect("locate openproxy binary")
+        .env("OPENPROXY_URL", &server.uri())
+        .env("OPENPROXY_API_KEY", API_KEY)
+        // Force a clean data dir so the CLI does not fall back to a real
+        // local install on the test host.
+        .env(
+            "DATA_DIR",
+            tempfile::tempdir()
+                .expect("tempdir")
+                .path()
+                .to_string_lossy()
+                .to_string(),
+        )
+        .args(args)
+        .output()
+        .expect("run openproxy")
+}
+
+fn parse_robot(stdout: &[u8]) -> Value {
+    let s = std::str::from_utf8(stdout).expect("utf8 stdout");
+    serde_json::from_str(s.trim()).unwrap_or_else(|e| {
+        panic!("invalid robot envelope: {e}\nraw: {s}");
+    })
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn usage_summary_emits_robot_envelope() {
+    let server = boot_server().await;
+    Mock::given(method("GET"))
+        .and(path("/api/usage/summary"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "total_requests": 42,
+            "total_prompt_tokens": 1000,
+            "total_completion_tokens": 500,
+            "total_cost": 0.12345,
+        })))
+        .mount(&server)
+        .await;
+
+    let out = op(&server, &["--robot", "usage", "summary"]);
+    assert!(
+        out.status.success(),
+        "stderr: {}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+    let env = parse_robot(&out.stdout);
+    assert_eq!(env["schema"], "openproxy.v1.usage.summary");
+    assert_eq!(env["ok"], true);
+    assert_eq!(env["data"]["total_requests"], 42);
+    assert_eq!(env["data"]["total_cost"], 0.12345);
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn usage_providers_emits_robot_envelope() {
+    let server = boot_server().await;
+    Mock::given(method("GET"))
+        .and(path("/api/usage/providers"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "providers": [
+                {"provider": "openai",    "requests": 10, "tokens": 1234, "cost": 0.05},
+                {"provider": "anthropic", "requests":  3, "tokens":  234, "cost": 0.01},
+            ],
+        })))
+        .mount(&server)
+        .await;
+
+    let out = op(&server, &["--robot", "usage", "providers"]);
+    assert!(
+        out.status.success(),
+        "stderr: {}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+    let env = parse_robot(&out.stdout);
+    assert_eq!(env["schema"], "openproxy.v1.usage.providers");
+    assert_eq!(env["data"]["providers"].as_array().unwrap().len(), 2);
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn logs_stats_emits_robot_envelope() {
+    let server = boot_server().await;
+    Mock::given(method("GET"))
+        .and(path("/api/observability/stats"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "logBufferLines": 17,
+            "totalRequestsLifetime": 123,
+            "levelCounts": {"info": 10, "warn": 5, "error": 2},
+        })))
+        .mount(&server)
+        .await;
+
+    let out = op(&server, &["--robot", "logs", "stats"]);
+    assert!(
+        out.status.success(),
+        "stderr: {}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+    let env = parse_robot(&out.stdout);
+    assert_eq!(env["schema"], "openproxy.v1.log.stats");
+    assert_eq!(env["data"]["logBufferLines"], 17);
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn logs_clear_posts_and_envelopes() {
+    let server = boot_server().await;
+    Mock::given(method("POST"))
+        .and(path("/api/observability/clear"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({"cleared": true})))
+        .mount(&server)
+        .await;
+
+    let out = op(&server, &["--robot", "logs", "clear"]);
+    assert!(
+        out.status.success(),
+        "stderr: {}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+    let env = parse_robot(&out.stdout);
+    assert_eq!(env["schema"], "openproxy.v1.log.clear");
+    assert_eq!(env["data"]["cleared"], true);
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn quota_list_uses_usage_providers() {
+    let server = boot_server().await;
+    Mock::given(method("GET"))
+        .and(path("/api/usage/providers"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "providers": [
+                {"provider": "openai", "requests": 1, "tokens": 100, "cost": 0.01},
+            ],
+        })))
+        .mount(&server)
+        .await;
+
+    let out = op(&server, &["--robot", "quota", "list"]);
+    assert!(
+        out.status.success(),
+        "stderr: {}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+    let env = parse_robot(&out.stdout);
+    assert_eq!(env["schema"], "openproxy.v1.quota.list");
+    let quotas = env["data"]["quotas"].as_array().expect("quotas array");
+    assert_eq!(quotas.len(), 1);
+    assert_eq!(quotas[0]["provider"], "openai");
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn quota_get_returns_not_found_for_missing_provider() {
+    let server = boot_server().await;
+    Mock::given(method("GET"))
+        .and(path("/api/usage/providers"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "providers": [],
+        })))
+        .mount(&server)
+        .await;
+
+    let out = op(&server, &["--robot", "quota", "get", "openai"]);
+    assert!(!out.status.success(), "should fail with not_found");
+    let env = parse_robot(&out.stdout);
+    assert_eq!(env["schema"], "openproxy.v1.error");
+    assert_eq!(env["error"]["code"], "not_found");
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn chat_models_envelopes_v1_models() {
+    let server = boot_server().await;
+    Mock::given(method("GET"))
+        .and(path("/v1/models"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "data": [
+                {"id": "gpt-4o-mini"},
+                {"id": "claude-3-5-sonnet"},
+            ],
+        })))
+        .mount(&server)
+        .await;
+
+    let out = op(&server, &["--robot", "chat", "models"]);
+    assert!(
+        out.status.success(),
+        "stderr: {}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+    let env = parse_robot(&out.stdout);
+    assert_eq!(env["schema"], "openproxy.v1.chat.models");
+    assert_eq!(env["data"]["data"].as_array().unwrap().len(), 2);
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn provider_oauth_status_envelopes() {
+    let server = boot_server().await;
+    Mock::given(method("GET"))
+        .and(path("/api/oauth/claude/status"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "provider": "claude",
+            "status": "linked",
+            "url": null,
+            "expires_at": 1735689600u64,
+        })))
+        .mount(&server)
+        .await;
+
+    let out = op(
+        &server,
+        &["--robot", "provider", "oauth", "status", "claude"],
+    );
+    assert!(
+        out.status.success(),
+        "stderr: {}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+    let env = parse_robot(&out.stdout);
+    assert_eq!(env["schema"], "openproxy.v1.oauth.status");
+    assert_eq!(env["data"]["status"], "linked");
+    assert_eq!(env["data"]["provider"], "claude");
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn server_down_exits_with_code_6() {
+    // Bind to an unused port and immediately drop the listener so connection
+    // is refused. `openproxy` must exit 6 with a `server_unreachable` envelope.
+    let listener = std::net::TcpListener::bind("127.0.0.1:0").expect("listen");
+    let port = listener.local_addr().expect("addr").port();
+    drop(listener);
+
+    let out = Command::cargo_bin("openproxy")
+        .expect("openproxy binary")
+        .env("OPENPROXY_URL", format!("http://127.0.0.1:{port}"))
+        .env("OPENPROXY_API_KEY", API_KEY)
+        .env(
+            "DATA_DIR",
+            tempfile::tempdir()
+                .expect("tempdir")
+                .path()
+                .to_string_lossy()
+                .to_string(),
+        )
+        .args(["--robot", "usage", "summary"])
+        .output()
+        .expect("run openproxy");
+
+    assert_eq!(
+        out.status.code(),
+        Some(6),
+        "stdout: {}",
+        String::from_utf8_lossy(&out.stdout)
+    );
+    let env = parse_robot(&out.stdout);
+    assert_eq!(env["schema"], "openproxy.v1.error");
+    assert_eq!(env["error"]["code"], "server_unreachable");
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn schema_list_includes_m4_resources() {
+    let out = Command::cargo_bin("openproxy")
+        .expect("openproxy binary")
+        .env(
+            "DATA_DIR",
+            tempfile::tempdir()
+                .expect("tempdir")
+                .path()
+                .to_string_lossy()
+                .to_string(),
+        )
+        .args(["--robot", "schema", "list"])
+        .output()
+        .expect("run openproxy");
+    assert!(
+        out.status.success(),
+        "stderr: {}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+    let env = parse_robot(&out.stdout);
+    let resources = env["data"]["resources"]
+        .as_array()
+        .expect("resources array")
+        .iter()
+        .filter_map(|v| v.as_str())
+        .collect::<Vec<_>>();
+    for required in [
+        "usage-event",
+        "log-event",
+        "chat-event",
+        "quota",
+        "oauth-status",
+    ] {
+        assert!(
+            resources.contains(&required),
+            "schema list missing '{required}': {resources:?}"
+        );
+    }
+}


### PR DESCRIPTION
## Summary

Implements **M4 — Observability & runtime** from the PLAN v3: ~25 new CLI subcommands that wrap the running server's `/api/usage/*`, `/api/observability/*`, `/api/oauth/*`, `/v1/models`, and `/api/dashboard/chat/completions` endpoints. Single PR per user request — no M4a/M4b split.

### New runtime plumbing (`src/cli/runtime.rs`)

- Reqwest-based HTTP client that resolves the target server in priority order:
  1. `--url` / `OPENPROXY_URL` (remote mode)
  2. `{data_dir}/openproxy.endpoint` sidecar
  3. `127.0.0.1:4623` fallback
- API key resolution: explicit flag → `OPENPROXY_API_KEY` env → first active key in local `db.json`.
- `ensure_alive()` probes `/api/health` with a 1.5s timeout and maps connection failures to a stable **exit code 6** + `server_unreachable` envelope.
- `stream_sse()` / `post_stream_sse()` open SSE responses with **no client-side timeout** — streaming subcommands follow indefinitely until Ctrl+C, per spec.
- `SseFrames` adapter extracts `data:` payloads from raw SSE bytes (handles both LF and CRLF, skips `:`-prefixed pings); unit-tested.

### New CLI commands

| Group | Subcommands | Source endpoint |
|-------|-------------|-----------------|
| `usage` | `summary`, `daily`, `chart`, `history`, `stats`, `providers`, `logs`, `request-logs`, `stream`, `pricing` | `/api/usage/*` |
| `logs` | `tail [--follow]`, `export`, `clear`, `stats` | `/api/observability/*` |
| `quota` | `list`, `get`, `reset --yes`, `refresh` | `/api/usage/providers` + `/api/observability/clear` |
| `chat` | `models`, `tags`, `send`, `stream` | `/v1/models`, `/api/tags`, `/api/dashboard/chat/completions` |
| `provider oauth` | `start`, `poll`, `status`, `refresh`, `import-kiro [--auto]`, `iflow-cookie`, `gitlab-pat` | `/api/oauth/*` |

All commands honor the global `--robot` flag and emit stable `openproxy.v1.*` envelopes (NDJSON for streams). Streaming commands flush per chunk.

### Server-side support

- **Re-introduces** `/api/observability/{logs,stream,stats,clear}` (moved from inline `/api/logs/list` in `mod.rs`), backed by the existing `console_logs` broadcast channel + 25-second SSE keepalive pings. All four endpoints require API-key auth so CLI sessions can subscribe.
- **Relaxes** auth on `/api/usage/stats` and `/api/usage/stream` from `require_dashboard_session` → `require_usage_access`, so CLI API keys can read live counters without forging a dashboard session cookie.

### Schema introspection

`openproxy schema list/show/example` now covers the new envelope shapes so agents can introspect without browsing the dashboard:

- `usage-event`, `log-event`, `chat-event` — NDJSON event envelopes
- `quota` — per-provider aggregate row
- `oauth-status` — `provider oauth status` return shape

### Test infrastructure

- New dev-deps: `assert_cmd`, `predicates`, `insta` (last reserved for future golden-snapshot tests).
- `tests/cli_m4_robot_envelopes.rs` (10 cases, all green): launches the real `openproxy` binary via `assert_cmd` against a `wiremock` mock server, round-trips `--robot` stdout through `serde_json`, and asserts envelope shape. Covers happy paths for every M4 group plus the exit-6 / `server_unreachable` path.
- `src/cli/runtime.rs` unit tests cover SSE frame extraction and `RuntimeError → exit_code` mapping.

## Review & Testing Checklist for Human

- [ ] Skim `src/cli/runtime.rs` — this is the dependency of every M4 command. Pay attention to how `api_key` is resolved (cfg → env → first active db.json key) and where streams disable the request timeout (`stream_client()`).
- [ ] Spot-check one envelope: `target/debug/openproxy --robot usage summary` against a running server. Confirm shape is `{schema, ok, data, error, meta}`.
- [ ] Confirm streaming UX: `openproxy logs tail --follow` and `openproxy usage stream` should run until Ctrl+C with no spurious disconnects. Server emits an SSE `:keepalive` ping every 25s.
- [ ] Verify exit code: `OPENPROXY_URL=http://127.0.0.1:1 openproxy --robot usage summary; echo $?` → must print exit 6 with `server_unreachable`.
- [ ] Run `cargo test --test cli_m4_robot_envelopes` locally — 10 tests should pass in <1s.

### Notes

- `provider oauth` is nested under `provider` (not top-level) because the M3 layout already groups everything provider-related under that namespace; the dispatcher in both `main.rs` and `cli/mod.rs::Cli::run` peels off the `Oauth` variant before falling through to `run_provider` (which still owns the DB-mode subcommands).
- `chat stream` reads stdin via `--prompt -` (or accepts an inline `--prompt "hello"`); same for `chat send`.
- `quota reset` is a thin alias over the observability `clear` endpoint — true per-key quota enforcement is a separate M6 task.
- No DB schema changes. No web UI changes.
- Insta is included but no golden snapshots are written yet — adding them is a friction-level cleanup item from the PLAN, deferred until the schema surface stabilizes after M5/M6.
