### PR TITLE
feat(providers): add xiaomi-tokenplan provider (m3-op-1)

### DIFF
--- a/src/core/executor/default.rs
+++ b/src/core/executor/default.rs
@@ -249,6 +249,10 @@ static PROVIDER_CONFIGS: Lazy<BTreeMap<&'static str, ProviderConfig>> = Lazy::ne
             ProviderConfig::openai("https://api.topazlabs.com/v1"),
         ),
         (
+            "xiaomi-tokenplan",
+            ProviderConfig::openai("https://api.xiaomimimo.com/v1/chat/completions"),
+        ),
+        (
             "ollama",
             ProviderConfig::openai("https://api.ollama.com/v1/chat/completions"),
         ),

--- a/src/core/executor/provider.rs
+++ b/src/core/executor/provider.rs
@@ -847,6 +847,10 @@ static PROVIDER_REGISTRY: once_cell::sync::Lazy<BTreeMap<&'static str, ProviderE
                 "ollama",
                 ProviderExecutorConfig::openai("https://api.ollama.com/v1"),
             ),
+            (
+                "xiaomi-tokenplan",
+                ProviderExecutorConfig::openai("https://api.xiaomimimo.com/v1"),
+            ),
         ])
     });
 
@@ -956,6 +960,7 @@ pub fn get_api_key_providers() -> Vec<&'static str> {
         "firecrawl",
         "topaz",
         "ollama",
+        "xiaomi-tokenplan",
     ]
 }
 

--- a/src/core/model/provider_catalog.json
+++ b/src/core/model/provider_catalog.json
@@ -55,7 +55,8 @@
     "perplexity-web": "perplexity-web",
     "azure": "azure",
     "cloudflare-ai": "cloudflare-ai",
-    "xiaomi-mimo": "xiaomi-mimo"
+    "xiaomi-mimo": "xiaomi-mimo",
+    "xiaomi-tokenplan": "xiaomi-tokenplan"
   },
   "providerModels": [
     {
@@ -3051,6 +3052,51 @@
           "kind": "llm"
         }
       ]
+    },
+    {
+      "alias": "xiaomi-tokenplan",
+      "models": [
+        {
+          "id": "mimo-v2.5-pro",
+          "name": "MiMo V2.5 Pro",
+          "kind": "llm"
+        },
+        {
+          "id": "mimo-v2.5",
+          "name": "MiMo V2.5",
+          "kind": "llm"
+        },
+        {
+          "id": "mimo-v2-pro",
+          "name": "MiMo V2 Pro",
+          "kind": "llm"
+        },
+        {
+          "id": "mimo-v2-omni",
+          "name": "MiMo V2 Omni",
+          "kind": "llm"
+        },
+        {
+          "id": "mimo-v2-tts",
+          "name": "MiMo V2 TTS",
+          "kind": "tts"
+        },
+        {
+          "id": "mimo-v2.5-tts",
+          "name": "MiMo V2.5 TTS",
+          "kind": "tts"
+        },
+        {
+          "id": "mimo-v2.5-tts-voiceclone",
+          "name": "MiMo V2.5 TTS Voice Clone",
+          "kind": "tts"
+        },
+        {
+          "id": "mimo-v2.5-tts-voicedesign",
+          "name": "MiMo V2.5 TTS Voice Design",
+          "kind": "tts"
+        }
+      ]
     }
   ],
   "providers": [
@@ -4098,6 +4144,23 @@
         "llm"
       ],
       "ttsModels": [],
+      "embeddingModels": [],
+      "hasSearch": false,
+      "hasFetch": false
+    },
+    {
+      "id": "xiaomi-tokenplan",
+      "alias": "xiaomi-tokenplan",
+      "serviceKinds": [
+        "llm",
+        "tts"
+      ],
+      "ttsModels": [
+        "mimo-v2-tts",
+        "mimo-v2.5-tts",
+        "mimo-v2.5-tts-voiceclone",
+        "mimo-v2.5-tts-voicedesign"
+      ],
       "embeddingModels": [],
       "hasSearch": false,
       "hasFetch": false


### PR DESCRIPTION
## Summary

Adds the Xiaomi Tokenplan provider to openproxy, mirroring `decolua/9router` v0.4.52 (`providerModels.js` lines 541-550). Routes through the OpenAI-compatible adapter at `https://api.xiaomimimo.com/v1`, exposes both LLM and TTS service kinds.

## Changes

- `src/core/model/provider_catalog.json`
  - `providerIdToAlias`: maps `xiaomi-tokenplan` -> `xiaomi-tokenplan`
  - `providerModels`: new entry with 8 models (4 LLM, 4 TTS)
    - LLM: `mimo-v2.5-pro`, `mimo-v2.5`, `mimo-v2-pro`, `mimo-v2-omni`
    - TTS: `mimo-v2-tts`, `mimo-v2.5-tts`, `mimo-v2.5-tts-voiceclone`, `mimo-v2.5-tts-voicedesign`
  - `providers`: metadata entry with `serviceKinds: ["llm", "tts"]` and `ttsModels` populated
- `src/core/executor/provider.rs`
  - `PROVIDER_REGISTRY`: `ProviderExecutorConfig::openai("https://api.xiaomimimo.com/v1")`
  - `get_api_key_providers()`: appends `"xiaomi-tokenplan"`
- `src/core/executor/default.rs`
  - `PROVIDER_CONFIGS`: `ProviderConfig::openai("https://api.xiaomimimo.com/v1/chat/completions")`

## Acceptance

- `cargo build --release` succeeds.
- Catalog deserializes through `serde_json::from_str::<ProviderCatalog>`.
- Provider is reachable via the OpenAI-compatible chat completions adapter and TTS endpoint once an API key is configured.

## Plan reference

m3-op-1, sub-PR for `xiaomi-token`. See `plan-openproxy-m2-m3.md`.