### PR TITLE
feat(providers): add vercel-ai-gateway provider (m3-op-1)

### DIFF
--- a/src/core/executor/default.rs
+++ b/src/core/executor/default.rs
@@ -249,6 +249,10 @@ static PROVIDER_CONFIGS: Lazy<BTreeMap<&'static str, ProviderConfig>> = Lazy::ne
             ProviderConfig::openai("https://api.topazlabs.com/v1"),
         ),
         (
+            "vercel-ai-gateway",
+            ProviderConfig::openai("https://ai-gateway.vercel.sh/v1/chat/completions"),
+        ),
+        (
             "ollama",
             ProviderConfig::openai("https://api.ollama.com/v1/chat/completions"),
         ),

--- a/src/core/executor/provider.rs
+++ b/src/core/executor/provider.rs
@@ -847,6 +847,10 @@ static PROVIDER_REGISTRY: once_cell::sync::Lazy<BTreeMap<&'static str, ProviderE
                 "ollama",
                 ProviderExecutorConfig::openai("https://api.ollama.com/v1"),
             ),
+            (
+                "vercel-ai-gateway",
+                ProviderExecutorConfig::openai("https://ai-gateway.vercel.sh/v1"),
+            ),
         ])
     });
 
@@ -956,6 +960,7 @@ pub fn get_api_key_providers() -> Vec<&'static str> {
         "firecrawl",
         "topaz",
         "ollama",
+        "vercel-ai-gateway",
     ]
 }
 

--- a/src/core/model/provider_catalog.json
+++ b/src/core/model/provider_catalog.json
@@ -55,7 +55,8 @@
     "perplexity-web": "perplexity-web",
     "azure": "azure",
     "cloudflare-ai": "cloudflare-ai",
-    "xiaomi-mimo": "xiaomi-mimo"
+    "xiaomi-mimo": "xiaomi-mimo",
+    "vercel-ai-gateway": "vercel-ai-gateway"
   },
   "providerModels": [
     {
@@ -4094,6 +4095,17 @@
     {
       "id": "perplexity-web",
       "alias": "pw",
+      "serviceKinds": [
+        "llm"
+      ],
+      "ttsModels": [],
+      "embeddingModels": [],
+      "hasSearch": false,
+      "hasFetch": false
+    },
+    {
+      "id": "vercel-ai-gateway",
+      "alias": "vercel-ai-gateway",
       "serviceKinds": [
         "llm"
       ],


### PR DESCRIPTION
## Summary

Adds Vercel AI Gateway as a passthrough OpenAI-compatible provider in openproxy, mirroring `decolua/9router` v0.4.52 (`providers.js` lines 127-130).

## Changes

- `src/core/model/provider_catalog.json`
  - `providerIdToAlias`: maps `vercel-ai-gateway` -> `vercel-ai-gateway`
  - `providers`: metadata entry with `serviceKinds: ["llm"]`
  - No `providerModels` entry — the gateway forwards arbitrary model IDs (`openai/gpt-4o`, `anthropic/claude-3-5-sonnet`, etc.), mirroring upstream where Vercel AI Gateway is intentionally not enumerated in `providerModels.js`.
- `src/core/executor/provider.rs`
  - `PROVIDER_REGISTRY`: `ProviderExecutorConfig::openai("https://ai-gateway.vercel.sh/v1")`
  - `get_api_key_providers()`: appends `"vercel-ai-gateway"`
- `src/core/executor/default.rs`
  - `PROVIDER_CONFIGS`: `ProviderConfig::openai("https://ai-gateway.vercel.sh/v1/chat/completions")`

## Acceptance

- `cargo build --release` succeeds.
- Catalog deserializes through `serde_json::from_str::<ProviderCatalog>`.
- Provider routes any OpenAI-style chat completion request to the Vercel AI Gateway endpoint once an API key is configured.

## Plan reference

m3-op-1, sub-PR for `vercel-ai-gw`. See `plan-openproxy-m2-m3.md`.