### PR TITLE
feat(usage): add 'Today' period default + mobile-friendly pagination (m3-op-7)

### DIFF
--- a/src/server/api/usage.rs
+++ b/src/server/api/usage.rs
@@ -98,15 +98,15 @@ async fn get_usage_stats(
         return response;
     }
 
-    let period = match query.period.as_deref().unwrap_or("7d") {
-        value @ ("24h" | "7d" | "30d" | "60d" | "all") => {
+    let period = match query.period.as_deref().unwrap_or("today") {
+        value @ ("today" | "24h" | "7d" | "30d" | "60d" | "all") => {
             UsagePeriod::parse(value).expect("validated usage period must parse")
         }
         _ => {
             return (
                 axum::http::StatusCode::BAD_REQUEST,
                 Json(serde_json::json!({
-                    "error": "Invalid period. Use one of: 24h, 7d, 30d, 60d, all"
+                    "error": "Invalid period. Use one of: today, 24h, 7d, 30d, 60d, all"
                 })),
             )
                 .into_response()
@@ -484,8 +484,8 @@ async fn get_usage_chart(
         return response;
     }
 
-    let period = params.period.as_deref().unwrap_or("7d");
-    if !matches!(period, "24h" | "7d" | "30d" | "60d") {
+    let period = params.period.as_deref().unwrap_or("today");
+    if !matches!(period, "today" | "24h" | "7d" | "30d" | "60d") {
         return (
             axum::http::StatusCode::BAD_REQUEST,
             Json(serde_json::json!({ "error": "Invalid period" })),
@@ -499,6 +499,44 @@ async fn get_usage_chart(
 }
 
 fn build_usage_chart(usage_db: &UsageDb, period: &str) -> Vec<UsageChartBucket> {
+    if period == "today" {
+        let now = Utc::now();
+        let start = now
+            .date_naive()
+            .and_hms_opt(0, 0, 0)
+            .map(|naive| naive.and_utc())
+            .unwrap_or(now);
+        let bucket_count = 24usize;
+        let bucket_ms = 60 * 60 * 1000_i64;
+
+        let mut buckets = (0..bucket_count)
+            .map(|index| {
+                let ts = start + ChronoDuration::hours(index as i64);
+                UsageChartBucket {
+                    label: ts.format("%H:%M").to_string(),
+                    tokens: 0,
+                    cost: 0.0,
+                }
+            })
+            .collect::<Vec<_>>();
+
+        for entry in &usage_db.history {
+            let Some(timestamp) = entry.timestamp.as_deref().and_then(parse_usage_timestamp) else {
+                continue;
+            };
+            if timestamp < start || timestamp > now {
+                continue;
+            }
+
+            let delta_ms = timestamp.timestamp_millis() - start.timestamp_millis();
+            let index = (delta_ms / bucket_ms).clamp(0, (bucket_count - 1) as i64) as usize;
+            buckets[index].tokens += usage_prompt_tokens(entry) + usage_completion_tokens(entry);
+            buckets[index].cost += entry.cost.unwrap_or(0.0);
+        }
+
+        return buckets;
+    }
+
     if period == "24h" {
         let now = Utc::now();
         let bucket_count = 24usize;

--- a/src/server/usage_stream.rs
+++ b/src/server/usage_stream.rs
@@ -120,6 +120,7 @@ pub struct RecentRequest {
 
 #[derive(Debug, Clone, Copy)]
 pub enum UsagePeriod {
+    Today,
     Last24Hours,
     Last7Days,
     Last30Days,
@@ -130,6 +131,7 @@ pub enum UsagePeriod {
 impl UsagePeriod {
     pub fn parse(value: &str) -> Option<Self> {
         match value {
+            "today" => Some(Self::Today),
             "24h" => Some(Self::Last24Hours),
             "7d" => Some(Self::Last7Days),
             "30d" => Some(Self::Last30Days),
@@ -213,6 +215,29 @@ pub fn build_usage_stats(
     };
 
     match period {
+        UsagePeriod::Today => {
+            let now = Utc::now();
+            let cutoff = now
+                .date_naive()
+                .and_hms_opt(0, 0, 0)
+                .map(|naive| naive.and_utc())
+                .unwrap_or(now);
+            for entry in usage_db.history.iter().filter(|entry| {
+                entry
+                    .timestamp
+                    .as_deref()
+                    .and_then(parse_timestamp)
+                    .is_some_and(|ts| ts >= cutoff)
+            }) {
+                aggregate_live_entry(
+                    &mut stats,
+                    entry,
+                    &connection_names,
+                    &provider_names,
+                    &api_key_names,
+                );
+            }
+        }
         UsagePeriod::Last24Hours => {
             let cutoff = Utc::now() - ChronoDuration::hours(24);
             for entry in usage_db.history.iter().filter(|entry| {
@@ -240,7 +265,7 @@ pub fn build_usage_stats(
                 UsagePeriod::Last30Days => Some(30),
                 UsagePeriod::Last60Days => Some(60),
                 UsagePeriod::All => None,
-                UsagePeriod::Last24Hours => unreachable!(),
+                UsagePeriod::Last24Hours | UsagePeriod::Today => unreachable!(),
             };
             let today = Utc::now().date_naive();
             for (date_key, day) in &usage_db.daily_summary {

--- a/web/src/components/usage/UsagePageClient.tsx
+++ b/web/src/components/usage/UsagePageClient.tsx
@@ -4,6 +4,7 @@ import { UsageStats, RequestLogger, CardSkeleton, SegmentedControl } from "@/sha
 import RequestDetailsTab from "@/components/usage/RequestDetailsTab";
 
 const PERIODS = [
+  { value: "today", label: "Today" },
   { value: "24h", label: "24h" },
   { value: "7d", label: "7D" },
   { value: "30d", label: "30D" },
@@ -36,7 +37,7 @@ function UsageContent() {
   };
 
   const [tabLoading, setTabLoading] = useState(false);
-  const [period, setPeriod] = useState("7d");
+  const [period, setPeriod] = useState("today");
 
   const tabFromUrl = searchParams.get("tab");
   const activeTab = tabFromUrl && ["overview", "logs", "details"].includes(tabFromUrl)

--- a/web/src/shared/components/Pagination.tsx
+++ b/web/src/shared/components/Pagination.tsx
@@ -47,7 +47,7 @@ export default function Pagination({
   return (
     <div
       className={cn(
-        "flex flex-col sm:flex-row items-center justify-between gap-4 py-4",
+        "flex flex-col sm:flex-row items-center justify-between gap-4 py-4 px-2",
         className
       )}
     >
@@ -60,7 +60,7 @@ export default function Pagination({
         </div>
       )}
 
-      <div className="flex items-center gap-4">
+      <div className="flex flex-wrap items-center justify-center gap-2 sm:gap-4">
         {/* Page size selector */}
         {onPageSizeChange && (
           <div className="flex items-center gap-2">
@@ -73,6 +73,7 @@ export default function Pagination({
                 "text-sm text-text-main focus:outline-none focus:ring-2 focus:ring-primary/20",
                 "cursor-pointer"
               )}
+              style={{ colorScheme: "auto" }}
             >
               {[10, 20, 50].map((size) => (
                 <option key={size} value={size}>
@@ -101,12 +102,12 @@ export default function Pagination({
                   variant="ghost"
                   size="sm"
                   onClick={() => onPageChange(1)}
-                  className="w-9 px-0"
+                  className="w-9 px-0 hidden sm:inline-flex"
                 >
                   1
                 </Button>
                 {pageNumbers[0] > 2 && (
-                  <span className="text-text-muted px-1">...</span>
+                  <span className="text-text-muted px-1 hidden sm:inline">...</span>
                 )}
               </>
             )}
@@ -117,7 +118,10 @@ export default function Pagination({
                 variant={currentPage === page ? "primary" : "ghost"}
                 size="sm"
                 onClick={() => onPageChange(page)}
-                className="w-9 px-0"
+                className={cn(
+                  "w-9 px-0",
+                  currentPage === page ? "inline-flex" : "hidden sm:inline-flex"
+                )}
               >
                 {page}
               </Button>
@@ -126,13 +130,13 @@ export default function Pagination({
             {pageNumbers[pageNumbers.length - 1] < totalPages && (
               <>
                 {pageNumbers[pageNumbers.length - 1] < totalPages - 1 && (
-                  <span className="text-text-muted px-1">...</span>
+                  <span className="text-text-muted px-1 hidden sm:inline">...</span>
                 )}
                 <Button
                   variant="ghost"
                   size="sm"
                   onClick={() => onPageChange(totalPages)}
-                  className="w-9 px-0"
+                  className="w-9 px-0 hidden sm:inline-flex"
                 >
                   {totalPages}
                 </Button>


### PR DESCRIPTION
## Summary

Implements `m3-op-7` from the M2/M3 catch-up plan, bringing openproxy in line with upstream 9router v0.4.40 (#1063) and v0.4.43 (#1218).

**Today period default**
- Adds `today` as a new `UsagePeriod` variant. Filters history to entries since midnight UTC of the current day.
- Wires `today` through `/api/usage/stats` and `/api/usage/chart`, including 24 hourly buckets for the chart (`00:00`..`23:00` UTC).
- Defaults the dashboard period selector + the API to `today` (previously `7d`).

**Mobile-friendly pagination**
- The pagination component now wraps and hides first/last/dots and inactive page numbers on mobile (`sm:`) so the controls fit on narrow screens.
- Active page indicator + prev/next buttons remain visible at all breakpoints.

## Upstream references
- decolua/9router#1063 — add `Today` period
- decolua/9router#1218 — mobile pagination

## Tests
- `cargo build --release` — green
- `cargo test --lib usage` — 24 passed, 0 failed
- `pnpm run build` (web) — 111 pages built in 9.76s

Link to Devin run: https://app.devin.ai/sessions/6aae1c3d72b840b6bd5522c651090bad
Requested by Trần Quang Đãng (tranquangdang21@gmail.com)