### PR TITLE
feat(mcp): add stdio->SSE bridge for local MCP plugins (m2-op-4)

### DIFF
--- a/src/core/mcp/bridge.rs
+++ b/src/core/mcp/bridge.rs
@@ -1,0 +1,310 @@
+//! Per-plugin stdio→broadcast bridge for MCP. One [`BridgeEntry`] per
+//! plugin, shared across all SSE sessions of that plugin.
+//!
+//! Mirrors `getOrSpawn` / `registerSession` / `sendToChild` from upstream
+//! 9router (`src/lib/mcp/stdioSseBridge.js`), but built on tokio:
+//!
+//!   * `tokio::process::Command` for the child process.
+//!   * `tokio::sync::broadcast` for fan-out of filtered JSON-RPC frames to
+//!     all subscribed SSE listeners.
+//!   * `tokio::io::AsyncBufReadExt::lines()` for newline-delimited stdout
+//!     framing.
+//!
+//! Lifecycle: the bridge is created on first SSE subscription (or message
+//! POST) and torn down when the child exits or [`shutdown_plugin`] is
+//! called. Slow SSE consumers are tolerated up to `BROADCAST_CAPACITY`
+//! pending frames — beyond that the receiver gets `Lagged` and just resyncs.
+
+use std::collections::HashMap;
+use std::path::{Path, PathBuf};
+use std::process::Stdio;
+use std::sync::Arc;
+use std::sync::OnceLock;
+
+use parking_lot::Mutex as PlMutex;
+use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader};
+use tokio::process::{Child, ChildStdin, Command};
+use tokio::sync::{broadcast, Mutex};
+
+use super::plugins::{find_plugin, PluginDef};
+use super::smart_filter::filter_jsonrpc_frame;
+
+/// Max number of frames buffered in the per-bridge broadcast channel before
+/// laggy receivers start dropping. 256 is conservative — most MCP servers
+/// emit a handful of frames per tool call.
+pub const BROADCAST_CAPACITY: usize = 256;
+
+#[derive(Debug, thiserror::Error)]
+pub enum BridgeError {
+    #[error("unknown plugin: {0}")]
+    UnknownPlugin(String),
+    #[error("failed to spawn `{cmd}`: {source}")]
+    Spawn {
+        cmd: String,
+        #[source]
+        source: std::io::Error,
+    },
+    #[error("child `{0}` has no piped stdio")]
+    MissingStdio(String),
+    #[error("failed to write to child stdin: {0}")]
+    Write(#[source] std::io::Error),
+    #[error("invalid JSON-RPC body: {0}")]
+    InvalidJson(#[source] serde_json::Error),
+    #[error("bridge not running for plugin `{0}`")]
+    NotRunning(String),
+}
+
+/// One running plugin process plus its broadcast channel.
+pub struct BridgeEntry {
+    pub plugin_name: String,
+    /// Writable end of the child's stdin. Held behind a tokio Mutex so the
+    /// HTTP message handler can serialise frame writes without blocking the
+    /// reactor.
+    stdin: Mutex<Option<ChildStdin>>,
+    /// Broadcast channel for filtered JSON-RPC frames (one item per line).
+    sender: broadcast::Sender<String>,
+    /// Retained so the bridge stays alive as long as `BridgeEntry` is held.
+    /// The child is killed on shutdown via `kill_on_drop(true)`.
+    #[allow(dead_code)]
+    child: Mutex<Option<Child>>,
+}
+
+impl BridgeEntry {
+    pub fn subscribe(&self) -> broadcast::Receiver<String> {
+        self.sender.subscribe()
+    }
+
+    /// Forward a JSON-RPC frame to the child's stdin, with newline framing.
+    pub async fn send_to_child(&self, frame: &serde_json::Value) -> Result<(), BridgeError> {
+        let mut line = serde_json::to_string(frame).map_err(BridgeError::InvalidJson)?;
+        line.push('\n');
+        let mut guard = self.stdin.lock().await;
+        let stdin = guard
+            .as_mut()
+            .ok_or_else(|| BridgeError::NotRunning(self.plugin_name.clone()))?;
+        stdin
+            .write_all(line.as_bytes())
+            .await
+            .map_err(BridgeError::Write)?;
+        stdin.flush().await.map_err(BridgeError::Write)?;
+        Ok(())
+    }
+}
+
+type BridgeMap = HashMap<String, Arc<BridgeEntry>>;
+
+fn bridge_store() -> &'static PlMutex<BridgeMap> {
+    static STORE: OnceLock<PlMutex<BridgeMap>> = OnceLock::new();
+    STORE.get_or_init(|| PlMutex::new(HashMap::new()))
+}
+
+/// Return the running bridge for `name` if any.
+pub fn get(name: &str) -> Option<Arc<BridgeEntry>> {
+    bridge_store().lock().get(name).cloned()
+}
+
+/// Look up `name`'s [`PluginDef`] under `data_dir`, spawn the child if no
+/// bridge is running yet, and return the live [`BridgeEntry`].
+pub fn get_or_spawn(name: &str, data_dir: &Path) -> Result<Arc<BridgeEntry>, BridgeError> {
+    if let Some(entry) = get(name) {
+        return Ok(entry);
+    }
+    let plugin =
+        find_plugin(name, data_dir).ok_or_else(|| BridgeError::UnknownPlugin(name.to_string()))?;
+    spawn_bridge(plugin, data_dir.to_path_buf())
+}
+
+fn spawn_bridge(plugin: PluginDef, _data_dir: PathBuf) -> Result<Arc<BridgeEntry>, BridgeError> {
+    let mut cmd = Command::new(&plugin.command);
+    cmd.args(&plugin.args)
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .kill_on_drop(true);
+
+    let mut child = cmd.spawn().map_err(|e| BridgeError::Spawn {
+        cmd: plugin.command.clone(),
+        source: e,
+    })?;
+
+    let stdin = child
+        .stdin
+        .take()
+        .ok_or_else(|| BridgeError::MissingStdio(plugin.name.clone()))?;
+    let stdout = child
+        .stdout
+        .take()
+        .ok_or_else(|| BridgeError::MissingStdio(plugin.name.clone()))?;
+    let stderr = child.stderr.take();
+
+    let (sender, _initial_receiver) = broadcast::channel::<String>(BROADCAST_CAPACITY);
+
+    let entry = Arc::new(BridgeEntry {
+        plugin_name: plugin.name.clone(),
+        stdin: Mutex::new(Some(stdin)),
+        sender: sender.clone(),
+        child: Mutex::new(Some(child)),
+    });
+
+    {
+        let mut store = bridge_store().lock();
+        // Double-check under lock so we don't race with a concurrent caller.
+        if let Some(existing) = store.get(&plugin.name) {
+            return Ok(existing.clone());
+        }
+        store.insert(plugin.name.clone(), entry.clone());
+    }
+
+    // Stdout reader task: split on `\n`, filter, broadcast.
+    {
+        let sender = sender.clone();
+        let name = plugin.name.clone();
+        tokio::spawn(async move {
+            let mut reader = BufReader::new(stdout).lines();
+            loop {
+                match reader.next_line().await {
+                    Ok(Some(line)) => {
+                        let trimmed = line.trim();
+                        if trimmed.is_empty() {
+                            continue;
+                        }
+                        let filtered = filter_jsonrpc_frame(trimmed);
+                        let _ = sender.send(filtered);
+                    }
+                    Ok(None) => break,
+                    Err(err) => {
+                        tracing::warn!(
+                            target: "openproxy::mcp",
+                            plugin = %name,
+                            error = %err,
+                            "stdout read error; tearing down bridge"
+                        );
+                        break;
+                    }
+                }
+            }
+            shutdown_plugin(&name).await;
+        });
+    }
+
+    // Stderr drain task: log lines as warnings, mirroring upstream's
+    // `console.log(...)`.
+    if let Some(stderr) = stderr {
+        let name = plugin.name.clone();
+        tokio::spawn(async move {
+            let mut reader = BufReader::new(stderr).lines();
+            while let Ok(Some(line)) = reader.next_line().await {
+                tracing::warn!(target: "openproxy::mcp", plugin = %name, "{line}");
+            }
+        });
+    }
+
+    Ok(entry)
+}
+
+/// Tear down the bridge for `name` (closes stdin, kills child, removes from
+/// the registry). Idempotent.
+pub async fn shutdown_plugin(name: &str) {
+    let removed = bridge_store().lock().remove(name);
+    if let Some(entry) = removed {
+        {
+            let mut guard = entry.stdin.lock().await;
+            *guard = None;
+        }
+        let mut guard = entry.child.lock().await;
+        if let Some(mut child) = guard.take() {
+            let _ = child.start_kill();
+            // Don't await child.wait() here — kill_on_drop on the Child
+            // dropped from `entry`'s Mutex handles cleanup async-ly.
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::core::mcp::plugins::{
+        clear_custom_store_for_test, register_custom_plugin, PluginDef,
+    };
+    use std::time::Duration;
+    use tempfile::tempdir;
+
+    fn cat_plugin(name: &str) -> PluginDef {
+        // `cat` is not on the allowlist, so we have to register via test-only
+        // bypass. But upstream parity demands we use an allowlisted command;
+        // wrap `cat` through node -e for tests so we exercise the spawn path
+        // without coupling to npm.
+        PluginDef {
+            name: name.to_string(),
+            title: None,
+            description: None,
+            command: "node".to_string(),
+            args: vec![
+                "-e".to_string(),
+                // Echo each stdin line back inside a JSON-RPC frame so the
+                // bridge has something to broadcast and we exercise the
+                // filter path.
+                r#"process.stdin.setEncoding('utf8');let buf='';process.stdin.on('data',c=>{buf+=c;let i;while((i=buf.indexOf('\n'))>=0){const raw=buf.slice(0,i);buf=buf.slice(i+1);try{const m=JSON.parse(raw);process.stdout.write(JSON.stringify({jsonrpc:'2.0',id:m.id,result:{content:[{type:'text',text:'echo:'+(m.params||'')}]}})+'\n');}catch{}}});"#.to_string(),
+            ],
+            extension_url: None,
+            tool_names: vec![],
+        }
+    }
+
+    #[tokio::test]
+    async fn get_or_spawn_returns_error_for_unknown_plugin() {
+        let dir = tempdir().unwrap();
+        let err = match get_or_spawn("nope-nonexistent", dir.path()) {
+            Ok(_) => panic!("expected error"),
+            Err(e) => e,
+        };
+        assert!(matches!(err, BridgeError::UnknownPlugin(_)));
+    }
+
+    #[tokio::test]
+    async fn full_round_trip_via_node_echo() {
+        // Skip the test gracefully if no node binary is present in PATH.
+        if which_node().is_none() {
+            eprintln!("skipping: node not on PATH");
+            return;
+        }
+        clear_custom_store_for_test();
+        let dir = tempdir().unwrap();
+        register_custom_plugin(cat_plugin("echo-test")).unwrap();
+
+        let entry = get_or_spawn("echo-test", dir.path()).expect("spawn");
+        let mut rx = entry.subscribe();
+
+        let req = serde_json::json!({"id": 7, "params": "hi"});
+        entry.send_to_child(&req).await.unwrap();
+
+        let line = tokio::time::timeout(Duration::from_secs(5), rx.recv())
+            .await
+            .expect("timed out")
+            .expect("recv");
+
+        let parsed: serde_json::Value = serde_json::from_str(&line).unwrap();
+        assert_eq!(parsed["id"], 7);
+        assert_eq!(parsed["result"]["content"][0]["text"], "echo:hi");
+
+        shutdown_plugin("echo-test").await;
+        clear_custom_store_for_test();
+    }
+
+    #[tokio::test]
+    async fn shutdown_plugin_is_idempotent() {
+        shutdown_plugin("does-not-exist").await;
+        shutdown_plugin("does-not-exist").await; // still fine
+    }
+
+    fn which_node() -> Option<PathBuf> {
+        let path = std::env::var_os("PATH")?;
+        for entry in std::env::split_paths(&path) {
+            let candidate = entry.join("node");
+            if candidate.exists() {
+                return Some(candidate);
+            }
+        }
+        None
+    }
+}

--- a/src/core/mcp/mod.rs
+++ b/src/core/mcp/mod.rs
@@ -1,0 +1,15 @@
+//! Local stdio→SSE bridge for MCP plugins. Ports
+//! `src/lib/mcp/stdioSseBridge.js` from upstream 9router so existing MCP
+//! clients (Claude desktop, etc.) can connect to openproxy via the same
+//! `/api/mcp/<plugin>/sse` + `/api/mcp/<plugin>/message` wire protocol.
+//!
+//! Layout:
+//!   * [`smart_filter`] — text noise stripper + frame filter (pure logic).
+//!   * [`plugins`]      — built-in plugin catalog + allowlist + custom store.
+//!   * [`bridge`]       — per-plugin child process + broadcast channel.
+//!
+//! The HTTP handlers live in `crate::server::api::mcp`.
+
+pub mod bridge;
+pub mod plugins;
+pub mod smart_filter;

--- a/src/core/mcp/plugins.rs
+++ b/src/core/mcp/plugins.rs
@@ -1,0 +1,237 @@
+//! Catalog of MCP plugins openproxy can spawn under its stdio→SSE bridge,
+//! plus the allowlist that gates which executables may be used for custom
+//! plugins.
+//!
+//! Mirrors `src/shared/constants/coworkPlugins.js` from upstream 9router so
+//! the dashboard and existing MCP clients see the same plugin names.
+//!
+//! Custom plugins are persisted on disk at
+//! `${DATA_DIR}/mcp/customPlugins.json` and re-validated against the
+//! allowlist on every load — `npx`/`uvx` injection from a writable settings
+//! file is the obvious attack vector here.
+
+use std::path::Path;
+use std::sync::OnceLock;
+
+use parking_lot::RwLock;
+use serde::{Deserialize, Serialize};
+
+/// One spawnable stdio MCP plugin.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct PluginDef {
+    pub name: String,
+    /// Display title for the dashboard.
+    #[serde(default)]
+    pub title: Option<String>,
+    /// Short description for the dashboard.
+    #[serde(default)]
+    pub description: Option<String>,
+    pub command: String,
+    #[serde(default)]
+    pub args: Vec<String>,
+    /// Optional URL where users can install supporting browser/desktop
+    /// extensions (e.g. browsermcp's Chrome extension).
+    #[serde(default, rename = "extensionUrl")]
+    pub extension_url: Option<String>,
+    #[serde(default, rename = "toolNames")]
+    pub tool_names: Vec<String>,
+}
+
+/// Built-in local stdio plugins. The dashboard surfaces these as the default
+/// catalog; users can install/run them without editing settings on disk.
+///
+/// Currently mirrors upstream's `LOCAL_STDIO_PLUGINS` exactly (just
+/// `browsermcp` for now). Adding new entries here is the only way to ship
+/// "default" plugins without going through the customPlugins.json path.
+pub fn local_stdio_plugins() -> Vec<PluginDef> {
+    vec![PluginDef {
+        name: "browsermcp".to_string(),
+        title: Some("Browser MCP".to_string()),
+        description: Some(
+            "Control your running Chrome (requires Chrome extension)".to_string(),
+        ),
+        command: "npx".to_string(),
+        args: vec![
+            "-y".to_string(),
+            "@browsermcp/mcp@latest".to_string(),
+        ],
+        extension_url: Some(
+            "https://chromewebstore.google.com/detail/browser-mcp-automate-your/bjfgambnhccakkhmkepdoekmckoijdlc"
+                .to_string(),
+        ),
+        tool_names: vec![
+            "browser_navigate".to_string(),
+            "browser_snapshot".to_string(),
+            "browser_click".to_string(),
+            "browser_type".to_string(),
+            "browser_screenshot".to_string(),
+            "browser_get_console_logs".to_string(),
+            "browser_wait".to_string(),
+            "browser_press_key".to_string(),
+            "browser_go_back".to_string(),
+            "browser_go_forward".to_string(),
+        ],
+    }]
+}
+
+/// Executables that may be spawned for custom stdio MCP plugins. Mirrors
+/// upstream `ALLOWED_MCP_COMMANDS`. Anything else is rejected at
+/// registration time.
+pub const ALLOWED_MCP_COMMANDS: &[&str] =
+    &["npx", "node", "uvx", "python", "python3", "bunx", "bun"];
+
+/// True if `cmd` (after basename extraction) is on the allowlist.
+pub fn is_allowed_command(cmd: &str) -> bool {
+    let base = Path::new(cmd)
+        .file_name()
+        .and_then(|n| n.to_str())
+        .unwrap_or(cmd);
+    ALLOWED_MCP_COMMANDS.iter().any(|a| *a == base)
+}
+
+/// In-memory cache of custom plugins. Survives across requests but resets on
+/// process restart — `find_plugin` re-hydrates from
+/// `${data_dir}/mcp/customPlugins.json` lazily.
+fn custom_store() -> &'static RwLock<Vec<PluginDef>> {
+    static STORE: OnceLock<RwLock<Vec<PluginDef>>> = OnceLock::new();
+    STORE.get_or_init(|| RwLock::new(Vec::new()))
+}
+
+/// Path to the on-disk custom plugin catalog under `data_dir`.
+pub fn custom_plugins_file(data_dir: &Path) -> std::path::PathBuf {
+    data_dir.join("mcp").join("customPlugins.json")
+}
+
+/// Resolve a plugin by name. Checks (1) the in-memory custom store, then
+/// (2) built-in `LOCAL_STDIO_PLUGINS`, then (3) lazily reads
+/// `customPlugins.json` from disk (re-validating against the allowlist).
+pub fn find_plugin(name: &str, data_dir: &Path) -> Option<PluginDef> {
+    if let Some(found) = custom_store().read().iter().find(|p| p.name == name) {
+        return Some(found.clone());
+    }
+    if let Some(found) = local_stdio_plugins().into_iter().find(|p| p.name == name) {
+        return Some(found);
+    }
+
+    let path = custom_plugins_file(data_dir);
+    let raw = std::fs::read_to_string(&path).ok()?;
+    let list: Vec<PluginDef> = serde_json::from_str(&raw).ok()?;
+    let def = list
+        .into_iter()
+        .find(|p| p.name == name && !p.command.is_empty() && is_allowed_command(&p.command))?;
+    custom_store().write().push(def.clone());
+    Some(def)
+}
+
+/// Register a custom plugin in the in-memory store. Refuses any command not
+/// on the allowlist — same gate as upstream.
+pub fn register_custom_plugin(def: PluginDef) -> Result<(), String> {
+    if !is_allowed_command(&def.command) {
+        return Err(format!(
+            "Blocked: command '{}' not in MCP allowlist",
+            def.command
+        ));
+    }
+    let mut store = custom_store().write();
+    if let Some(pos) = store.iter().position(|p| p.name == def.name) {
+        store[pos] = def;
+    } else {
+        store.push(def);
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+pub(crate) fn clear_custom_store_for_test() {
+    custom_store().write().clear();
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::path::PathBuf;
+
+    fn def(name: &str, cmd: &str) -> PluginDef {
+        PluginDef {
+            name: name.to_string(),
+            title: None,
+            description: None,
+            command: cmd.to_string(),
+            args: vec![],
+            extension_url: None,
+            tool_names: vec![],
+        }
+    }
+
+    #[test]
+    fn allowed_command_checks_basename() {
+        assert!(is_allowed_command("npx"));
+        assert!(is_allowed_command("/usr/local/bin/npx"));
+        assert!(is_allowed_command("python3"));
+        assert!(!is_allowed_command("curl"));
+        assert!(!is_allowed_command("/bin/bash"));
+        assert!(!is_allowed_command(""));
+    }
+
+    #[test]
+    fn local_plugins_include_browsermcp() {
+        let plugins = local_stdio_plugins();
+        let browsermcp = plugins.iter().find(|p| p.name == "browsermcp").unwrap();
+        assert_eq!(browsermcp.command, "npx");
+        assert!(browsermcp.tool_names.iter().any(|t| t == "browser_click"));
+    }
+
+    #[test]
+    fn register_rejects_disallowed_command() {
+        clear_custom_store_for_test();
+        let err = register_custom_plugin(def("evil", "rm")).unwrap_err();
+        assert!(err.contains("not in MCP allowlist"));
+        clear_custom_store_for_test();
+    }
+
+    #[test]
+    fn register_accepts_allowed_command_and_overrides() {
+        clear_custom_store_for_test();
+        register_custom_plugin(def("foo", "npx")).unwrap();
+        register_custom_plugin(def("foo", "uvx")).unwrap();
+        let found = find_plugin("foo", Path::new("/nonexistent")).unwrap();
+        assert_eq!(found.command, "uvx");
+        clear_custom_store_for_test();
+    }
+
+    #[test]
+    fn find_plugin_loads_from_disk() {
+        clear_custom_store_for_test();
+        let dir = tempfile::tempdir().unwrap();
+        let data_dir: PathBuf = dir.path().to_path_buf();
+        std::fs::create_dir_all(data_dir.join("mcp")).unwrap();
+        let list = vec![def("disk-plug", "uvx")];
+        std::fs::write(
+            data_dir.join("mcp").join("customPlugins.json"),
+            serde_json::to_string(&list).unwrap(),
+        )
+        .unwrap();
+
+        let found = find_plugin("disk-plug", &data_dir).unwrap();
+        assert_eq!(found.command, "uvx");
+
+        // Disallowed command on disk must NOT be loaded even if the file is
+        // present — defends against settings tampering.
+        let bad = vec![def("nope", "bash")];
+        std::fs::write(
+            data_dir.join("mcp").join("customPlugins.json"),
+            serde_json::to_string(&bad).unwrap(),
+        )
+        .unwrap();
+        clear_custom_store_for_test();
+        assert!(find_plugin("nope", &data_dir).is_none());
+        clear_custom_store_for_test();
+    }
+
+    #[test]
+    fn find_plugin_misses_when_not_found() {
+        clear_custom_store_for_test();
+        let dir = tempfile::tempdir().unwrap();
+        assert!(find_plugin("does-not-exist", dir.path()).is_none());
+    }
+}

--- a/src/core/mcp/smart_filter.rs
+++ b/src/core/mcp/smart_filter.rs
@@ -1,0 +1,349 @@
+//! Smart text filter for MCP tool results. Mirrors `smartFilterText` /
+//! `collapseRepeated` from upstream 9router (`src/lib/mcp/stdioSseBridge.js`)
+//! byte-for-byte so existing MCP clients receive the same filtered output.
+//!
+//! The filter is conservative:
+//!   1. Skip short payloads (< 2_000 chars) — they're already cheap.
+//!   2. Strip a couple of well-known noise lines (`- generic:`, `- text: ""`).
+//!   3. Collapse blocks of consecutive same-indent + same-role siblings
+//!      (e.g. 50 identical `- listitem` rows → 10 head + omitted-marker + 5 tail).
+//!   4. Hard-truncate the result at `MAX_TEXT_CHARS` with an explanatory note.
+//!
+//! `[ref=eXX]` markers are preserved automatically — we only strip whole
+//! lines that don't contain them.
+
+const MAX_TEXT_CHARS: usize = 50_000;
+const COLLAPSE_THRESHOLD: usize = 30;
+const COLLAPSE_KEEP_HEAD: usize = 10;
+const COLLAPSE_KEEP_TAIL: usize = 5;
+const MIN_FILTER_LEN: usize = 2_000;
+
+/// Returns a filtered copy of `text` matching the upstream `smartFilterText`
+/// behaviour. Returns `None` when the text is short enough to skip — callers
+/// can then keep the original reference and avoid an allocation.
+pub fn smart_filter_text(text: &str) -> Option<String> {
+    if text.len() < MIN_FILTER_LEN {
+        return None;
+    }
+
+    let stripped = strip_noise_lines(text);
+    let collapsed = collapse_repeated(&stripped);
+
+    let final_text = if collapsed.len() > MAX_TEXT_CHARS {
+        let head_end = MAX_TEXT_CHARS.saturating_sub(300);
+        let head = &collapsed[..head_end];
+        format!(
+            "{head}\n\n... [truncated {} chars by openproxy bridge. Page is large; ask user to scroll/navigate to a specific section, or click an element with the refs shown above]",
+            text.len() - head.len()
+        )
+    } else {
+        collapsed
+    };
+
+    if final_text == text {
+        None
+    } else {
+        Some(final_text)
+    }
+}
+
+fn strip_noise_lines(text: &str) -> String {
+    // Mirror upstream regex semantics: strip `- generic:?` and `- text: ""`
+    // lines (with arbitrary leading whitespace) but preserve everything else.
+    text.lines()
+        .filter(|line| !is_noise_line(line))
+        .collect::<Vec<_>>()
+        .join("\n")
+}
+
+fn is_noise_line(line: &str) -> bool {
+    let trimmed = line.trim_start();
+    if let Some(rest) = trimmed.strip_prefix("- ") {
+        // `- generic:` or `- generic` with trailing whitespace only
+        if rest == "generic" || rest == "generic:" {
+            return true;
+        }
+        if let Some(after) = rest.strip_prefix("generic") {
+            let after = after.strip_prefix(':').unwrap_or(after);
+            if after.trim().is_empty() {
+                return true;
+            }
+        }
+        // `- text: ""` with trailing whitespace only
+        if let Some(after) = rest.strip_prefix("text:") {
+            if after.trim() == "\"\"" {
+                return true;
+            }
+        }
+    }
+    false
+}
+
+/// Returns a header (indent, role) for a line if it matches the
+/// `^(\s*)-\s*([A-Za-z]+)\b` shape upstream uses to detect siblings.
+fn parse_header(line: &str) -> Option<(&str, &str)> {
+    let indent_end = line.bytes().take_while(|b| b.is_ascii_whitespace()).count();
+    let (indent, rest) = line.split_at(indent_end);
+
+    let rest = rest.strip_prefix("- ").or_else(|| rest.strip_prefix('-'))?;
+    let rest = rest.trim_start_matches(|c: char| c.is_ascii_whitespace());
+
+    let role_end = rest.bytes().take_while(|b| b.is_ascii_alphabetic()).count();
+    if role_end == 0 {
+        return None;
+    }
+    let role = &rest[..role_end];
+    // upstream uses `\b` — next char must not be alphanumeric/underscore.
+    if let Some(c) = rest.as_bytes().get(role_end) {
+        let c = *c as char;
+        if c.is_ascii_alphanumeric() || c == '_' {
+            return None;
+        }
+    }
+    Some((indent, role))
+}
+
+fn collapse_repeated(text: &str) -> String {
+    let lines: Vec<&str> = text.split('\n').collect();
+    let mut out: Vec<String> = Vec::with_capacity(lines.len());
+
+    let mut i = 0;
+    while i < lines.len() {
+        let line = lines[i];
+        let Some((indent, role)) = parse_header(line) else {
+            out.push(line.to_string());
+            i += 1;
+            continue;
+        };
+
+        // Group: starting at `i`, extend forward through consecutive sibling
+        // headers with the same (indent, role), plus any deeper-indented
+        // continuation lines belonging to those siblings.
+        let mut j = i;
+        let nested_prefix_space = format!("{indent} ");
+        let nested_prefix_tab = format!("{indent}\t");
+        while j < lines.len() {
+            let ln = lines[j];
+            match parse_header(ln) {
+                Some((ind, r)) if ind == indent && r == role => {
+                    j += 1;
+                    continue;
+                }
+                _ => {}
+            }
+            if ln.starts_with(&nested_prefix_space) || ln.starts_with(&nested_prefix_tab) {
+                j += 1;
+                continue;
+            }
+            break;
+        }
+
+        let group_len = j - i;
+        if group_len >= COLLAPSE_THRESHOLD {
+            let head_end = find_nth_sibling_end(&lines, i, indent, role, COLLAPSE_KEEP_HEAD);
+            let tail_start = find_last_n_sibling_start(&lines, j, indent, role, COLLAPSE_KEEP_TAIL);
+            for line in &lines[i..head_end] {
+                out.push((*line).to_string());
+            }
+            let omitted = group_len - COLLAPSE_KEEP_HEAD - COLLAPSE_KEEP_TAIL;
+            out.push(format!(
+                "{indent}... [{omitted} similar \"{role}\" items omitted by openproxy bridge]"
+            ));
+            for line in &lines[tail_start..j] {
+                out.push((*line).to_string());
+            }
+        } else {
+            for line in &lines[i..j] {
+                out.push((*line).to_string());
+            }
+        }
+        i = j;
+    }
+
+    out.join("\n")
+}
+
+fn find_nth_sibling_end(lines: &[&str], start: usize, indent: &str, role: &str, n: usize) -> usize {
+    let mut count = 0;
+    for (k, line) in lines.iter().enumerate().skip(start) {
+        if let Some((ind, r)) = parse_header(line) {
+            if ind == indent && r == role {
+                count += 1;
+                if count > n {
+                    return k;
+                }
+            }
+        }
+    }
+    lines.len()
+}
+
+fn find_last_n_sibling_start(
+    lines: &[&str],
+    end: usize,
+    indent: &str,
+    role: &str,
+    n: usize,
+) -> usize {
+    let mut positions: Vec<usize> = Vec::new();
+    for (k, line) in lines.iter().enumerate().take(end) {
+        if let Some((ind, r)) = parse_header(line) {
+            if ind == indent && r == role {
+                positions.push(k);
+            }
+        }
+    }
+    if positions.len() > n {
+        positions[positions.len() - n]
+    } else {
+        end
+    }
+}
+
+/// Apply [`smart_filter_text`] to every `result.content[*].text` entry in a
+/// JSON-RPC line. Returns the (possibly re-serialised) line. Invalid JSON or
+/// frames without a `result.content[]` array pass through untouched.
+pub fn filter_jsonrpc_frame(line: &str) -> String {
+    let Ok(mut value) = serde_json::from_str::<serde_json::Value>(line) else {
+        return line.to_string();
+    };
+    let mut mutated = false;
+    if let Some(content) = value
+        .get_mut("result")
+        .and_then(|v| v.get_mut("content"))
+        .and_then(|v| v.as_array_mut())
+    {
+        for item in content.iter_mut() {
+            let Some(obj) = item.as_object_mut() else {
+                continue;
+            };
+            if obj.get("type").and_then(|v| v.as_str()) != Some("text") {
+                continue;
+            }
+            let Some(text) = obj.get("text").and_then(|v| v.as_str()) else {
+                continue;
+            };
+            if let Some(filtered) = smart_filter_text(text) {
+                obj.insert("text".to_string(), serde_json::Value::String(filtered));
+                mutated = true;
+            }
+        }
+    }
+    if mutated {
+        serde_json::to_string(&value).unwrap_or_else(|_| line.to_string())
+    } else {
+        line.to_string()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn short_text_returns_none() {
+        assert!(smart_filter_text("hello").is_none());
+        assert!(smart_filter_text(&"x".repeat(1_999)).is_none());
+    }
+
+    #[test]
+    fn noise_line_stripping() {
+        assert!(is_noise_line("- generic"));
+        assert!(is_noise_line("- generic:"));
+        assert!(is_noise_line("  - generic:"));
+        assert!(is_noise_line("- text: \"\""));
+        assert!(is_noise_line("    - text: \"\""));
+        assert!(!is_noise_line("- text: \"hello\""));
+        assert!(!is_noise_line("- button: clicky"));
+    }
+
+    #[test]
+    fn parse_header_detects_role() {
+        assert_eq!(parse_header("- button: foo"), Some(("", "button")));
+        assert_eq!(parse_header("  - listitem"), Some(("  ", "listitem")));
+        assert_eq!(parse_header("    - link [ref=e42]"), Some(("    ", "link")));
+        assert_eq!(parse_header("not a header"), None);
+        assert_eq!(parse_header("- 1234"), None);
+        // Underscore is a word char, so the `\b` between `e` and `_` does
+        // NOT match — mirrors upstream JS regex behaviour.
+        assert_eq!(parse_header("- snake_case"), None);
+    }
+
+    #[test]
+    fn collapses_long_runs_of_siblings() {
+        // 50 sibling listitems at the top level → upstream collapses to
+        // 10 head + omitted marker + 5 tail.
+        let lines: Vec<String> = (0..50).map(|i| format!("- listitem item-{i}")).collect();
+        let input = lines.join("\n");
+        // Pad to MIN_FILTER_LEN so smart_filter_text actually runs.
+        let padded = format!("{input}\n{}", "padding-".repeat(300));
+
+        let out = smart_filter_text(&padded).expect("should filter");
+        let count = out.lines().filter(|l| l.starts_with("- listitem")).count();
+        // 10 head + 5 tail = 15 listitem lines; the marker doesn't match.
+        assert_eq!(count, 15);
+        assert!(out.contains("35 similar \"listitem\" items omitted"));
+    }
+
+    #[test]
+    fn short_runs_arent_collapsed() {
+        // 20 sibling listitems is below the 30-threshold so no collapse runs;
+        // the filter returns None because nothing changed.
+        let lines: Vec<String> = (0..20).map(|i| format!("- listitem item-{i}")).collect();
+        let body = lines.join("\n");
+        let padded = format!("{body}\n{}", "padding-".repeat(300));
+        assert!(smart_filter_text(&padded).is_none());
+    }
+
+    #[test]
+    fn truncates_at_max_chars() {
+        let huge = "X".repeat(80_000);
+        let out = smart_filter_text(&huge).expect("should filter");
+        assert!(out.len() <= MAX_TEXT_CHARS + 300);
+        assert!(out.contains("truncated"));
+        assert!(out.contains("openproxy bridge"));
+    }
+
+    #[test]
+    fn frame_filter_rewrites_only_long_text() {
+        let text = (0..60)
+            .map(|i| format!("- listitem item-{i}"))
+            .collect::<Vec<_>>()
+            .join("\n")
+            + "\n"
+            + &"padding-".repeat(300);
+        let frame = serde_json::json!({
+            "jsonrpc": "2.0",
+            "id": 1,
+            "result": {
+                "content": [
+                    { "type": "text", "text": text },
+                    { "type": "text", "text": "short — keep me as-is" },
+                    { "type": "image", "data": "..." }
+                ]
+            }
+        });
+        let line = serde_json::to_string(&frame).unwrap();
+        let filtered = filter_jsonrpc_frame(&line);
+        let parsed: serde_json::Value = serde_json::from_str(&filtered).unwrap();
+        let arr = parsed["result"]["content"].as_array().unwrap();
+        assert!(arr[0]["text"]
+            .as_str()
+            .unwrap()
+            .contains("similar \"listitem\" items omitted"));
+        assert_eq!(arr[1]["text"].as_str().unwrap(), "short — keep me as-is");
+        assert_eq!(arr[2]["data"].as_str().unwrap(), "...");
+    }
+
+    #[test]
+    fn frame_filter_passes_through_bad_json() {
+        assert_eq!(filter_jsonrpc_frame("{not json}"), "{not json}");
+        assert_eq!(filter_jsonrpc_frame(""), "");
+    }
+
+    #[test]
+    fn frame_filter_passes_through_when_no_content() {
+        let frame = r#"{"jsonrpc":"2.0","method":"ping"}"#;
+        assert_eq!(filter_jsonrpc_frame(frame), frame);
+    }
+}

--- a/src/core/mod.rs
+++ b/src/core/mod.rs
@@ -4,6 +4,7 @@ pub mod combo;
 pub mod config;
 pub mod dns;
 pub mod executor;
+pub mod mcp;
 pub mod media;
 pub mod mitm;
 pub mod model;

--- a/src/server/api/mcp.rs
+++ b/src/server/api/mcp.rs
@@ -1,0 +1,143 @@
+//! HTTP routes for MCP stdio→SSE bridge. Mirrors upstream 9router's wire
+//! protocol byte-for-byte so existing MCP clients (Claude desktop's
+//! `--transport sse`, etc.) connect unchanged.
+//!
+//! Wire protocol:
+//!   * `GET  /api/mcp/<plugin>/sse`     — server-sent events. First frame is
+//!     `event: endpoint\ndata: /api/mcp/<plugin>/message?sessionId=<uuid>\n\n`
+//!     followed by `event: message\ndata: <json>\n\n` for every JSON-RPC
+//!     frame the child writes to stdout.
+//!   * `POST /api/mcp/<plugin>/message` — accept one JSON-RPC frame in the
+//!     body and forward it to the child's stdin. Returns 202.
+
+use std::path::PathBuf;
+
+use async_stream::stream;
+use axum::body::Body;
+use axum::extract::{Path, State};
+use axum::http::{header, StatusCode};
+use axum::response::{IntoResponse, Response};
+use axum::{
+    routing::{get, post},
+    Json, Router,
+};
+use serde_json::{json, Value};
+use uuid::Uuid;
+
+use crate::core::mcp::bridge;
+use crate::core::mcp::plugins::find_plugin;
+use crate::server::state::AppState;
+
+pub fn routes() -> Router<AppState> {
+    Router::new()
+        .route("/api/mcp/{plugin}/sse", get(sse_handler))
+        .route("/api/mcp/{plugin}/message", post(message_handler))
+}
+
+fn data_dir(state: &AppState) -> PathBuf {
+    state.db.data_dir.clone()
+}
+
+async fn sse_handler(State(state): State<AppState>, Path(plugin): Path<String>) -> Response {
+    let dir = data_dir(&state);
+    if find_plugin(&plugin, &dir).is_none() {
+        return (StatusCode::NOT_FOUND, format!("Unknown plugin: {plugin}")).into_response();
+    }
+
+    let entry = match bridge::get_or_spawn(&plugin, &dir) {
+        Ok(e) => e,
+        Err(err) => {
+            tracing::error!(
+                target: "openproxy::mcp",
+                plugin = %plugin,
+                error = %err,
+                "failed to spawn MCP bridge"
+            );
+            return (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                format!("Failed to spawn `{plugin}`: {err}"),
+            )
+                .into_response();
+        }
+    };
+
+    let session_id = Uuid::new_v4().to_string();
+    let endpoint_frame =
+        format!("event: endpoint\ndata: /api/mcp/{plugin}/message?sessionId={session_id}\n\n");
+
+    let mut rx = entry.subscribe();
+    let plugin_for_log = plugin.clone();
+    let body_stream = stream! {
+        yield Ok::<_, std::convert::Infallible>(bytes::Bytes::from(endpoint_frame));
+        loop {
+            match rx.recv().await {
+                Ok(line) => {
+                    let frame = format!("event: message\ndata: {line}\n\n");
+                    yield Ok(bytes::Bytes::from(frame));
+                }
+                Err(tokio::sync::broadcast::error::RecvError::Lagged(skipped)) => {
+                    tracing::warn!(
+                        target: "openproxy::mcp",
+                        plugin = %plugin_for_log,
+                        skipped,
+                        "SSE session lagged; some frames were dropped"
+                    );
+                    continue;
+                }
+                Err(tokio::sync::broadcast::error::RecvError::Closed) => {
+                    break;
+                }
+            }
+        }
+    };
+
+    Response::builder()
+        .status(StatusCode::OK)
+        .header(header::CONTENT_TYPE, "text/event-stream")
+        .header(header::CACHE_CONTROL, "no-cache, no-transform")
+        .header(header::CONNECTION, "keep-alive")
+        .header("X-Accel-Buffering", "no")
+        .body(Body::from_stream(body_stream))
+        .unwrap_or_else(|err| {
+            tracing::error!(target: "openproxy::mcp", error = %err, "build SSE response");
+            (StatusCode::INTERNAL_SERVER_ERROR, "internal error").into_response()
+        })
+}
+
+async fn message_handler(
+    State(state): State<AppState>,
+    Path(plugin): Path<String>,
+    Json(body): Json<Value>,
+) -> Response {
+    let dir = data_dir(&state);
+    if find_plugin(&plugin, &dir).is_none() {
+        return (
+            StatusCode::NOT_FOUND,
+            Json(json!({ "error": format!("Unknown plugin: {plugin}") })),
+        )
+            .into_response();
+    }
+
+    let entry = match bridge::get(&plugin) {
+        Some(e) => e,
+        None => {
+            return (
+                StatusCode::CONFLICT,
+                Json(json!({
+                    "error": format!("Bridge not running for `{plugin}`; open the SSE stream first.")
+                })),
+            )
+                .into_response();
+        }
+    };
+
+    if let Err(err) = entry.send_to_child(&body).await {
+        return (
+            StatusCode::INTERNAL_SERVER_ERROR,
+            Json(json!({ "error": err.to_string() })),
+        )
+            .into_response();
+    }
+
+    StatusCode::ACCEPTED.into_response()
+}

--- a/src/server/api/mod.rs
+++ b/src/server/api/mod.rs
@@ -6,6 +6,7 @@ pub mod cloud_credentials;
 pub mod cloud_sync;
 pub mod compat;
 pub mod locale;
+pub mod mcp;
 pub mod media;
 pub mod media_providers;
 pub mod mitm_config;
@@ -106,6 +107,7 @@ pub fn routes() -> Router<AppState> {
         .merge(cloud_sync::routes())
         .merge(cloud_credentials::routes())
         .merge(locale::routes())
+        .merge(mcp::routes())
         .merge(models_disabled::routes())
         .merge(models_alias::routes())
         .merge(models_availability::routes())


### PR DESCRIPTION
**What**: First-class local MCP plugin support. Adds a stdio→SSE bridge so existing MCP clients (Claude desktop `--transport sse`, etc.) can connect to openproxy via the same wire protocol upstream 9router speaks:
- `GET  /api/mcp/<plugin>/sse` — server-sent events. First frame is `event: endpoint\ndata: /api/mcp/<plugin>/message?sessionId=<uuid>\n\n`; subsequent frames are `event: message\ndata: <json>\n\n` for every JSON-RPC line the child writes to stdout.
- `POST /api/mcp/<plugin>/message` — accepts one JSON-RPC frame in the body and forwards it to the child's stdin. Returns `202`.

**Layout**:
- `src/core/mcp/smart_filter.rs` — pure noise-stripper + frame filter; mirrors upstream `smartFilterText` + `collapseRepeated` + `filterFrame` byte-for-byte. Preserves `[ref=eXX]` markers, hard-truncates at 50KB, collapses 30+ identical same-indent same-role siblings to `10 head + omitted-marker + 5 tail`.
- `src/core/mcp/plugins.rs` — built-in stdio catalog + `ALLOWED_MCP_COMMANDS` allowlist + disk-backed custom-plugin store at `${DATA_DIR}/mcp/customPlugins.json`. Allowlist is re-validated on every load so settings tampering cannot spawn arbitrary executables.
- `src/core/mcp/bridge.rs` — per-plugin `tokio::process::Command` + `tokio::sync::broadcast` fan-out. One child per plugin, `kill_on_drop`, stderr drained into `tracing`, stdout split on `\n` and each frame run through `filter_jsonrpc_frame` before being broadcast to every subscribed SSE session.
- `src/server/api/mcp.rs` — axum routes wired into the main router.

**Upstream**: ports `src/lib/mcp/stdioSseBridge.js` (199 LoC) + `src/app/api/mcp/[plugin]/{sse,message}/route.js` from decolua/9router, plus `src/shared/constants/coworkPlugins.js` for the plugin catalog + allowlist.

**Risk**: M. New module, no existing route conflicts. Child-process lifecycle is the sensitive part — bridges are torn down on stdout EOF or `shutdown_plugin(name)`, and `kill_on_drop(true)` guarantees the child is reaped if the bridge entry is removed. Slow SSE consumers are tolerated up to 256 pending frames; beyond that they get `Lagged` and just resync.

**To test locally**:
```bash
cargo test --no-default-features --lib -- core::mcp
# Smoke test (requires npx + the browsermcp Chrome extension):
openproxy server start
curl -N http://127.0.0.1:4623/api/mcp/browsermcp/sse
# In another terminal:
claude mcp add browsermcp --transport sse \
  --url http://127.0.0.1:4623/api/mcp/browsermcp/sse
```

**Followups** (out of scope for this PR):
- HTTP endpoint to register custom plugins from the dashboard (the in-memory + disk-backed store already exists; just needs route wiring).
- Per-session message routing on `?sessionId=…` (today every connected client receives every broadcast frame; matches upstream behaviour, but a real session-aware fan-out would let multiple agents share a plugin without cross-talk).