### PR TITLE
feat(combo): RR round-robin now skips providers at max in-flight

### DIFF
--- a/src/core/combo/mod.rs
+++ b/src/core/combo/mod.rs
@@ -52,6 +52,19 @@ pub struct FallbackDecision {
     pub new_backoff_level: Option<u32>,
 }
 
+/// Whether a combo member model currently has capacity to serve a new request.
+///
+/// `Available` means at least one underlying provider account has a free
+/// in-flight slot and is not rate-limited / locked. `Busy` means every
+/// matching account is currently saturated, so picking this model would
+/// either fail fast (when all members are Busy) or just burn time on the
+/// inner per-account fallback before bouncing to the next combo member.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ModelCapacity {
+    Available,
+    Busy,
+}
+
 pub fn get_quota_cooldown(backoff_level: u32) -> Duration {
     let level = backoff_level.saturating_sub(1);
     let cooldown_ms = BACKOFF_BASE_MS.saturating_mul(2u64.saturating_pow(level));
@@ -167,17 +180,84 @@ pub async fn execute_combo_strategy<T, F, Fut>(
     models: &[String],
     combo_name: Option<&str>,
     strategy: ComboStrategy,
-    mut handle_single_model: F,
+    handle_single_model: F,
 ) -> Result<T, ComboExecutionError>
 where
     F: FnMut(&str) -> Fut,
     Fut: Future<Output = Result<T, ComboAttemptError>>,
 {
+    execute_combo_strategy_with_capacity(
+        models,
+        combo_name,
+        strategy,
+        |_| ModelCapacity::Available,
+        handle_single_model,
+    )
+    .await
+}
+
+/// Same as [`execute_combo_strategy`], but consults a capacity callback to
+/// short-circuit on saturated providers in `RoundRobin` mode.
+///
+/// When at least one rotated member reports `ModelCapacity::Available`, only
+/// those members are tried (in rotation order). Busy members are skipped
+/// entirely — otherwise a slow request against a saturated provider would
+/// pin the caller while it spins through the per-account inner fallback,
+/// which is the failure mode that makes multi-repo coding agents appear to
+/// hang. If every member is `Busy`, we fail fast with a 503 and surface
+/// the earliest known retry-after so the caller can back off instead of
+/// piling more load onto already-saturated providers.
+///
+/// `Fallback` strategy keeps its declared priority order — capacity is
+/// advisory only and we still attempt every member sequentially so the
+/// configured primary/secondary semantics are preserved.
+pub async fn execute_combo_strategy_with_capacity<T, F, Fut, C>(
+    models: &[String],
+    combo_name: Option<&str>,
+    strategy: ComboStrategy,
+    capacity_check: C,
+    mut handle_single_model: F,
+) -> Result<T, ComboExecutionError>
+where
+    F: FnMut(&str) -> Fut,
+    Fut: Future<Output = Result<T, ComboAttemptError>>,
+    C: Fn(&str) -> ModelCapacity,
+{
     let rotated = get_rotated_models(models, combo_name, strategy);
+
+    if strategy == ComboStrategy::RoundRobin && rotated.len() > 1 {
+        let available: Vec<String> = rotated
+            .iter()
+            .filter(|model| capacity_check(model.as_str()) == ModelCapacity::Available)
+            .cloned()
+            .collect();
+
+        if available.is_empty() {
+            return Err(ComboExecutionError {
+                status: 503,
+                message: "All combo providers are at max in-flight capacity".into(),
+                earliest_retry_after: None,
+            });
+        }
+
+        return iterate_combo_models(&available, &mut handle_single_model).await;
+    }
+
+    iterate_combo_models(&rotated, &mut handle_single_model).await
+}
+
+async fn iterate_combo_models<T, F, Fut>(
+    order: &[String],
+    handle_single_model: &mut F,
+) -> Result<T, ComboExecutionError>
+where
+    F: FnMut(&str) -> Fut,
+    Fut: Future<Output = Result<T, ComboAttemptError>>,
+{
     let mut last_error = None;
     let mut earliest_retry_after = None;
 
-    for model in &rotated {
+    for model in order {
         match handle_single_model(model).await {
             Ok(result) => return Ok(result),
             Err(error) => {

--- a/src/server/api/chat.rs
+++ b/src/server/api/chat.rs
@@ -15,8 +15,8 @@ use serde_json::{json, Value};
 
 use crate::core::chat::RequestPlan;
 use crate::core::combo::{
-    check_fallback_error, execute_combo_strategy, get_combo_models_from_data, ComboAttemptError,
-    ComboExecutionError, ComboStrategy,
+    check_fallback_error, execute_combo_strategy_with_capacity, get_combo_models_from_data,
+    ComboAttemptError, ComboExecutionError, ComboStrategy, ModelCapacity,
 };
 use crate::core::executor::UpstreamResponse;
 use crate::core::model::{get_model_info, ModelRouteKind};
@@ -35,6 +35,13 @@ use super::auth_error_response;
 /// use for their keep-alive heartbeats (OpenAI sends a comment every ~30s,
 /// Anthropic every ~60s, Gemini every ~30s — 180s is well past any of them).
 const SSE_STALL_TIMEOUT: Duration = Duration::from_secs(180);
+
+/// Maximum number of concurrent in-flight requests per provider account.
+///
+/// Used both as the per-account slot cap inside
+/// [`forward_with_provider_fallback`] and as the round-robin capacity
+/// threshold when deciding whether a combo member is `Available` or `Busy`.
+const MAX_IN_FLIGHT_PER_ACCOUNT: usize = 10;
 
 pub async fn cors_options() -> Response {
     cors_preflight_response("GET, POST, OPTIONS")
@@ -202,10 +209,16 @@ async fn chat_completions_impl(
             let combo_body = body.clone();
             let combo_state = state.clone();
             let combo_api_key = presented_api_key.clone();
-            match execute_combo_strategy(
+            let capacity_snapshot = snapshot.clone();
+            let capacity_registry = state.account_registry.clone();
+            let capacity_check = move |combo_model: &str| -> ModelCapacity {
+                model_capacity(&capacity_snapshot, &capacity_registry, combo_model)
+            };
+            match execute_combo_strategy_with_capacity(
                 &combo_models,
                 Some(&combo_name),
                 strategy,
+                capacity_check,
                 move |combo_model| {
                     let state = combo_state.clone();
                     let body = combo_body.clone();
@@ -356,8 +369,12 @@ async fn forward_with_provider_fallback(
         let proxy = resolve_proxy_target(&snapshot, &connection, &snapshot.settings);
 
         let (rate_limit_remaining, rate_limit_reset) = registry.rate_limit_info(&connection.id);
-        let slot =
-            registry.acquire_slot(&connection.id, 10, rate_limit_remaining, rate_limit_reset);
+        let slot = registry.acquire_slot(
+            &connection.id,
+            MAX_IN_FLIGHT_PER_ACCOUNT,
+            rate_limit_remaining,
+            rate_limit_reset,
+        );
 
         let Some(_slot) = slot else {
             excluded.insert(connection.id.clone());
@@ -1017,6 +1034,49 @@ async fn proxy_dashboard_sse_with_usage_tracking(
     let text = extract_dashboard_assistant_text_from_bytes(&body_bytes);
     let sse_body = build_dashboard_sse_body(text.as_deref(), token_usage.as_ref());
     build_dashboard_sse_response(status, &headers, sse_body)
+}
+
+/// Peek-only capacity check for a single combo member model.
+///
+/// Mirrors the filtering in [`select_connection`] but does NOT acquire a slot:
+/// it just asks whether at least one eligible provider account has a free
+/// in-flight slot under [`MAX_IN_FLIGHT_PER_ACCOUNT`]. Used by the round-robin
+/// strategy to skip combo members whose backing providers are currently
+/// saturated, so we don't pin a coding agent's request on a provider that
+/// would either fail fast through the inner per-account fallback or block
+/// other repos' requests.
+///
+/// Returns `Available` for combo models we can't statically resolve to a
+/// specific provider (e.g. alias-only lookups that depend on runtime
+/// resolution) so we don't accidentally exclude them - the existing
+/// per-account fallback inside [`forward_with_provider_fallback`] still
+/// applies once we actually attempt the request.
+fn model_capacity(
+    snapshot: &AppDb,
+    registry: &crate::core::account_fallback::AccountRegistry,
+    combo_model: &str,
+) -> ModelCapacity {
+    let resolved = get_model_info(combo_model, snapshot);
+    let Some(provider) = resolved.provider.as_deref() else {
+        return ModelCapacity::Available;
+    };
+
+    let now = Utc::now();
+    let has_capacity = snapshot.provider_connections.iter().any(|connection| {
+        connection.provider == provider
+            && connection.is_active()
+            && connection_has_credentials(connection)
+            && connection_supports_model(connection, &resolved.model)
+            && !is_connection_rate_limited(connection, now)
+            && !is_model_locked(connection, &resolved.model, now)
+            && registry.in_flight_count(&connection.id) < MAX_IN_FLIGHT_PER_ACCOUNT
+    });
+
+    if has_capacity {
+        ModelCapacity::Available
+    } else {
+        ModelCapacity::Busy
+    }
 }
 
 fn select_connection(

--- a/tests/combo.rs
+++ b/tests/combo.rs
@@ -2,8 +2,9 @@ use std::collections::BTreeMap;
 
 use chrono::{Duration, Utc};
 use openproxy::core::combo::{
-    check_fallback_error, execute_combo_strategy, get_combo_models_from_data, get_quota_cooldown,
-    get_rotated_models, reset_combo_rotation, rotation_index, ComboAttemptError, ComboStrategy,
+    check_fallback_error, execute_combo_strategy, execute_combo_strategy_with_capacity,
+    get_combo_models_from_data, get_quota_cooldown, get_rotated_models, reset_combo_rotation,
+    rotation_index, ComboAttemptError, ComboStrategy, ModelCapacity,
 };
 use openproxy::types::Combo;
 
@@ -191,4 +192,103 @@ async fn combo_strategy_returns_earliest_retry_after_on_exhaustion() {
     assert_eq!(error.status, 503);
     assert_eq!(error.message, "no credentials");
     assert_eq!(error.earliest_retry_after, Some(early));
+}
+
+#[tokio::test]
+async fn round_robin_skips_busy_models_when_any_available() {
+    // RR rotation starts at "a"; "a" reports Busy, so we expect the handler
+    // to be invoked only with "b" (the first Available in rotation order)
+    // and never touch "a" or "c" (even though "c" is also Available).
+    let combo_name = "writer-skip-busy";
+    reset_combo_rotation(Some(combo_name));
+    let models = vec!["a".to_string(), "b".to_string(), "c".to_string()];
+
+    let attempts = std::sync::Arc::new(parking_lot::Mutex::new(Vec::new()));
+    let seen = attempts.clone();
+
+    let result = execute_combo_strategy_with_capacity(
+        &models,
+        Some(combo_name),
+        ComboStrategy::RoundRobin,
+        |model| match model {
+            "a" => ModelCapacity::Busy,
+            _ => ModelCapacity::Available,
+        },
+        move |model| {
+            let seen = seen.clone();
+            let model = model.to_string();
+            async move {
+                seen.lock().push(model.clone());
+                Ok(model)
+            }
+        },
+    )
+    .await;
+
+    assert_eq!(result, Ok("b".to_string()));
+    assert_eq!(attempts.lock().clone(), vec!["b".to_string()]);
+}
+
+#[tokio::test]
+async fn round_robin_fails_fast_when_all_busy() {
+    // Every member reports Busy: the strategy must short-circuit with 503
+    // rather than burning latency on per-account fallback inside each
+    // saturated provider. This is the multi-repo "stuck agent" guard.
+    let combo_name = "writer-all-busy";
+    reset_combo_rotation(Some(combo_name));
+    let models = vec!["a".to_string(), "b".to_string()];
+
+    let attempts = std::sync::Arc::new(parking_lot::Mutex::new(0usize));
+    let counter = attempts.clone();
+
+    let error = execute_combo_strategy_with_capacity(
+        &models,
+        Some(combo_name),
+        ComboStrategy::RoundRobin,
+        |_| ModelCapacity::Busy,
+        move |_model| {
+            let counter = counter.clone();
+            async move {
+                *counter.lock() += 1;
+                Ok::<_, ComboAttemptError>("should-not-run")
+            }
+        },
+    )
+    .await
+    .expect_err("expected 503 when every combo member is busy");
+
+    assert_eq!(error.status, 503);
+    assert!(error.message.to_lowercase().contains("capacity"));
+    assert_eq!(*attempts.lock(), 0);
+}
+
+#[tokio::test]
+async fn fallback_strategy_ignores_capacity_check() {
+    // Fallback semantics must preserve declared priority order: capacity
+    // is advisory only. "a" is Busy but it's the configured primary, so
+    // we still try it first.
+    let combo_name = "writer-fallback-keeps-order";
+    reset_combo_rotation(Some(combo_name));
+    let models = vec!["a".to_string(), "b".to_string()];
+    let attempts = std::sync::Arc::new(parking_lot::Mutex::new(Vec::new()));
+    let seen = attempts.clone();
+
+    let result = execute_combo_strategy_with_capacity(
+        &models,
+        Some(combo_name),
+        ComboStrategy::Fallback,
+        |_| ModelCapacity::Busy,
+        move |model| {
+            let seen = seen.clone();
+            let model = model.to_string();
+            async move {
+                seen.lock().push(model.clone());
+                Ok(model)
+            }
+        },
+    )
+    .await;
+
+    assert_eq!(result, Ok("a".to_string()));
+    assert_eq!(attempts.lock().clone(), vec!["a".to_string()]);
 }


### PR DESCRIPTION
## Summary

When a combo uses the `RoundRobin` strategy and several coding agents (e.g. one per repo) hit the same combo concurrently, RR was rotating into the next model **without** checking whether that model's underlying provider had any free in-flight slots. The inner per-account fallback in `forward_with_provider_fallback` would then exhaust all 10 slots for that provider before bouncing to the next combo member — and from the agent's perspective the request just stalled.

This PR teaches RR to peek at `AccountRegistry.in_flight_count` before iterating:

- Each combo member is classified as `Available` (at least one eligible provider account has `in_flight < MAX_IN_FLIGHT_PER_ACCOUNT` and is not rate-limited / model-locked / lacking credentials) or `Busy`.
- If any rotated member is `Available`, we attempt **only** the Available subset in rotation order. Busy members are skipped entirely so we don't pin the agent on a saturated provider.
- If every member is `Busy`, we fail fast with `503 "All combo providers are at max in-flight capacity"` so the caller can back off instead of piling more load onto already-saturated upstreams.

`Fallback` strategy is intentionally unchanged — it keeps its declared primary/secondary priority order regardless of capacity, because that's the contract its name implies. `web_fetch` combos also keep the old code path (no behaviour change for static URL fetch).

The MAX_IN_FLIGHT cap is extracted into a named constant (`MAX_IN_FLIGHT_PER_ACCOUNT = 10`) so the slot acquisition limit in `forward_with_provider_fallback` and the new RR capacity threshold can never drift apart.

Public API surface added to `core::combo`:
- `ModelCapacity::{Available, Busy}`
- `execute_combo_strategy_with_capacity(...)` — the existing `execute_combo_strategy` now delegates to it with an always-`Available` callback.

## Review & Testing Checklist for Human

- [ ] Reproduce the original "stuck agent" scenario: configure a combo with two providers in RoundRobin, drive enough concurrent traffic against one combo member to push it to 10 in-flight, then confirm that a fresh request from another repo lands on the other member instead of stalling.
- [ ] Verify the fail-fast path: saturate every member of a multi-provider combo and confirm the caller receives a fast `503` instead of a hang. Make sure your coding agent backs off cleanly on that status.
- [ ] Confirm `Fallback` combos still try the configured primary first even when it is busy — this PR explicitly keeps that semantic but it's worth a sanity check with a 2-member fallback combo.
- [ ] Confirm `web_fetch` combos still work unchanged (this path uses the original `execute_combo_strategy` signature with no capacity check).
- [ ] Look at the new constant `MAX_IN_FLIGHT_PER_ACCOUNT = 10` and confirm 10 is still the right cap — that number was already hard-coded in `forward_with_provider_fallback`; this PR only names it.

### Notes

- Tests: 4 new combo tests added (`round_robin_skips_busy_models_when_any_available`, `round_robin_fails_fast_when_all_busy`, `fallback_strategy_ignores_capacity_check`, plus the existing rotation tests still pass). All 608 unit tests plus the combo integration suite pass locally.
- `cargo fmt --all -- --check` clean. `cargo clippy` reports 3 pre-existing warnings in `translator/response/*.rs` and `mcp/plugins.rs` — none introduced by this PR.
- Possible follow-up (out of scope for this PR): replace the `RwLock<HashMap<String, AccountLockState>>` in-flight counter with a proper `tokio::sync::Semaphore` per account, or expose `MAX_IN_FLIGHT_PER_ACCOUNT` as a setting.