### PR TITLE
feat(mitm): show warning banner on MITM dashboard page (m3-op-9)

### DIFF
--- a/web/src/components/MitmPageClient.tsx
+++ b/web/src/components/MitmPageClient.tsx
@@ -85,6 +85,13 @@ export default function MitmPageClient() {
 
   return (
     <div className="flex w-full flex-col gap-6">
+      <div className="flex items-start gap-2 rounded-lg border border-yellow-500/30 bg-yellow-500/10 px-3 py-2">
+        <span className="material-symbols-outlined mt-0.5 shrink-0 text-[16px] text-yellow-500">warning</span>
+        <p className="text-xs leading-relaxed text-red-600 dark:text-yellow-400">
+          ⚠️ MITM intercepts HTTPS traffic of IDE tools (Antigravity, GitHub Copilot, Kiro) via a local CA to redirect requests to your providers. May violate ToS → account ban. Use at your own risk.
+        </p>
+      </div>
+
       {/* MITM Server Card */}
       <MitmServerCard
         apiKeys={apiKeys}


### PR DESCRIPTION
**What**: Adds a yellow warning banner at the top of `/dashboard/mitm` that explains MITM intercepts IDE traffic via a local CA and may violate vendor ToS.

**Upstream**: mirrors decolua/9router commit `b5979df` ("MITM Warning", v0.4.49). Dashboard-only — the tray-icon variant from upstream is intentionally out of scope (user opted out of tray work in m1).

**Risk**: S. Pure JSX addition to a single component. No new logic, no new dependencies.

**To test locally**:
```bash
pnpm --dir web run dev
# open http://127.0.0.1:4321/dashboard/mitm
```
Confirm the yellow banner appears above the MITM Server card.