### PR TITLE
feat(tts): route coqui/inworld/tortoise via synthesize_via_format (m3-op-4)

### DIFF
--- a/src/core/media/tts/mod.rs
+++ b/src/core/media/tts/mod.rs
@@ -25,9 +25,10 @@ pub use base::{TtsAdapter, TtsRequest, TtsResult};
 pub use generic_formats::{synthesize_via_format, GenericFormat, GenericTtsRequest};
 pub use handler::{handle_tts, TtsHandlerError};
 
-/// Synthesize speech for `provider` if a matching adapter exists.
-/// Returns the OpenAI-shape `{audio, format}` body, or `None` to fall
-/// through to a generic flow.
+/// Synthesize speech for `provider` via either a dedicated adapter or
+/// the generic format-driven path. Returns the OpenAI-shape
+/// `{audio, format}` body, or `None` if no TTS path is registered for
+/// this provider (the caller falls through to its generic forwarder).
 pub async fn dispatch(
     client: &reqwest::Client,
     credentials: &crate::types::ProviderConnection,
@@ -35,22 +36,48 @@ pub async fn dispatch(
     model: &str,
     body: &serde_json::Value,
 ) -> Option<Result<serde_json::Value, super::MediaError>> {
-    let adapter = get_tts_adapter(provider)?;
+    if !is_tts_provider(provider) {
+        return None;
+    }
     let text = body.get("input").and_then(|v| v.as_str()).unwrap_or("");
     if text.trim().is_empty() {
         return Some(Err(super::MediaError::Validation(
             "Missing required field: input".into(),
         )));
     }
-    let request = TtsRequest {
+    if let Some(adapter) = get_tts_adapter(provider) {
+        let request = TtsRequest {
+            text,
+            model,
+            credentials,
+            language: body.get("language").and_then(|v| v.as_str()),
+        };
+        return Some(
+            adapter
+                .synthesize(client, &request)
+                .await
+                .map(|r| serde_json::json!({"audio": r.base64, "format": r.format}))
+                .map_err(Into::into),
+        );
+    }
+    let format = provider_generic_format(provider)?;
+    let base_url = generic_base_url(credentials, provider);
+    let api_key = credentials
+        .api_key
+        .as_deref()
+        .or(credentials.access_token.as_deref())
+        .filter(|s| !s.is_empty());
+    let (model_id, voice_id) = split_model_voice(model);
+    let request = GenericTtsRequest {
+        format,
+        base_url: &base_url,
+        api_key,
         text,
-        model,
-        credentials,
-        language: body.get("language").and_then(|v| v.as_str()),
+        model_id,
+        voice_id,
     };
     Some(
-        adapter
-            .synthesize(client, &request)
+        synthesize_via_format(client, request)
             .await
             .map(|r| serde_json::json!({"audio": r.base64, "format": r.format}))
             .map_err(Into::into),
@@ -72,8 +99,139 @@ pub fn get_tts_adapter(provider: &str) -> Option<&'static dyn TtsAdapter> {
     }
 }
 
+/// Map a provider id to its generic `ttsConfig.format` for the
+/// config-driven path in [`synthesize_via_format`].
+pub fn provider_generic_format(provider: &str) -> Option<GenericFormat> {
+    Some(match provider {
+        "hyperbolic" => GenericFormat::Hyperbolic,
+        "deepgram" => GenericFormat::Deepgram,
+        "nvidia" => GenericFormat::NvidiaTts,
+        "huggingface" => GenericFormat::HuggingfaceTts,
+        "inworld" => GenericFormat::Inworld,
+        "cartesia" => GenericFormat::Cartesia,
+        "playht" => GenericFormat::Playht,
+        "coqui" => GenericFormat::Coqui,
+        "tortoise" => GenericFormat::Tortoise,
+        _ => return None,
+    })
+}
+
 /// Returns true if `provider` exposes a TTS endpoint via
 /// [`get_tts_adapter`] or via [`synthesize_via_format`]'s generic path.
 pub fn is_tts_provider(provider: &str) -> bool {
-    get_tts_adapter(provider).is_some()
+    get_tts_adapter(provider).is_some() || provider_generic_format(provider).is_some()
+}
+
+/// Resolve the upstream URL for a generic-format TTS provider, preferring
+/// the per-connection override in `provider_specific_data.baseUrl`.
+fn generic_base_url(credentials: &crate::types::ProviderConnection, provider: &str) -> String {
+    if let Some(url) = credentials
+        .provider_specific_data
+        .get("baseUrl")
+        .and_then(|v| v.as_str())
+        .map(str::trim)
+        .filter(|s| !s.is_empty())
+    {
+        return url.to_string();
+    }
+    default_generic_base_url(provider).to_string()
+}
+
+/// Upstream defaults that mirror 9router's `providers.js` ttsConfig.
+fn default_generic_base_url(provider: &str) -> &'static str {
+    match provider {
+        "hyperbolic" => "https://api.hyperbolic.xyz/v1/audio/generation",
+        "deepgram" => "https://api.deepgram.com/v1/speak",
+        "nvidia" => "https://integrate.api.nvidia.com/v1/audio/synthesis",
+        "huggingface" => "https://api-inference.huggingface.co/models",
+        "inworld" => "https://api.inworld.ai/tts/v1/voice",
+        "cartesia" => "https://api.cartesia.ai/tts/bytes",
+        "playht" => "https://api.play.ht/api/v2/tts/stream",
+        "coqui" => "http://localhost:5002/api/tts",
+        "tortoise" => "http://localhost:8000/tts",
+        _ => "",
+    }
+}
+
+/// Split a `model/voice` string into `(model_id, voice_id)`. Returns
+/// `(model, "")` when there's no slash.
+fn split_model_voice(model: &str) -> (&str, &str) {
+    if let Some(idx) = model.find('/') {
+        (&model[..idx], &model[idx + 1..])
+    } else {
+        (model, "")
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn dispatch_classifies_known_providers() {
+        for p in [
+            "openai",
+            "openrouter",
+            "gemini",
+            "elevenlabs",
+            "minimax",
+            "google-tts",
+            "edge-tts",
+            "local-device",
+            "coqui",
+            "inworld",
+            "tortoise",
+            "cartesia",
+            "playht",
+            "hyperbolic",
+            "deepgram",
+            "nvidia",
+            "huggingface",
+        ] {
+            assert!(is_tts_provider(p), "{p} should be a TTS provider");
+        }
+        assert!(!is_tts_provider("not-a-real-provider"));
+    }
+
+    #[test]
+    fn generic_format_maps_coqui_inworld_tortoise() {
+        assert_eq!(provider_generic_format("coqui"), Some(GenericFormat::Coqui));
+        assert_eq!(
+            provider_generic_format("inworld"),
+            Some(GenericFormat::Inworld)
+        );
+        assert_eq!(
+            provider_generic_format("tortoise"),
+            Some(GenericFormat::Tortoise)
+        );
+        assert_eq!(provider_generic_format("openai"), None);
+        assert_eq!(provider_generic_format("not-real"), None);
+    }
+
+    #[test]
+    fn split_model_voice_works() {
+        assert_eq!(split_model_voice("tts-1/alloy"), ("tts-1", "alloy"));
+        assert_eq!(split_model_voice("solo"), ("solo", ""));
+        assert_eq!(split_model_voice(""), ("", ""));
+    }
+
+    #[test]
+    fn default_generic_base_urls_are_populated() {
+        for p in [
+            "coqui",
+            "tortoise",
+            "inworld",
+            "cartesia",
+            "playht",
+            "hyperbolic",
+            "deepgram",
+            "nvidia",
+            "huggingface",
+        ] {
+            assert!(
+                !default_generic_base_url(p).is_empty(),
+                "default URL missing for {p}"
+            );
+        }
+    }
 }


### PR DESCRIPTION
## Summary

Fixes TTS dispatch for `coqui`, `inworld`, `tortoise` (the three providers called out as v0.4.10 catch-up in m3-op-4) and the other config-driven TTS providers already shipped in `generic_formats.rs` (cartesia, playht, hyperbolic, deepgram, nvidia, huggingface).

Before this PR, `tts::dispatch` only returned a handler for providers with explicit adapters (openai/openrouter/gemini/elevenlabs/minimax/google-tts/edge-tts/local-device). Every other TTS provider fell through to the generic upstream forwarder, which doesnt know about their special request shapes — so the catalog listed them but the requests never reached the right handler.

## Changes

- `dispatch()` now tries `get_tts_adapter()` first, then falls back to `synthesize_via_format()` for providers with a known `GenericFormat` mapping.
- New `provider_generic_format(provider)` registry maps provider id → `GenericFormat`.
- `is_tts_provider()` covers both adapter and generic-format providers, so the cataloged TTS providers match what dispatch actually serves.
- `generic_base_url()` honours `provider_specific_data.baseUrl` per connection and falls back to defaults mirroring 9routers `open-sse/config/providers.js` ttsConfig.
- `split_model_voice()` parses `<model>/<voice>` shape into the `GenericTtsRequest` fields.
- Adds unit tests covering provider classification, format mapping, default URLs, and the model/voice splitter.

## Upstream reference

Mirrors 9router commits/handlers under `open-sse/handlers/ttsProviders/` (especially `genericFormats.js`) and `open-sse/config/ttsModels.js` + `providers.js` ttsConfig — see CHANGELOG entry for v0.4.10.

## Risk

Low. Pure additive routing; no existing adapter path is changed. New unit tests cover the dispatch mapping.

## To test locally

```bash
cargo test --lib core::media::tts
```

Then seed a connection for `coqui` / `inworld` / `tortoise` and POST to `/v1/audio/speech` — the request now reaches `synthesize_via_format` instead of falling through.
