### PR TITLE
fix: custom provider nav, Ollama 301, Quota Tracker + add missing models

### DIFF
--- a/src/core/executor/api_key.rs
+++ b/src/core/executor/api_key.rs
@@ -358,7 +358,7 @@ static API_KEY_PROVIDERS: Lazy<BTreeMap<&'static str, (&'static str, &'static st
             ),
             (
                 "ollama-cloud",
-                ("https://api.ollama.com/v1", "Authorization"),
+                ("https://ollama.com/v1", "Authorization"),
             ),
         ])
     });

--- a/src/core/executor/api_key.rs
+++ b/src/core/executor/api_key.rs
@@ -356,10 +356,7 @@ static API_KEY_PROVIDERS: Lazy<BTreeMap<&'static str, (&'static str, &'static st
                     "Authorization",
                 ),
             ),
-            (
-                "ollama-cloud",
-                ("https://ollama.com/v1", "Authorization"),
-            ),
+            ("ollama-cloud", ("https://ollama.com/v1", "Authorization")),
         ])
     });
 

--- a/src/core/executor/default.rs
+++ b/src/core/executor/default.rs
@@ -180,7 +180,7 @@ static PROVIDER_CONFIGS: Lazy<BTreeMap<&'static str, ProviderConfig>> = Lazy::ne
         ),
         (
             "ollama-cloud",
-            ProviderConfig::openai("https://api.ollama.com/v1/chat/completions"),
+            ProviderConfig::openai("https://ollama.com/v1/chat/completions"),
         ),
         (
             "vertex",
@@ -262,7 +262,7 @@ static PROVIDER_CONFIGS: Lazy<BTreeMap<&'static str, ProviderConfig>> = Lazy::ne
         ),
         (
             "ollama",
-            ProviderConfig::openai("https://api.ollama.com/v1/chat/completions"),
+            ProviderConfig::openai("https://ollama.com/v1/chat/completions"),
         ),
         (
             "assemblyai",

--- a/src/core/executor/provider.rs
+++ b/src/core/executor/provider.rs
@@ -659,7 +659,7 @@ static PROVIDER_REGISTRY: once_cell::sync::Lazy<BTreeMap<&'static str, ProviderE
             ),
             (
                 "ollama-cloud",
-                ProviderExecutorConfig::openai("https://api.ollama.com/v1"),
+                ProviderExecutorConfig::openai("https://ollama.com/v1"),
             ),
             (
                 "ollama-local",
@@ -845,7 +845,7 @@ static PROVIDER_REGISTRY: once_cell::sync::Lazy<BTreeMap<&'static str, ProviderE
             ),
             (
                 "ollama",
-                ProviderExecutorConfig::openai("https://api.ollama.com/v1"),
+                ProviderExecutorConfig::openai("https://ollama.com/v1"),
             ),
             (
                 "inference-net",

--- a/src/core/model/provider_catalog.json
+++ b/src/core/model/provider_catalog.json
@@ -328,6 +328,11 @@
           "id": "coder-model",
           "name": "Qwen3.6 Coder Model",
           "kind": "llm"
+        },
+        {
+          "id": "qwen3-coder-next",
+          "name": "Qwen3 Coder Next",
+          "kind": "llm"
         }
       ]
     },
@@ -613,6 +618,11 @@
           "id": "MiniMax-M2.5",
           "name": "MiniMax M2.5",
           "kind": "llm"
+        },
+        {
+          "id": "claude-opus-4.5",
+          "name": "Claude Opus 4.5",
+          "kind": "llm"
         }
       ]
     },
@@ -707,6 +717,11 @@
         {
           "id": "kimi-latest",
           "name": "Kimi Latest",
+          "kind": "llm"
+        },
+        {
+          "id": "kimi-k2.6",
+          "name": "Kimi K2.6",
           "kind": "llm"
         }
       ]
@@ -1007,6 +1022,11 @@
           "id": "dall-e-2",
           "name": "DALL-E 2",
           "kind": "image"
+        },
+        {
+          "id": "whisper-1",
+          "name": "Whisper 1",
+          "kind": "stt"
         }
       ]
     },
@@ -1261,6 +1281,11 @@
         {
           "id": "kimi-latest",
           "name": "Kimi Latest",
+          "kind": "llm"
+        },
+        {
+          "id": "kimi-k2.6",
+          "name": "Kimi K2.6",
           "kind": "llm"
         }
       ]
@@ -1727,6 +1752,21 @@
           "id": "deepseek-reasoner",
           "name": "DeepSeek V3.2 Reasoner",
           "kind": "llm"
+        },
+        {
+          "id": "deepseek-v4-pro",
+          "name": "DeepSeek V4 Pro",
+          "kind": "llm"
+        },
+        {
+          "id": "deepseek-v4-pro-max",
+          "name": "DeepSeek V4 Pro Max",
+          "kind": "llm"
+        },
+        {
+          "id": "deepseek-v4-pro-none",
+          "name": "DeepSeek V4 Pro None",
+          "kind": "llm"
         }
       ]
     },
@@ -1752,6 +1792,11 @@
           "id": "openai/gpt-oss-120b",
           "name": "GPT-OSS 120B",
           "kind": "llm"
+        },
+        {
+          "id": "whisper-large-v3",
+          "name": "Whisper Large V3",
+          "kind": "stt"
         }
       ]
     },
@@ -1952,6 +1997,11 @@
           "id": "nvidia/nv-embedqa-e5-v5",
           "name": "NV EmbedQA E5 v5",
           "kind": "embedding"
+        },
+        {
+          "id": "nvidia/parakeet-ctc-1.1b-asr",
+          "name": "Parakeet CTC 1.1B ASR",
+          "kind": "stt"
         }
       ]
     },
@@ -3172,6 +3222,86 @@
           "id": "mimo-v2.5-tts-voicedesign",
           "name": "MiMo V2.5 TTS Voice Design",
           "kind": "tts"
+        }
+      ]
+    },
+    {
+      "alias": "commandcode",
+      "models": [
+        {
+          "id": "deepseek/deepseek-v4-pro",
+          "name": "DeepSeek V4 Pro",
+          "kind": "llm"
+        },
+        {
+          "id": "deepseek/deepseek-v4-flash",
+          "name": "DeepSeek V4 Flash",
+          "kind": "llm"
+        },
+        {
+          "id": "moonshotai/Kimi-K2.6",
+          "name": "Kimi K2.6",
+          "kind": "llm"
+        },
+        {
+          "id": "moonshotai/Kimi-K2.5",
+          "name": "Kimi K2.5",
+          "kind": "llm"
+        },
+        {
+          "id": "zai-org/GLM-5.1",
+          "name": "GLM 5.1",
+          "kind": "llm"
+        },
+        {
+          "id": "zai-org/GLM-5",
+          "name": "GLM 5",
+          "kind": "llm"
+        },
+        {
+          "id": "MiniMaxAI/MiniMax-M2.7",
+          "name": "MiniMax M2.7",
+          "kind": "llm"
+        },
+        {
+          "id": "MiniMaxAI/MiniMax-M2.5",
+          "name": "MiniMax M2.5",
+          "kind": "llm"
+        },
+        {
+          "id": "Qwen/Qwen3.6-Max-Preview",
+          "name": "Qwen3.6 Max Preview",
+          "kind": "llm"
+        },
+        {
+          "id": "Qwen/Qwen3.6-Plus",
+          "name": "Qwen3.6 Plus",
+          "kind": "llm"
+        },
+        {
+          "id": "stepfun/Step-3.5-Flash",
+          "name": "Step 3.5 Flash",
+          "kind": "llm"
+        }
+      ]
+    },
+    {
+      "alias": "deepgram",
+      "models": [
+        {
+          "id": "nova-3",
+          "name": "Nova 3",
+          "kind": "stt"
+        }
+      ]
+    },
+    {
+      "alias": "assemblyai",
+      "models": [
+        {
+          "id": "universal-3-pro",
+          "name": "Universal 3 Pro",
+          "kind": "stt"
         }
       ]
     }

--- a/src/server/dashboard/mod.rs
+++ b/src/server/dashboard/mod.rs
@@ -103,6 +103,14 @@ async fn serve_embedded(uri: &Uri) -> Response {
         if let Some(resp) = lookup_embedded(&dir_candidate) {
             return resp;
         }
+        // Dynamic-segment fallback: for paths like `/dashboard/providers/<uuid>`
+        // where the final segment is a user-created ID unknown at build time,
+        // try a `_dynamic.html` placeholder page in the parent directory. The
+        // Astro build emits this file so the correct page shell (e.g.
+        // ProviderDetailPageClient) is served instead of the generic dashboard.
+        if let Some(resp) = dynamic_segment_fallback(candidate, |p| lookup_embedded(p)) {
+            return resp;
+        }
         // SPA fallback: requests without a file extension are client-router
         // routes. Serve the SPA shell so the JS router can take over.
         if let Some(resp) = lookup_embedded("dashboard.html") {
@@ -160,6 +168,24 @@ fn looks_like_asset(path: &str) -> bool {
         .is_some_and(|last| last.contains('.'))
 }
 
+/// For a path like `dashboard/providers/8d82774e-…`, try
+/// `dashboard/providers/_dynamic.html`. The Astro build emits this placeholder
+/// so that user-created provider UUIDs (unknown at build time) still get the
+/// correct page shell instead of the generic `dashboard.html` fallback.
+fn dynamic_segment_fallback<F>(candidate: &str, lookup: F) -> Option<Response>
+where
+    F: Fn(&str) -> Option<Response>,
+{
+    // Only attempt this for paths with at least two segments (parent + slug).
+    if let Some(parent) = candidate.rsplit_once('/').map(|(p, _)| p) {
+        let fallback = format!("{parent}/_dynamic.html");
+        if let Some(resp) = lookup(&fallback) {
+            return Some(resp);
+        }
+    }
+    None
+}
+
 fn cache_control_for(path: &str) -> &'static str {
     // HTML shells must not be cached: a stale shell breaks code-split bundles
     // after a redeploy. Other assets are content-hashed by the Astro build
@@ -190,6 +216,10 @@ async fn serve_from_disk(root: &Path, uri: &Uri) -> Response {
         }
         let dir_candidate = format!("{candidate}/index.html");
         if let Some(resp) = read_disk_asset(root, &dir_candidate) {
+            return resp;
+        }
+        // Dynamic-segment fallback (mirrors embedded mode logic above).
+        if let Some(resp) = dynamic_segment_fallback(candidate, |p| read_disk_asset(root, p)) {
             return resp;
         }
         if let Some(resp) = read_disk_asset(root, "dashboard.html") {

--- a/web/src/components/usage/ProviderLimits/index.tsx
+++ b/web/src/components/usage/ProviderLimits/index.tsx
@@ -287,21 +287,17 @@ export default function ProviderLimits() {
       const conns = await fetchConnections();
       setConnectionsLoading(false);
 
-      const oauthConnections = conns.filter(
-        (conn) =>
-          USAGE_SUPPORTED_PROVIDERS.includes(conn.provider) &&
-          conn.authType === "oauth",
-      );
+      const eligibleConnections = conns.filter(isUsageEligible);
 
       // Mark all as loading before fetching
       const loadingState: Record<string, boolean> = {};
-      oauthConnections.forEach((conn) => {
+      eligibleConnections.forEach((conn) => {
         loadingState[conn.id] = true;
       });
       setLoading(loadingState);
 
       await Promise.all(
-        oauthConnections.map((conn) => fetchQuota(conn.id, conn.provider)),
+        eligibleConnections.map((conn) => fetchQuota(conn.id, conn.provider)),
       );
       setLastUpdated(new Date());
     };

--- a/web/src/pages/dashboard/providers/[id]/index.astro
+++ b/web/src/pages/dashboard/providers/[id]/index.astro
@@ -7,9 +7,13 @@ import DashboardLayout from '@/shared/components/layouts/DashboardLayout';
 export async function getStaticPaths() {
   // Pre-render the detail page for every known provider id so that
   // `/dashboard/providers/<id>` resolves in the static build.
-  // User-added compatible providers (`openai-compatible-*`, `anthropic-compatible-*`)
-  // are not pre-rendered; navigation to those works only in dev mode for now.
-  return Object.keys(AI_PROVIDERS).map((id) => ({ params: { id } }));
+  // The `_dynamic` placeholder generates a generic shell page that the
+  // Rust server can serve for user-added compatible providers whose UUIDs
+  // are unknown at build time (see dashboard/mod.rs dynamic-segment fallback).
+  return [
+    ...Object.keys(AI_PROVIDERS).map((id) => ({ params: { id } })),
+    { params: { id: '_dynamic' } },
+  ];
 }
 ---
 <Layout>


### PR DESCRIPTION
## Summary

Four changes in this PR:

### 1. Serve correct page shell for custom provider detail routes

Fixes a navigation bug where clicking a custom provider card (OpenAI/Anthropic compatible) on the providers list redirected to the home page instead of opening the provider detail page.

**Root cause**: Custom providers use dynamic UUIDs as IDs (e.g. `8d82774e-aa4e-4818-…`). Astro's static build (`getStaticPaths`) only pre-renders pages for known `AI_PROVIDERS` keys, so no HTML file exists for these UUIDs. The Rust server's SPA fallback then serves `dashboard.html`, which renders `EndpointPageClient` (home page) instead of `ProviderDetailPageClient`.

**Fix** (two-part):
1. **Frontend**: Add a `_dynamic` placeholder to `getStaticPaths()` so Astro emits `dashboard/providers/_dynamic.html` containing the correct `ProviderDetailPageClient` shell.
2. **Backend**: Add `dynamic_segment_fallback()` in the Rust dashboard module that tries `<parent>/_dynamic.html` before the generic `dashboard.html` SPA fallback. Applied to both embedded and on-disk serving modes.

The `ProviderDetailPageClient` already reads the provider ID from `window.location.pathname`, so the placeholder page works for any UUID.

### 2. Fix Ollama Cloud 301 redirect (`api.ollama.com` → `ollama.com`)

`api.ollama.com` returns HTTP 301 (Moved Permanently) redirecting to `ollama.com`. Most HTTP clients (including reqwest) convert POST to GET on 301 redirects, which breaks chat completion requests — the upstream sees a bodyless GET and returns an error.

Updated all 5 occurrences of `api.ollama.com` to `ollama.com` across `api_key.rs`, `default.rs`, and `provider.rs`. Verified against the [reference implementation](https://github.com/decolua/9router) which uses `ollama.com` directly, and confirmed working end-to-end with `kimi-k2.6:cloud` through the proxy.

### 3. Fix Quota Tracker initial load for apikey providers

The Quota Tracker page only fetched quota data for OAuth connections on initial load, but displayed both OAuth and apikey connections (via `isUsageEligible`). Apikey providers (e.g. `glm`, `minimax`) appeared on the page but showed no quota data until manually refreshed. On page reload, that manually-fetched data was lost.

**Fix**: Changed the initial data load in `ProviderLimits` to use the same `isUsageEligible` filter already used by `refreshAll`, so all eligible connections (OAuth + whitelisted apikey) have their quota fetched automatically on page load.

### 4. Add missing models from 9router reference

Synced the provider model catalog against the [9router reference](https://github.com/decolua/9router). Changes to `provider_catalog.json`:

**New models added to existing providers:**
- `deepseek`: deepseek-v4-pro, deepseek-v4-pro-max, deepseek-v4-pro-none
- `groq`: whisper-large-v3
- `kimi` / `kmc`: kimi-k2.6
- `kr` (Kiro): claude-opus-4.5
- `nvidia`: nvidia/parakeet-ctc-1.1b-asr
- `openai`: whisper-1
- `qw` (Qwen): qwen3-coder-next

**New provider entries:**
- `commandcode` (11 models)
- `deepgram` (nova-3)
- `assemblyai` (universal-3-pro)

## Review & Testing Checklist for Human

- [ ] **Test custom provider navigation**: Add a custom OpenAI/Anthropic-compatible provider via the dashboard, click its card — it should open the provider detail page, not redirect to home. Also test direct URL access to `/dashboard/providers/<custom-uuid>`.
- [ ] **Verify dynamic fallback scope**: `dynamic_segment_fallback` applies to *all* dashboard paths with unmatched final segments. Confirm no other routes are unintentionally affected (e.g., `/dashboard/combos/<id>`, `/dashboard/media-providers/<kind>/<id>`).
- [ ] **Test Ollama Cloud provider**: Add an Ollama Cloud connection and verify requests to `ollama/kimi-k2.6:cloud` succeed without 301 errors.
- [ ] **Test Quota Tracker page**: Add a GLM or MiniMax apikey connection, navigate to the Quota Tracker page, and verify quota data loads automatically on initial page load and survives a page reload.
- [ ] **Verify new catalog models appear**: Check that newly added models (e.g. `deepseek-v4-pro`, `kimi-k2.6`, `whisper-1`) are available in the provider detail pages and model selection dropdowns for their respective providers.

### Notes
- The three new provider catalog entries (`commandcode`, `deepgram`, `assemblyai`) are model-list-only additions. They require corresponding backend provider configurations (base URLs in `default.rs` / `provider.rs`) to be functional for routing — verify these already exist or add them separately.
- No unit tests were added for `dynamic_segment_fallback`. The function is simple (single `rsplit_once` + format), but a test confirming the lookup pattern would harden it.
- This pattern is extensible — any future Astro page with dynamic segments can add a `_dynamic` placeholder entry to `getStaticPaths()` and it will automatically be picked up by the server fallback.

Link to Devin session: https://app.devin.ai/sessions/904ca6e7e58446e9a78f1b4dc2c5b71a
Requested by: @quangdang46