### PR TITLE
Fix CLI timeout enforcement, web-fetch cooldown persistence, vertex test assertions

### DIFF
--- a/src/core/executor/vertex.rs
+++ b/src/core/executor/vertex.rs
@@ -414,6 +414,7 @@ mod tests {
         let (location, project_id, actual_model, is_partner) =
             VertexExecutor::parse_vertex_model("vertex/gemini-2.5-flash");
         assert_eq!(location, "us-central1");
+        assert_eq!(project_id, "");
         assert_eq!(actual_model, "models/gemini-2.5-flash");
         assert!(!is_partner);
     }
@@ -423,6 +424,8 @@ mod tests {
         let (location, project_id, actual_model, is_partner) =
             VertexExecutor::parse_vertex_model("vertex-partner/glm-5-maas");
         assert_eq!(location, "us-central1");
+        assert_eq!(project_id, "");
+        assert_eq!(actual_model, "glm-5-maas");
         assert!(is_partner);
     }
 

--- a/src/server/api/cli_tools.rs
+++ b/src/server/api/cli_tools.rs
@@ -132,40 +132,14 @@ pub async fn execute_command(
         }
     };
 
-    // Execute the command
-    let result = tokio::process::Command::new(&program)
-        .args(&args)
-        .output()
-        .await;
-
+    // Execute the command with a hard timeout so callers can't hang the request.
+    let response = run_command_with_timeout(&program, &args, timeout_secs).await;
     let duration_ms = start_time.elapsed().as_millis() as u64;
-
-    match result {
-        Ok(output) => {
-            let stdout = String::from_utf8_lossy(&output.stdout);
-            let stderr = String::from_utf8_lossy(&output.stderr);
-            let exit_code = output.status.code();
-
-            Json(CliCommandResponse {
-                success: output.status.success(),
-                exit_code,
-                stdout: stdout.to_string(),
-                stderr: stderr.to_string(),
-                duration_ms,
-                timed_out: false,
-            })
-            .into_response()
-        }
-        Err(e) => Json(CliCommandResponse {
-            success: false,
-            exit_code: Some(-1),
-            stdout: String::new(),
-            stderr: format!("Failed to execute command: {}", e),
-            duration_ms,
-            timed_out: false,
-        })
-        .into_response(),
-    }
+    Json(CliCommandResponse {
+        duration_ms,
+        ..response
+    })
+    .into_response()
 }
 
 /// POST /api/cli-tools/run
@@ -184,35 +158,76 @@ pub async fn run_tool(
     let start_time = std::time::Instant::now();
 
     let (program, args) = build_tool_command(&tool_name, req.args.unwrap_or_default());
+
+    let response = run_command_with_timeout(&program, &args, timeout_secs).await;
     let duration_ms = start_time.elapsed().as_millis() as u64;
 
-    let output = match Command::new(&program).args(&args).output().await {
-        Ok(o) => o,
+    Json(CliCommandResponse {
+        duration_ms,
+        ..response
+    })
+    .into_response()
+}
+
+/// Run a child process with a hard timeout. Returns a `CliCommandResponse`
+/// (with `duration_ms` set to 0 so the caller can fill it in once they've
+/// measured wall-clock time from before parsing).
+async fn run_command_with_timeout(
+    program: &str,
+    args: &[String],
+    timeout_secs: u64,
+) -> CliCommandResponse {
+    let child = match tokio::process::Command::new(program)
+        .args(args)
+        .kill_on_drop(true)
+        .stdout(std::process::Stdio::piped())
+        .stderr(std::process::Stdio::piped())
+        .spawn()
+    {
+        Ok(c) => c,
         Err(e) => {
-            return Json(CliCommandResponse {
+            return CliCommandResponse {
                 success: false,
                 exit_code: Some(-1),
                 stdout: String::new(),
-                stderr: format!("Failed to execute: {}", e),
-                duration_ms,
+                stderr: format!("Failed to execute command: {}", e),
+                duration_ms: 0,
                 timed_out: false,
-            })
-            .into_response()
+            };
         }
     };
 
-    let stdout = String::from_utf8_lossy(&output.stdout);
-    let stderr = String::from_utf8_lossy(&output.stderr);
-
-    Json(CliCommandResponse {
-        success: output.status.success(),
-        exit_code: output.status.code(),
-        stdout: stdout.to_string(),
-        stderr: stderr.to_string(),
-        duration_ms,
-        timed_out: false,
-    })
-    .into_response()
+    let wait_fut = child.wait_with_output();
+    match tokio::time::timeout(std::time::Duration::from_secs(timeout_secs), wait_fut).await {
+        Ok(Ok(output)) => {
+            let stdout = String::from_utf8_lossy(&output.stdout).to_string();
+            let stderr = String::from_utf8_lossy(&output.stderr).to_string();
+            CliCommandResponse {
+                success: output.status.success(),
+                exit_code: output.status.code(),
+                stdout,
+                stderr,
+                duration_ms: 0,
+                timed_out: false,
+            }
+        }
+        Ok(Err(e)) => CliCommandResponse {
+            success: false,
+            exit_code: Some(-1),
+            stdout: String::new(),
+            stderr: format!("Failed to execute command: {}", e),
+            duration_ms: 0,
+            timed_out: false,
+        },
+        Err(_) => CliCommandResponse {
+            success: false,
+            exit_code: None,
+            stdout: String::new(),
+            stderr: format!("Command timed out after {}s", timeout_secs),
+            duration_ms: 0,
+            timed_out: true,
+        },
+    }
 }
 
 /// Parse a command string into program and arguments
@@ -2611,5 +2626,59 @@ mod tests {
         let (program, args) = build_tool_command("unknown-tool", vec!["arg1".to_string()]);
         assert_eq!(program, "unknown-tool");
         assert_eq!(args, vec!["arg1"]);
+    }
+
+    #[tokio::test]
+    async fn run_command_with_timeout_returns_success_for_fast_command() {
+        let response =
+            run_command_with_timeout("/bin/sh", &["-c".to_string(), "exit 0".to_string()], 5).await;
+        assert!(response.success);
+        assert_eq!(response.exit_code, Some(0));
+        assert!(!response.timed_out);
+    }
+
+    #[tokio::test]
+    async fn run_command_with_timeout_captures_stdout() {
+        let response = run_command_with_timeout(
+            "/bin/sh",
+            &["-c".to_string(), "printf hello".to_string()],
+            5,
+        )
+        .await;
+        assert!(response.success);
+        assert_eq!(response.stdout, "hello");
+        assert!(!response.timed_out);
+    }
+
+    #[tokio::test]
+    async fn run_command_with_timeout_kills_long_running_process() {
+        // sleep 30 should easily exceed the 1s timeout; we expect the killer
+        // to fire and return timed_out=true within a couple of seconds.
+        let start = std::time::Instant::now();
+        let response =
+            run_command_with_timeout("/bin/sh", &["-c".to_string(), "sleep 30".to_string()], 1)
+                .await;
+        let elapsed = start.elapsed();
+        assert!(response.timed_out, "expected timed_out=true, got {response:?}");
+        assert!(!response.success);
+        assert!(response.exit_code.is_none());
+        assert!(
+            elapsed < std::time::Duration::from_secs(10),
+            "command should have been killed quickly, took {elapsed:?}"
+        );
+    }
+
+    #[tokio::test]
+    async fn run_command_with_timeout_reports_failure_for_missing_binary() {
+        let response = run_command_with_timeout(
+            "/this/definitely/does/not/exist-openproxy-test",
+            &[],
+            5,
+        )
+        .await;
+        assert!(!response.success);
+        assert_eq!(response.exit_code, Some(-1));
+        assert!(response.stderr.contains("Failed to execute"));
+        assert!(!response.timed_out);
     }
 }

--- a/src/server/api/cli_tools.rs
+++ b/src/server/api/cli_tools.rs
@@ -2659,7 +2659,10 @@ mod tests {
             run_command_with_timeout("/bin/sh", &["-c".to_string(), "sleep 30".to_string()], 1)
                 .await;
         let elapsed = start.elapsed();
-        assert!(response.timed_out, "expected timed_out=true, got {response:?}");
+        assert!(
+            response.timed_out,
+            "expected timed_out=true, got {response:?}"
+        );
         assert!(!response.success);
         assert!(response.exit_code.is_none());
         assert!(
@@ -2670,12 +2673,9 @@ mod tests {
 
     #[tokio::test]
     async fn run_command_with_timeout_reports_failure_for_missing_binary() {
-        let response = run_command_with_timeout(
-            "/this/definitely/does/not/exist-openproxy-test",
-            &[],
-            5,
-        )
-        .await;
+        let response =
+            run_command_with_timeout("/this/definitely/does/not/exist-openproxy-test", &[], 5)
+                .await;
         assert!(!response.success);
         assert_eq!(response.exit_code, Some(-1));
         assert!(response.stderr.contains("Failed to execute"));

--- a/src/server/api/web_fetch.rs
+++ b/src/server/api/web_fetch.rs
@@ -645,6 +645,7 @@ async fn mark_connection_unavailable(
     let until = ChronoDuration::from_std(cooldown)
         .map(|d| Utc::now() + d)
         .unwrap_or_else(|_| Utc::now());
+    let until_rfc = until.to_rfc3339();
     let connection_id = connection_id.to_string();
     let message = message.to_string();
     let _ = state
@@ -664,6 +665,7 @@ async fn mark_connection_unavailable(
                     .map(|e| e.saturating_add(1))
                     .or(Some(1));
                 c.test_status = Some("unavailable".into());
+                c.rate_limited_until = Some(until_rfc);
             }
         })
         .await;
@@ -685,6 +687,7 @@ async fn clear_connection_error(state: &AppState, connection_id: &str) {
                 c.backoff_level = Some(0);
                 c.consecutive_errors = Some(0);
                 c.test_status = None;
+                c.rate_limited_until = None;
             }
         })
         .await;


### PR DESCRIPTION
## Summary

Three latent bugs were sitting in the Rust BE behind `unused variable: ...` compile warnings. None of them caused a compile/test failure, so CI was green, but each silently broke a real feature. Fixed all three and added regression tests.

### 1. `src/server/api/cli_tools.rs` — `timeout_secs` never enforced

`POST /api/cli-tools/execute` and `POST /api/cli-tools/run/:tool` both accept a `timeout_secs` field, capped to 120s. The handlers computed `timeout_secs` but then called `tokio::process::Command::output().await` directly, with no timeout wrapper. A slow or hung child process would block the request forever and return `timed_out: false`.

Pulled child execution into a new `run_command_with_timeout` helper that:
- spawns with `kill_on_drop(true)` so the child is reaped when the future is dropped,
- wraps `wait_with_output()` in `tokio::time::timeout(Duration::from_secs(timeout_secs), …)`,
- on expiry returns `success: false`, `exit_code: None`, `stderr: "Command timed out after Ns"`, `timed_out: true`.

Added 4 tokio tests: happy path, stdout capture, hard timeout (verifies the kill happens within seconds for a `sleep 30` child), and the missing-binary error path.

### 2. `src/server/api/web_fetch.rs` — `rate_limited_until` never persisted

`mark_connection_unavailable` is the function that gets called when a `/v1/web/fetch` upstream returns a fallback-worthy error (429 / 5xx). It computed an `until: DateTime<Utc>` from the cooldown duration but **never wrote it to `c.rate_limited_until`**. The fallback selector elsewhere (`select_connection`, `filter_available_accounts`, `is_account_unavailable` — see `core/account_fallback/`) keys off exactly that field to decide whether to skip a cooling-down connection.

Net effect: the per-connection cooldown for web-fetch fallback was a no-op across requests. The excluded HashSet inside `do_fetch_with_fallback` covered the current request only; the next request would happily re-pick the same dead connection until it died again. Compare to `apply_error_state` in `core/account_fallback/mod.rs:614` which sets `rate_limited_until` correctly for the chat path — same intent, just missed in this code path.

Fix: persist `until.to_rfc3339()` into `c.rate_limited_until` in `mark_connection_unavailable`, and clear it back to `None` in `clear_connection_error` on success.

### 3. `src/core/executor/vertex.rs` — missing test assertions

`test_parse_vertex_model_partner` destructured `(location, project_id, actual_model, is_partner)` but only asserted on `location` and `is_partner`. `test_parse_vertex_model_standard` ignored `project_id` similarly. Added the missing `assert_eq!`s so the partner branch's `actual_model == "glm-5-maas"` (no `models/` prefix) and the always-empty `project_id` contract are locked in.

## Review & Testing Checklist for Human

- [ ] `cargo test --lib --tests` — 54 test binaries, 0 failures locally; CI should be the same.
- [ ] Exercise `/api/cli-tools/execute` from the dashboard with a long-running command (e.g. `sleep 60`, `timeout_secs: 2`) and confirm the response returns within ~2s with `timed_out: true` and that no `sleep` process is left behind on the host (`pgrep sleep`).
- [ ] Exercise `/v1/web/fetch` against a provider that 429s, then immediately again and confirm the second request skips that connection (look for `rate_limited_until` in `db.json`'s provider_connections row, and the dashboard's provider card showing 'cooling down').
- [ ] Sanity check that the Astro dashboard still builds (`cd web && npm run build`).

### Notes

The compile warnings around `unused variable: timeout_secs`, `unused variable: until`, `unused variable: project_id`, and `unused variable: actual_model` are now gone, which is the simplest sniff-test that the bugs are gone too. A few unrelated unused-variable warnings remain (`p`, `tool_name_map`, `model_str`, `plan`, `provider`, `headers`, `req` for `StartMitmRequest`) — I reviewed each and they're stale parameters / leftover refactors, not behavior-affecting. Happy to clean those up in a follow-up if you want.

The CI workflow at `.github/workflows/rust-ci.yml` runs `cargo fmt --all --check` and `cargo test --lib --tests`. Both pass locally on Rust 1.95.0.