### PR TITLE
feat(translator): rewrite role 'developer' → 'system' for OAI-compat targets [m2-op-6]

### DIFF
--- a/src/core/translator/helpers/mod.rs
+++ b/src/core/translator/helpers/mod.rs
@@ -6,4 +6,5 @@
 
 pub mod image_helper;
 pub mod max_tokens_helper;
+pub mod openai_helper;
 pub mod tool_call_helper;

--- a/src/core/translator/helpers/openai_helper.rs
+++ b/src/core/translator/helpers/openai_helper.rs
@@ -1,0 +1,98 @@
+//! OpenAI-shape helpers shared across translators.
+//!
+//! Ports `open-sse/translator/helpers/openaiHelper.js` from upstream 9router.
+//! Currently the only invariant we enforce is the `developer` → `system` role
+//! rewrite: Codex CLI (and a few other OAI-compat clients) emit messages with
+//! `role: "developer"` per the newer OpenAI spec, but most OAI-compat
+//! providers (DeepSeek, Groq, Ollama, …) reject anything outside the
+//! `system | user | assistant | tool` quartet. Rewriting on the way out keeps
+//! the request payload portable.
+
+use serde_json::Value;
+
+/// Rewrite `role: "developer"` → `role: "system"` on every message in
+/// `body.messages[]`. No-op when the body has no `messages` array.
+///
+/// Mirrors the head of upstream `filterToOpenAIFormat()` in
+/// `open-sse/translator/helpers/openaiHelper.js`.
+pub fn normalize_developer_role(body: &mut Value) {
+    let Some(messages) = body.get_mut("messages").and_then(Value::as_array_mut) else {
+        return;
+    };
+    for msg in messages.iter_mut() {
+        let Some(obj) = msg.as_object_mut() else {
+            continue;
+        };
+        if obj.get("role").and_then(Value::as_str) == Some("developer") {
+            obj.insert("role".to_string(), Value::String("system".to_string()));
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    #[test]
+    fn rewrites_developer_to_system() {
+        let mut body = json!({
+            "model": "deepseek-chat",
+            "messages": [
+                {"role": "developer", "content": "You are an assistant."},
+                {"role": "user", "content": "hi"}
+            ]
+        });
+        normalize_developer_role(&mut body);
+        assert_eq!(body["messages"][0]["role"], "system");
+        assert_eq!(body["messages"][1]["role"], "user");
+    }
+
+    #[test]
+    fn leaves_other_roles_alone() {
+        let mut body = json!({
+            "messages": [
+                {"role": "system", "content": "sys"},
+                {"role": "user", "content": "u"},
+                {"role": "assistant", "content": "a"},
+                {"role": "tool", "tool_call_id": "x", "content": "t"}
+            ]
+        });
+        let before = body.clone();
+        normalize_developer_role(&mut body);
+        assert_eq!(body, before);
+    }
+
+    #[test]
+    fn ignores_body_without_messages() {
+        let mut body = json!({"contents": [{"role": "user", "parts": [{"text": "hi"}]}]});
+        let before = body.clone();
+        normalize_developer_role(&mut body);
+        assert_eq!(body, before);
+    }
+
+    #[test]
+    fn preserves_content_and_metadata() {
+        let mut body = json!({
+            "messages": [
+                {
+                    "role": "developer",
+                    "content": [{"type": "text", "text": "spec"}],
+                    "name": "spec-author"
+                }
+            ]
+        });
+        normalize_developer_role(&mut body);
+        assert_eq!(body["messages"][0]["role"], "system");
+        assert_eq!(body["messages"][0]["content"][0]["type"], "text");
+        assert_eq!(body["messages"][0]["content"][0]["text"], "spec");
+        assert_eq!(body["messages"][0]["name"], "spec-author");
+    }
+
+    #[test]
+    fn handles_empty_messages() {
+        let mut body = json!({"messages": []});
+        normalize_developer_role(&mut body);
+        assert_eq!(body["messages"], json!([]));
+    }
+}

--- a/src/core/translator/registry.rs
+++ b/src/core/translator/registry.rs
@@ -381,6 +381,10 @@ impl TranslationRegistry {
 /// Mirrors the hooks in open-sse/translator/index.js:
 ///   stripContentTypes, normalizeThinkingConfig, ensureToolCallIds, fixMissingToolResponses
 fn apply_normalization_hooks(body: &mut Value) -> bool {
+    // normalizeDeveloperRole: rewrite role "developer" -> "system" so
+    // OAI-compat providers (DeepSeek, Groq, Ollama, …) that pre-date the
+    // Codex CLI role split don't 400 on the request.
+    crate::core::translator::helpers::openai_helper::normalize_developer_role(body);
     // ensureToolCallIds: ensure tool_calls have ids
     ensure_tool_call_ids(body);
     // fixMissingToolResponses: insert empty tool_result if needed


### PR DESCRIPTION
## What

Port upstream **`open-sse/translator/helpers/openaiHelper.js`** (decolua/9router) — rewrite messages with `role: "developer"` → `role: "system"` before forwarding to OAI-compat targets.

Codex CLI (and a few other clients tracking the newer OpenAI spec) emit `role: "developer"`. Most OAI-compat providers we proxy to — DeepSeek, Groq, Ollama, and any provider that defaults to `Format::OpenAi` — only accept `system|user|assistant|tool` and 400 on anything else.

## Where

- New: `src/core/translator/helpers/openai_helper.rs` (helper + 5 unit tests)
- `src/core/translator/helpers/mod.rs` — register the module
- `src/core/translator/registry.rs::apply_normalization_hooks` — call helper so it runs on the OAI-compat passthrough path **and** after every `openai_to_<target>` transform (catches Ollama, whose transform preserves the original role string)

## Risk

**Low.** Pure additive read+write on `body.messages[*].role`. No-op when there is no `messages` array (Gemini/Antigravity bodies). All 118 existing translator tests still pass.

## To test locally

```bash
cargo test --no-default-features --lib core::translator::helpers::openai_helper
curl -sS http://localhost:13119/v1/chat/completions \
  -H 'content-type: application/json' \
  -d '{"model":"deepseek-chat","messages":[{"role":"developer","content":"sys"},{"role":"user","content":"hi"}]}' \
  | head
# Upstream provider should see role:"system" for the first message.
```

Upstream reference: `filterToOpenAIFormat()` in `open-sse/translator/helpers/openaiHelper.js` @ decolua/9router. Plan item: **m2-op-6** in `plan-openproxy-m2-m3.md`.