### PR TITLE
docs: fix README header, add 'For AI Agents' guide + auto-install openproxy skill

### DIFF
--- a/.agents/skills/openproxy/SKILL.md
+++ b/.agents/skills/openproxy/SKILL.md
@@ -1,0 +1,273 @@
+---
+name: openproxy
+description: Install, initialize, and operate OpenProxy from the CLI — either guiding a human through setup or driving it fully autonomously as an agent. Use whenever the user asks to install the openproxy binary, start the local AI router on 127.0.0.1:4623, configure providers / combos / keys, or wire an AI coding CLI (Claude Code, Codex, Cursor, Cline, OpenClaw, Copilot, …) into OpenProxy.
+---
+
+# openproxy — install & operate from the CLI
+
+[OpenProxy](https://github.com/quangdang46/openproxy) is a single-binary AI router that exposes an OpenAI-compatible API on `127.0.0.1:4623` and fans out to 40+ providers with auto-fallback. This skill walks an agent through:
+
+1. Installing or upgrading the `openproxy` binary
+2. Initializing a data dir and capturing the admin API key
+3. Starting the server **detached + headless** and verifying it
+4. Configuring providers / keys / pools declaratively via `apply`
+5. Wiring an AI coding CLI into the proxy
+
+Every step is non-interactive and safe to run unattended.
+
+## 0 · Detect what's already installed
+
+Always inspect state before mutating anything:
+
+```bash
+command -v openproxy && openproxy --version || echo "not installed"
+test -f "$HOME/.openproxy/db.json" && echo "data dir already provisioned" || true
+```
+
+If a binary is already on PATH, jump to step 2. Run `openproxy doctor` early — it catches half-installed states.
+
+## 1 · Install the binary
+
+Two equivalent install paths. Pick whichever is least invasive in the current environment.
+
+### 1a. One-shot curl installer (recommended for Linux / macOS, x86_64 + aarch64)
+
+```bash
+curl -fsSL "https://raw.githubusercontent.com/quangdang46/openproxy/main/install.sh" | bash
+export PATH="$HOME/.local/bin:$PATH"
+```
+
+Drops the binary at `~/.local/bin/openproxy`. Idempotent (locked via `/tmp/openproxy-install.lock.d`). Useful flags:
+
+| Flag | Effect |
+|---|---|
+| `--version vX.Y.Z` | Pin a specific release (default: latest from GitHub Releases). |
+| `--dest <path>` | Install to a custom directory. |
+| `--system` | Install to `/usr/local/bin` (may need sudo). |
+| `--easy-mode` | Append `PATH` export to `~/.bashrc` and `~/.zshrc`. |
+| `--from-source` | Build from source via cargo (needs Rust ≥ 1.95 + Node 20 + pnpm). |
+| `--verify` | Run `openproxy --version` after install. |
+| `--uninstall` | Remove binary and any easy-mode PATH lines. |
+| `--quiet` / `-q` | Suppress info logs. |
+
+Pass flags after `--`, for example:
+
+```bash
+curl -fsSL "https://raw.githubusercontent.com/quangdang46/openproxy/main/install.sh" \
+  | bash -s -- --version v0.1.0 --easy-mode --verify
+```
+
+### 1b. npm (any platform with Node ≥ 18)
+
+```bash
+npm install -g @openprx/openproxy
+```
+
+The shim resolves the platform-specific binary via `optionalDependencies` (`@openprx/openproxy-{linux,darwin}-{x64,arm64}`). If your package manager was run with `--no-optional` / `--ignore-optional`, reinstall with `--force` or install the platform package directly.
+
+### 1c. Windows
+
+No prebuilt binary. Either:
+
+- Install under WSL2 and use 1a.
+- Use the npm package from a Windows Node install: `npm install -g @openprx/openproxy`.
+- `--from-source` (requires Rust + Node + pnpm in the Windows shell).
+
+### Verify
+
+```bash
+openproxy --version
+openproxy doctor
+```
+
+Both should succeed before continuing.
+
+## 2 · Initialize a data dir + capture the admin API key
+
+`openproxy server init` creates an empty `db.json` at `$DATA_DIR` (default `~/.openproxy/`) and emits **one** fresh admin API key — shown exactly once.
+
+In `--robot` mode the key is on `.data.admin_key.key` of the JSONL envelope:
+
+```bash
+openproxy --robot server init | tee /tmp/op-init.json
+APIKEY=$(jq -r '.data.admin_key.key' /tmp/op-init.json)
+
+mkdir -p "$HOME/.openproxy"
+printf '%s\n' "$APIKEY" > "$HOME/.openproxy/admin.key"
+chmod 600 "$HOME/.openproxy/admin.key"
+
+# Export for subsequent commands in this session
+export OPENPROXY_API_KEY="$APIKEY"
+```
+
+> Re-running `server init` against an existing data dir errors out (envelope kind `error`, reason `conflict`) unless `--force` is passed. **Do not force without asking the user** — it wipes the existing config.
+
+If the data dir is already provisioned and the admin key is unknown, authenticate via password against the running server instead:
+
+```bash
+# Default INITIAL_PASSWORD is "123456" unless set in env at first boot.
+curl -sS -X POST http://127.0.0.1:4623/api/auth/login \
+  -H 'content-type: application/json' \
+  -d '{"password":"123456"}' \
+  -c /tmp/op.cookies
+```
+
+Then either mint a new admin key from the dashboard, or use the cookie jar (`-b /tmp/op.cookies`) for subsequent `/api/*` calls.
+
+## 3 · Start the server (detached + headless)
+
+```bash
+openproxy server start --detach --no-open
+openproxy --robot server status
+openproxy --robot doctor
+```
+
+- `--detach` — daemonize. PID is recorded under `$DATA_DIR/server.pid`.
+- `--no-open` — never spawn a browser. Required in SSH / container / CI / agent contexts.
+- Server binds `127.0.0.1:4623` by default. Change with `--port N` or `PORT=N`.
+
+To expose on LAN, set `HOSTNAME=0.0.0.0` **and** `REQUIRE_API_KEY=true` (otherwise `/v1/*` is unauthenticated). Never expose on a public interface without TLS termination at a reverse proxy.
+
+Stop / restart:
+
+```bash
+openproxy server stop
+openproxy server start --detach --no-open --port 4624   # alt port
+```
+
+## 4 · Configure providers + combos non-interactively
+
+The CLI is self-documenting — discover the resource schemas before generating payloads:
+
+```bash
+openproxy schema list                  # available resource kinds
+openproxy schema show provider         # JSON shape
+openproxy schema example provider      # ready-to-edit example
+```
+
+`schema list` returns at least: `provider`, `provider-node`, `combo`, `key`, `pool`, `settings`, `custom-model`, `model-alias`, `usage-event`, `log-event`, `chat-event`, `quota`, `oauth-status`.
+
+### Declarative `apply`
+
+`apply --from-file` is idempotent. Pass `--prune` to delete resources not present in the file.
+
+```bash
+cat > /tmp/providers.json <<'JSON'
+{
+  "providers": [
+    {
+      "name": "openai-paid",
+      "provider": "openai",
+      "apiKey": "sk-...",
+      "isActive": true
+    },
+    {
+      "name": "anthropic-paid",
+      "provider": "anthropic",
+      "apiKey": "sk-ant-...",
+      "isActive": true
+    }
+  ]
+}
+JSON
+
+openproxy --robot provider apply --from-file /tmp/providers.json
+# Or, with --prune to make the file authoritative:
+# openproxy --robot provider apply --from-file /tmp/providers.json --prune
+```
+
+The same `apply --from-file` pattern works for `key apply` and `pool apply`. Read from stdin with `--from-file -`.
+
+### Quick combo (imperative)
+
+```bash
+openproxy combo create my-stack \
+  --models "openai/gpt-4o,anthropic/claude-3-5-sonnet"
+```
+
+Combo entries are `<provider-key>/<model-id>`. For a custom provider node, the prefix is the node's **UUID** (not its name) — see the model-resolution details in `.agents/skills/testing-combo-fallback/SKILL.md`.
+
+### OAuth subscription providers (Claude Code, Codex, Copilot, Cursor, Antigravity)
+
+OAuth providers (`openproxy provider oauth …`) require a one-time browser dance. In a headless / agent context, prefer:
+
+- API-key providers wherever possible.
+- If the user has a graphical session, direct them to the dashboard's **Providers → Reconnect** flow at `http://127.0.0.1:4623`.
+
+## 5 · Wire a CLI tool into the proxy
+
+Most AI CLIs accept an OpenAI-compatible base URL and a bearer token:
+
+| Tool | Setting | Value |
+|---|---|---|
+| Cursor / Cline / Continue / Roo / Kilo | OpenAI base URL | `http://127.0.0.1:4623/v1` |
+| Codex CLI | env `OPENAI_BASE_URL` | `http://127.0.0.1:4623` |
+| Claude Code | `~/.claude/config.json` → `anthropic_api_base` | `http://127.0.0.1:4623/v1` |
+| OpenClaw | dashboard → CLI Tools → OpenClaw | one-click apply |
+
+The bearer is the admin key captured in step 2, or any key minted via `openproxy key add`. OpenProxy also has a `tool` subcommand (`openproxy tool …`) that can apply these settings programmatically — run `openproxy tool --help` to see the matrix of supported tools in the installed binary.
+
+## 6 · Verifications
+
+```bash
+# Liveness (no auth required)
+curl -sS http://127.0.0.1:4623/health
+
+# Models list (auth required)
+curl -sS http://127.0.0.1:4623/v1/models \
+  -H "Authorization: Bearer $OPENPROXY_API_KEY"
+
+# End-to-end chat completion through a combo
+curl -sS http://127.0.0.1:4623/v1/chat/completions \
+  -H "Authorization: Bearer $OPENPROXY_API_KEY" \
+  -H 'content-type: application/json' \
+  -d '{"model":"my-stack","messages":[{"role":"user","content":"ping"}]}'
+```
+
+Stop after verification if you only needed a smoke test:
+
+```bash
+openproxy server stop
+```
+
+## Common failure modes & fixes
+
+| Symptom | Fix |
+|---|---|
+| `EADDRINUSE :4623` | `openproxy server stop` then restart, or `openproxy --port 4624 server start --detach`. |
+| `401 on /v1/*` | Wrong bearer; re-issue with `openproxy key add` or fall back to the admin key from `server init`. |
+| `db.json already exists at … (use --force to overwrite)` | Data dir is pre-populated. **Ask the user before passing `--force`** — it wipes existing config. |
+| `installer: could not resolve latest version` | No GitHub Release tags published yet. Pass `--version vX.Y.Z` or `--from-source`. |
+| `npm install -g @openprx/openproxy` → `E404` | npm package not yet published in the current registry. Use the curl installer (1a) instead. |
+| `unsupported platform "linux-musl"` | Alpine etc. — use `--from-source`. |
+| `unsupported OS: …` from installer | Use the npm package (1b) or `--from-source`. |
+| OAuth callback fails in headless env | Use API-key providers, or open the dashboard from a graphical session. |
+| `openproxy doctor` reports `server not running` | `openproxy server start --detach --no-open`. |
+| Dashboard blank / stale assets | Hard reload (`Ctrl+Shift+R`). Check `/health` returns 200. |
+
+## Environment variables (most-used)
+
+| Var | Default | Purpose |
+|---|---|---|
+| `OPENPROXY_API_KEY` | _(empty)_ | Bearer used for `--robot` CLI calls. Honor `--api-key` flag too. |
+| `OPENPROXY_DATA_DIR` / `DATA_DIR` | `~/.openproxy` | Where `db.json`, `usage.json`, `log.txt` live. |
+| `PORT` | `4623` | HTTP listen port. |
+| `HOSTNAME` | `127.0.0.1` | Bind host. `0.0.0.0` exposes on LAN. |
+| `INITIAL_PASSWORD` | `123456` | First-login password (replaced on first save). |
+| `JWT_SECRET` | `openproxy-default-secret-change-me` | **Change in any non-throwaway deploy.** |
+| `REQUIRE_API_KEY` | `false` | Reject `/v1/*` without a bearer. Required for any non-loopback bind. |
+| `OPENPROXY_NO_OPEN` | _(unset)_ | Equivalent to `--no-open`. |
+| `OPENPROXY_WEB_DIR` | _(unset)_ | Serve dashboard from a directory (UI dev). |
+
+## When _not_ to use this skill
+
+- The user has openproxy running and wants help debugging combo dispatch — use `.agents/skills/testing-combo-fallback/SKILL.md` instead.
+- The user is asking about cloud-hosted multi-tenant OpenProxy — out of scope; this skill covers the local single-binary mode only.
+- The user explicitly wants to `--from-source` build openproxy from scratch — follow the README's "Build from source" section; this skill optimizes for the prebuilt-binary path.
+
+## See also
+
+- Full README: https://github.com/quangdang46/openproxy
+- CLI reference: `openproxy --help` and `openproxy <command> --help`
+- Schema introspection: `openproxy schema list`
+- Combo-fallback / E2E skill: [`.agents/skills/testing-combo-fallback/SKILL.md`](../testing-combo-fallback/SKILL.md)

--- a/README.md
+++ b/README.md
@@ -145,6 +145,60 @@ curl -sS http://127.0.0.1:4623/v1/models -H "Authorization: Bearer $APIKEY"
 
 Full walkthrough — including failure modes, OAuth provider notes, and post-install verification — lives in [`.agents/skills/openproxy/SKILL.md`](.agents/skills/openproxy/SKILL.md).
 
+### Copy-paste prompt for your AI agent
+
+Paste the block below into Devin, Claude Code, Codex, Cursor, OpenClaw, or any agent chat. It's a single self-contained instruction set — the agent will install OpenProxy, start it, and verify it works without asking further questions.
+
+````text
+You are setting up OpenProxy (https://github.com/quangdang46/openproxy) on this
+machine. OpenProxy is a single-binary AI router exposing an OpenAI-compatible
+API on http://127.0.0.1:4623. Follow these steps exactly, stop on the first
+error, and report the captured admin API key back to me at the end.
+
+1. Check whether `openproxy` is already on PATH:
+       command -v openproxy && openproxy --version || echo "not installed"
+   If already installed, skip to step 3.
+
+2. Install the binary. Pick ONE path:
+   a) Linux / macOS, x86_64 or aarch64 (preferred):
+          curl -fsSL "https://raw.githubusercontent.com/quangdang46/openproxy/main/install.sh" | bash
+          export PATH="$HOME/.local/bin:$PATH"
+   b) Any platform with Node >= 18 (use if (a) fails or on Windows):
+          npm install -g @openprx/openproxy
+
+3. Initialize a data dir and capture the admin API key. Use --robot so the
+   output is JSON; never re-run with --force without my explicit approval:
+       openproxy --robot server init | tee /tmp/op-init.json
+       APIKEY=$(jq -r '.data.admin_key.key' /tmp/op-init.json)
+       export OPENPROXY_API_KEY="$APIKEY"
+   If `server init` reports `db.json already exists`, STOP and tell me — the
+   data dir is pre-populated and I need to decide whether to overwrite.
+
+4. Start the server detached and headless, then self-test:
+       openproxy server start --detach --no-open
+       openproxy --robot server status
+       openproxy --robot doctor
+
+5. Verify end-to-end:
+       curl -sS http://127.0.0.1:4623/health
+       curl -sS http://127.0.0.1:4623/v1/models \
+         -H "Authorization: Bearer $OPENPROXY_API_KEY"
+
+6. Report back to me:
+   - The exact `openproxy --version` output.
+   - The admin API key (value of $OPENPROXY_API_KEY).
+   - Result of step 4's `server status` and `doctor`.
+   - Any non-2xx response from step 5.
+
+Do NOT run `openproxy server init --force`, do NOT delete ~/.openproxy/, and
+do NOT add provider API keys unless I gave you values explicitly. If you hit
+the failure modes documented in
+https://github.com/quangdang46/openproxy/blob/main/.agents/skills/openproxy/SKILL.md
+("Common failure modes & fixes"), apply the listed fix; otherwise stop and ask.
+````
+
+The same instructions in machine-readable form live at [`.agents/skills/openproxy/SKILL.md`](.agents/skills/openproxy/SKILL.md) — agents that auto-discover `.agents/skills/` (Devin, etc.) will pick them up without any copy-paste.
+
 ---
 
 ## Supported providers

--- a/README.md
+++ b/README.md
@@ -1,11 +1,26 @@
-<div align="center">
-  # OpenProxy
+<h1 align="center">OpenProxy</h1>
 
-  Single-binary AI router for AI coding tools. Embedded web dashboard, OpenAI-compatible API, auto-fallback across 40+ providers, token compression via RTK.
+<p align="center">
+  <b>Single-binary AI router for AI coding tools.</b><br/>
+  Embedded dashboard · OpenAI-compatible API · auto-fallback across 40+ providers · ~20–40% input-token savings via RTK.
+</p>
 
-  [![npm](https://img.shields.io/npm/v/@openprx/openproxy.svg)](https://www.npmjs.com/package/@openprx/openproxy)
-  [![License](https://img.shields.io/npm/l/@openprx/openproxy.svg)](https://github.com/quangdang46/openproxy/blob/main/LICENSE)
-</div>
+<p align="center">
+  <a href="https://github.com/quangdang46/openproxy/actions/workflows/ci.yml"><img alt="CI" src="https://github.com/quangdang46/openproxy/actions/workflows/ci.yml/badge.svg?branch=main" /></a>
+  <a href="https://github.com/quangdang46/openproxy/releases"><img alt="GitHub release" src="https://img.shields.io/github/v/release/quangdang46/openproxy?display_name=tag&sort=semver&label=release&color=brightgreen" /></a>
+  <a href="https://www.npmjs.com/package/@openprx/openproxy"><img alt="npm" src="https://img.shields.io/badge/npm-%40openprx%2Fopenproxy-CB3837?logo=npm&logoColor=white" /></a>
+  <a href="https://github.com/quangdang46/openproxy/blob/main/README.md#license"><img alt="License: MIT" src="https://img.shields.io/badge/license-MIT-blue.svg" /></a>
+  <a href="#install"><img alt="Install" src="https://img.shields.io/badge/install-curl%20%7C%20npm-1e90ff" /></a>
+</p>
+
+<p align="center">
+  <a href="#install">Install</a> ·
+  <a href="#connect-a-cli-tool">Connect a CLI</a> ·
+  <a href="#supported-providers">Providers</a> ·
+  <a href="#combos-build-a-fallback-chain">Combos</a> ·
+  <a href="#for-ai-agents">For AI Agents</a> ·
+  <a href="#configuration">Configuration</a>
+</p>
 
 ---
 
@@ -81,6 +96,54 @@ Most tools ask for an OpenAI base URL and an API key.
 The API key comes from the dashboard. Visit `http://127.0.0.1:4623`, create an API key, paste it into the tool's settings.
 
 Tested CLIs: **Claude Code, Codex, Cursor, Cline, Continue, Roo, Kilo, Copilot, OpenClaw, OpenCode, Antigravity, Droid**.
+
+---
+
+## For AI Agents
+
+OpenProxy is built to be driven by AI agents (Devin, Claude Code, Codex, Cursor, OpenClaw, …) end-to-end — install, init, configure, and verify without any browser interaction.
+
+A ready-to-use agent skill ships in this repo:
+
+- [`.agents/skills/openproxy/SKILL.md`](.agents/skills/openproxy/SKILL.md) — install, `server init`, `server start --detach`, declarative `provider apply`, and wiring CLI tools.
+
+Drop the same file at `~/.agents/skills/openproxy/SKILL.md` to make it discoverable across sessions for tools that scan the home directory.
+
+The CLI is agent-friendly by design:
+
+- `--robot` emits stable line-delimited JSON envelopes (`openproxy.v1.*`, frozen contract — additive only).
+- `openproxy schema list` / `schema show <resource>` exposes the JSON shape for every `apply`-able resource.
+- `openproxy provider apply --from-file -` is declarative and idempotent (`--prune` to reconcile).
+- `openproxy doctor` self-tests the install, data dir, and server reachability.
+
+Minimal autonomous bootstrap (no TTY, no browser, no prompts):
+
+```bash
+# 1. Install (drops binary at ~/.local/bin/openproxy)
+curl -fsSL "https://raw.githubusercontent.com/quangdang46/openproxy/main/install.sh" | bash
+export PATH="$HOME/.local/bin:$PATH"
+
+# 2. Initialize data dir; capture the admin API key from the JSON envelope
+openproxy --robot server init | tee /tmp/op-init.json
+APIKEY=$(jq -r '.data.admin_key.key' /tmp/op-init.json)
+
+# 3. Start server detached + headless, then self-test
+openproxy server start --detach --no-open
+openproxy --robot doctor
+openproxy --robot server status
+
+# 4. Configure a provider declaratively (idempotent)
+cat > /tmp/providers.json <<JSON
+{ "providers": [{ "name": "openai", "provider": "openai", "apiKey": "sk-...", "isActive": true }] }
+JSON
+OPENPROXY_API_KEY="$APIKEY" openproxy --robot provider apply --from-file /tmp/providers.json
+
+# 5. End-to-end smoke test against the running server
+curl -sS http://127.0.0.1:4623/health
+curl -sS http://127.0.0.1:4623/v1/models -H "Authorization: Bearer $APIKEY"
+```
+
+Full walkthrough — including failure modes, OAuth provider notes, and post-install verification — lives in [`.agents/skills/openproxy/SKILL.md`](.agents/skills/openproxy/SKILL.md).
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -107,7 +107,10 @@ A ready-to-use agent skill ships in this repo:
 
 - [`.agents/skills/openproxy/SKILL.md`](.agents/skills/openproxy/SKILL.md) — install, `server init`, `server start --detach`, declarative `provider apply`, and wiring CLI tools.
 
-Drop the same file at `~/.agents/skills/openproxy/SKILL.md` to make it discoverable across sessions for tools that scan the home directory.
+The `install.sh` one-shot installer **automatically drops the same file at `~/.agents/skills/openproxy/SKILL.md`** so agents that scan the home directory (Devin, Claude Code, …) pick it up the moment you install openproxy. The installer preserves any user-edited skill file (detected via the `name: openproxy` frontmatter marker) and exposes two flags:
+
+- `--no-skill` — skip the auto-install entirely.
+- `--skill-dest <dir>` — write to a custom skills root (default: `~/.agents/skills`).
 
 The CLI is agent-friendly by design:
 

--- a/install.sh
+++ b/install.sh
@@ -13,6 +13,8 @@
 #   --easy-mode            Append PATH export to ~/.bashrc / ~/.zshrc if needed
 #   --verify               Run `openproxy --version` after install
 #   --from-source          Skip release download, build from source via cargo
+#   --no-skill             Skip installing the agent skill into ~/.agents/skills/openproxy/SKILL.md
+#   --skill-dest <dir>     Override the skills root. Default: ~/.agents/skills
 #   --quiet, -q            Suppress info logs
 #   --uninstall            Remove the binary and any easy-mode PATH lines
 #   -h, --help             Show this help and exit
@@ -35,6 +37,8 @@ EASY=0
 VERIFY=0
 FROM_SOURCE=0
 UNINSTALL=0
+NO_SKILL=0
+SKILL_DEST="${SKILL_DEST:-$HOME/.agents/skills}"
 MAX_RETRIES=3
 DOWNLOAD_TIMEOUT=120
 LOCK_DIR="/tmp/${BINARY_NAME}-install.lock.d"
@@ -96,17 +100,20 @@ usage() {
 
 while [ $# -gt 0 ]; do
     case "$1" in
-        --dest)        DEST="$2"; shift 2;;
-        --dest=*)      DEST="${1#*=}"; shift;;
-        --version)     VERSION="$2"; shift 2;;
-        --version=*)   VERSION="${1#*=}"; shift;;
-        --system)      DEST="/usr/local/bin"; shift;;
-        --easy-mode)   EASY=1; shift;;
-        --verify)      VERIFY=1; shift;;
-        --from-source) FROM_SOURCE=1; shift;;
-        --quiet|-q)    QUIET=1; shift;;
-        --uninstall)   UNINSTALL=1; shift;;
-        -h|--help)     usage;;
+        --dest)         DEST="$2"; shift 2;;
+        --dest=*)       DEST="${1#*=}"; shift;;
+        --version)      VERSION="$2"; shift 2;;
+        --version=*)    VERSION="${1#*=}"; shift;;
+        --system)       DEST="/usr/local/bin"; shift;;
+        --easy-mode)    EASY=1; shift;;
+        --verify)       VERIFY=1; shift;;
+        --from-source)  FROM_SOURCE=1; shift;;
+        --no-skill)     NO_SKILL=1; shift;;
+        --skill-dest)   SKILL_DEST="$2"; shift 2;;
+        --skill-dest=*) SKILL_DEST="${1#*=}"; shift;;
+        --quiet|-q)     QUIET=1; shift;;
+        --uninstall)    UNINSTALL=1; shift;;
+        -h|--help)      usage;;
         *) log_warn "unknown argument: $1 (ignored)"; shift;;
     esac
 done
@@ -133,6 +140,14 @@ do_uninstall() {
             log_success "cleaned PATH lines from $rc"
         fi
     done
+    # Remove the auto-installed agent skill if it still carries our header
+    # marker (preserves user edits).
+    local skill_file="$SKILL_DEST/${BINARY_NAME}/SKILL.md"
+    if [ -f "$skill_file" ] && grep -q "^name: ${BINARY_NAME}$" "$skill_file" 2>/dev/null; then
+        rm -f "$skill_file"
+        rmdir "$SKILL_DEST/${BINARY_NAME}" 2>/dev/null || true
+        log_success "removed agent skill $skill_file"
+    fi
     log_success "uninstalled"
     exit 0
 }
@@ -272,6 +287,50 @@ maybe_add_path() {
 }
 
 # ════════════════════════════════════════════════════════════════════════════
+# Agent skill install — drops SKILL.md into ~/.agents/skills/openproxy/ so
+# agents that auto-discover .agents/skills/ (Devin, Claude Code, ...) can
+# install + operate openproxy on the user's behalf.
+#
+# Idempotent: if the destination file already exists and was NOT written by
+# this installer (i.e. doesn't start with our "name: openproxy" frontmatter),
+# we leave it alone to preserve user edits.
+# ════════════════════════════════════════════════════════════════════════════
+
+install_agent_skill() {
+    [ "$NO_SKILL" -eq 1 ] && return 0
+
+    local skill_dir="$SKILL_DEST/${BINARY_NAME}"
+    local skill_file="$skill_dir/SKILL.md"
+    local skill_url
+    # Pull from the same ref the binary came from when --version was pinned,
+    # otherwise from main.
+    if [ -n "$VERSION" ]; then
+        skill_url="https://raw.githubusercontent.com/${OWNER}/${REPO}/${VERSION}/.agents/skills/${BINARY_NAME}/SKILL.md"
+    else
+        skill_url="https://raw.githubusercontent.com/${OWNER}/${REPO}/main/.agents/skills/${BINARY_NAME}/SKILL.md"
+    fi
+
+    if [ -f "$skill_file" ] && ! grep -q "^name: ${BINARY_NAME}$" "$skill_file" 2>/dev/null; then
+        log_info "agent skill at $skill_file looks user-edited — leaving it alone"
+        return 0
+    fi
+
+    mkdir -p "$skill_dir" 2>/dev/null || {
+        log_warn "could not create $skill_dir — skipping agent skill install"
+        return 0
+    }
+
+    local tmp_skill="$skill_file.tmp.$$"
+    if curl -fsSL --connect-timeout 10 --max-time 30 -o "$tmp_skill" "$skill_url"; then
+        mv -f "$tmp_skill" "$skill_file"
+        log_success "agent skill installed → $skill_file"
+    else
+        rm -f "$tmp_skill"
+        log_warn "could not download agent skill from $skill_url (continuing)"
+    fi
+}
+
+# ════════════════════════════════════════════════════════════════════════════
 # Build from source
 # ════════════════════════════════════════════════════════════════════════════
 
@@ -356,6 +415,7 @@ main() {
     fi
 
     maybe_add_path
+    install_agent_skill
 
     if [ "$VERIFY" -eq 1 ]; then
         log_info "running self-test: $DEST/$BINARY_NAME --version"


### PR DESCRIPTION
## Summary

Three related changes addressing the broken README header and missing agent-setup story flagged in the user's screenshot.

**1. README header now renders correctly.**

The previous header rendered as literal `# OpenProxy` plus `npm invalid` / `license package not found` badges because:

- GitHub Flavored Markdown doesn't parse a `#` heading inside `<div align="center">` without a blank line or `markdown="1"`.
- Both badges pulled from `@openprx/openproxy` on npm, which currently 404s (`curl https://registry.npmjs.org/@openprx/openproxy` → 404), and from a `LICENSE` file that's also missing from the repo root.

Replaced with a proper `<h1>` + tagline + five badges that don't 404 right now (CI status, GitHub release placeholder, static npm package, static MIT license, install methods) and added a subnav row.

**2. New top-level `## For AI Agents` section in the README** with:

- A minimal autonomous bootstrap (`install → server init → server start --detach --no-open → provider apply --from-file → verify`).
- A new **`### Copy-paste prompt for your AI agent`** subsection — a single self-contained block users can paste into Devin / Claude Code / Codex / Cursor / OpenClaw / etc., with explicit guardrails around `--force`, `~/.openproxy/` deletion, and unsolicited provider keys.
- A note pointing to the new `.agents/skills/openproxy/SKILL.md` and explaining the installer's new auto-skill-install behavior.

**3. `.agents/skills/openproxy/SKILL.md` (new) and matching `install.sh` integration.**

- The skill walks an agent through: detect existing install → install (curl or npm) → `server init` + capture admin key from `--robot` JSON → `server start --detach --no-open` → `schema list` introspection → declarative `provider apply --from-file` → wire CLI tool → smoke-test curls. Includes a failure-modes table and a complete env-var reference. Cross-links the existing `testing-combo-fallback` skill.
- `install.sh` now fetches that same SKILL.md (from the resolved release ref, or `main`) and writes it to `~/.agents/skills/openproxy/SKILL.md` after binary install — so any agent that auto-discovers `.agents/skills/` picks it up on first install. Idempotent: a user-edited file (frontmatter `name` ≠ `openproxy`) is preserved untouched. New flags: `--no-skill` (opt-out) and `--skill-dest <dir>` (custom skills root). `--uninstall` also removes the auto-installed skill when it still has the installer marker.

Verified locally against this branch's ref:
- initial install creates `~/.agents/skills/openproxy/SKILL.md`
- re-install overwrites our own marker cleanly
- a user-edited frontmatter is preserved
- `--no-skill` produces no skill directory at all
- `bash -n install.sh` passes

## Review & Testing Checklist for Human

- [ ] Open the rendered README on this branch and confirm the title now renders as an `<h1>`, the tagline is below it, all five badges render without "invalid"/"package not found", and the subnav links jump to the right sections.
- [ ] Scroll to **For AI Agents → Copy-paste prompt for your AI agent** and read the block end-to-end. Confirm the guardrails (no `--force`, no `rm ~/.openproxy/`, no unsolicited provider keys) match your intent.
- [ ] On a clean machine, run the branch's installer and confirm `~/.agents/skills/openproxy/SKILL.md` exists with `name: openproxy` frontmatter, that a hand-edited file is preserved on re-run, that `--no-skill` produces no directory, and that `install.sh --uninstall` removes the installer-written skill but leaves a user-edited one alone.
- [ ] Sanity-check `.agents/skills/openproxy/SKILL.md` against the actual CLI surface (`openproxy --help`, `openproxy server --help`, `openproxy schema list`).

### Notes

- The `@openprx/openproxy` npm package returns 404 on registry.npmjs.org right now and GitHub Releases is empty, which is why the original badges showed "invalid". Once the first release/npm version ships, the GitHub-release badge will auto-pick up the tag and the static npm badge can be swapped for a dynamic version badge.
- The skill is also mirrored at `~/.agents/skills/openproxy/SKILL.md` on the dev machine per the user's original request — that exact behavior is what `install.sh` now automates for everyone via the new `install_agent_skill` step.
