### PR TITLE
feat(providers): add inference-net provider (m3-op-1)

### DIFF
--- a/src/core/executor/default.rs
+++ b/src/core/executor/default.rs
@@ -249,6 +249,10 @@ static PROVIDER_CONFIGS: Lazy<BTreeMap<&'static str, ProviderConfig>> = Lazy::ne
             ProviderConfig::openai("https://api.topazlabs.com/v1"),
         ),
         (
+            "inference-net",
+            ProviderConfig::openai("https://api.inference.net/v1/chat/completions"),
+        ),
+        (
             "ollama",
             ProviderConfig::openai("https://api.ollama.com/v1/chat/completions"),
         ),

--- a/src/core/executor/provider.rs
+++ b/src/core/executor/provider.rs
@@ -847,6 +847,10 @@ static PROVIDER_REGISTRY: once_cell::sync::Lazy<BTreeMap<&'static str, ProviderE
                 "ollama",
                 ProviderExecutorConfig::openai("https://api.ollama.com/v1"),
             ),
+            (
+                "inference-net",
+                ProviderExecutorConfig::openai("https://api.inference.net/v1"),
+            ),
         ])
     });
 
@@ -956,6 +960,7 @@ pub fn get_api_key_providers() -> Vec<&'static str> {
         "firecrawl",
         "topaz",
         "ollama",
+        "inference-net",
     ]
 }
 

--- a/src/core/model/provider_catalog.json
+++ b/src/core/model/provider_catalog.json
@@ -55,7 +55,8 @@
     "perplexity-web": "perplexity-web",
     "azure": "azure",
     "cloudflare-ai": "cloudflare-ai",
-    "xiaomi-mimo": "xiaomi-mimo"
+    "xiaomi-mimo": "xiaomi-mimo",
+    "inference-net": "inference-net"
   },
   "providerModels": [
     {
@@ -3051,6 +3052,26 @@
           "kind": "llm"
         }
       ]
+    },
+    {
+      "alias": "inference-net",
+      "models": [
+        {
+          "id": "meta-llama/llama-3.3-70b-instruct/fp-16",
+          "name": "Llama 3.3 70B",
+          "kind": "llm"
+        },
+        {
+          "id": "deepseek/deepseek-v3-0324",
+          "name": "DeepSeek V3",
+          "kind": "llm"
+        },
+        {
+          "id": "mistralai/mistral-nemo-12b-instruct/fp-16",
+          "name": "Mistral Nemo 12B",
+          "kind": "llm"
+        }
+      ]
     }
   ],
   "providers": [
@@ -4094,6 +4115,17 @@
     {
       "id": "perplexity-web",
       "alias": "pw",
+      "serviceKinds": [
+        "llm"
+      ],
+      "ttsModels": [],
+      "embeddingModels": [],
+      "hasSearch": false,
+      "hasFetch": false
+    },
+    {
+      "id": "inference-net",
+      "alias": "inference-net",
       "serviceKinds": [
         "llm"
       ],


### PR DESCRIPTION
## Summary

Adds the Inference.net provider to openproxy, mirroring `decolua/9router` v0.4.52. Routes through the OpenAI-compatible adapter at `https://api.inference.net/v1`.

## Changes

- `src/core/model/provider_catalog.json`
  - `providerIdToAlias`: maps `inference-net` -> `inference-net`
  - `providerModels`: new entry with 3 models
    - `meta-llama/llama-3.3-70b-instruct/fp-16` — Llama 3.3 70B
    - `deepseek/deepseek-v3-0324` — DeepSeek V3
    - `mistralai/mistral-nemo-12b-instruct/fp-16` — Mistral Nemo 12B
  - `providers`: metadata entry with `serviceKinds: ["llm"]`
- `src/core/executor/provider.rs`
  - `PROVIDER_REGISTRY`: `ProviderExecutorConfig::openai("https://api.inference.net/v1")`
  - `get_api_key_providers()`: appends `"inference-net"`
- `src/core/executor/default.rs`
  - `PROVIDER_CONFIGS`: `ProviderConfig::openai("https://api.inference.net/v1/chat/completions")`

## Acceptance

- `cargo build --release` succeeds.
- Catalog round-trips through `serde_json::from_str::<ProviderCatalog>`.
- Provider is reachable via the OpenAI-compatible chat completions adapter once an API key is configured.

## Plan reference

m3-op-1, sub-PR for `inference-net`. See `plan-openproxy-m2-m3.md`.