### PR TITLE
feat(providers): refresh cloudflare-ai catalog with image models (m3-op-1)

### DIFF
--- a/src/core/model/provider_catalog.json
+++ b/src/core/model/provider_catalog.json
@@ -1609,6 +1609,61 @@
           "id": "@cf/qwen/qwen2.5-coder-32b-instruct",
           "name": "Qwen 2.5 Coder 32B Instruct",
           "kind": "llm"
+        },
+        {
+          "id": "@cf/black-forest-labs/flux-2-klein-9b",
+          "name": "FLUX.2 Klein 9B",
+          "kind": "image"
+        },
+        {
+          "id": "@cf/black-forest-labs/flux-2-klein-4b",
+          "name": "FLUX.2 Klein 4B",
+          "kind": "image"
+        },
+        {
+          "id": "@cf/black-forest-labs/flux-2-dev",
+          "name": "FLUX.2 Dev",
+          "kind": "image"
+        },
+        {
+          "id": "@cf/leonardo/lucid-origin",
+          "name": "Lucid Origin",
+          "kind": "image"
+        },
+        {
+          "id": "@cf/leonardo/phoenix-1.0",
+          "name": "Phoenix 1.0",
+          "kind": "image"
+        },
+        {
+          "id": "@cf/black-forest-labs/flux-1-schnell",
+          "name": "FLUX.1 Schnell",
+          "kind": "image"
+        },
+        {
+          "id": "@cf/bytedance/stable-diffusion-xl-lightning",
+          "name": "SDXL Lightning",
+          "kind": "image"
+        },
+        {
+          "id": "@cf/lykon/dreamshaper-8-lcm",
+          "name": "DreamShaper 8 LCM",
+          "kind": "image"
+        },
+        {
+          "id": "@cf/runwayml/stable-diffusion-v1-5-img2img",
+          "name": "Stable Diffusion v1.5 Img2Img",
+          "kind": "image"
+        },
+        {
+          "id": "@cf/runwayml/stable-diffusion-v1-5-inpainting",
+          "name": "Stable Diffusion v1.5 Inpainting",
+          "kind": "image"
+        },
+        {
+          "id": "@cf/stabilityai/stable-diffusion-xl-base-1.0",
+          "name": "SDXL Base 1.0",
+          "kind": "image"
         }
       ]
     },


### PR DESCRIPTION
## Summary

Refreshes the Cloudflare Workers AI provider catalog with the 10 image-generation models that ship in upstream `decolua/9router` v0.4.52, bringing openproxy to parity for image inference via Cloudflare.

## Changes

- `src/core/model/provider_catalog.json` — appends the following `kind: image` entries to the `cloudflare-ai` provider block:
  - `@cf/black-forest-labs/flux-2-klein-9b`
  - `@cf/black-forest-labs/flux-2-klein-4b`
  - `@cf/black-forest-labs/flux-2-dev`
  - `@cf/leonardo/lucid-origin`
  - `@cf/leonardo/phoenix-1.0`
  - `@cf/black-forest-labs/flux-1-schnell`
  - `@cf/bytedance/stable-diffusion-xl-lightning`
  - `@cf/lykon/dreamshaper-8-lcm`
  - `@cf/runwayml/stable-diffusion-v1-5-img2img`
  - `@cf/runwayml/stable-diffusion-v1-5-inpainting`
  - `@cf/stabilityai/stable-diffusion-xl-base-1.0`

The 13 LLM entries were already in sync; the executor wiring in `src/core/executor/provider.rs` already routes `cloudflare-ai` over the OpenAI-compatible adapter at the Workers AI base URL, so no Rust code changes are required for this refresh.

## Acceptance

- Catalog round-trips through `serde_json::from_str::<ProviderCatalog>` without errors.
- `cargo fmt --check` and `cargo clippy -- -D warnings` are unaffected (JSON-only diff).

## Plan reference

m3-op-1, sub-PR for `cloudflare-ai`. See `plan-openproxy-m2-m3.md`.