### PR TITLE
feat: noAuth virtual connection + public catalog API (9router parity)

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -364,6 +364,7 @@ async fn main() -> anyhow::Result<()> {
         .init();
 
     let db = Db::load().await?;
+    seed_default_api_key_if_missing(&db).await?;
     let db = Arc::new(db);
     spawn_watcher(db.clone());
     let state = AppState::new(db)
@@ -438,6 +439,35 @@ fn is_stdout_tty() -> bool {
     // Conservative default on non-Unix: assume interactive. Users on Windows
     // can opt out with --no-open if needed.
     true
+}
+
+async fn seed_default_api_key_if_missing(db: &Db) -> anyhow::Result<()> {
+    if !db.snapshot().api_keys.is_empty() {
+        return Ok(());
+    }
+
+    use openproxy::core::auth::generate_api_key_with_machine;
+    use openproxy::server::api::consistent_machine_id;
+    use openproxy::types::ApiKey;
+
+    let machine_id = consistent_machine_id();
+    let key = generate_api_key_with_machine(&machine_id);
+    let api_key = ApiKey {
+        id: uuid::Uuid::new_v4().to_string(),
+        name: "default".to_string(),
+        key: key.clone(),
+        machine_id: Some(machine_id),
+        is_active: Some(true),
+        created_at: Some(chrono::Utc::now().to_rfc3339()),
+        extra: std::collections::BTreeMap::new(),
+    };
+
+    db.update(|d| d.api_keys.push(api_key.clone())).await?;
+    tracing::info!(target: "openproxy", "seeded default API key (apiKeys was empty)");
+    eprintln!("  Default API key (saved to db.json):");
+    eprintln!("    {key}");
+    eprintln!();
+    Ok(())
 }
 
 /// Browser-friendly host: bind hosts like `0.0.0.0` are not resolvable in

--- a/src/server/api/chat.rs
+++ b/src/server/api/chat.rs
@@ -1102,7 +1102,36 @@ fn select_connection(
         .collect();
 
     candidates.sort_by_key(|connection| connection.priority.unwrap_or(999));
-    candidates.into_iter().next()
+    if let Some(connection) = candidates.into_iter().next() {
+        return Some(connection);
+    }
+
+    // No stored connection. Inject a virtual one for noAuth free providers
+    // (matches 9router's getProviderCredentials behavior). Lets OpenCode Free,
+    // edge-tts, google-tts, etc. route requests without manual setup.
+    if is_no_auth_provider(provider) && !excluded.contains("noauth") {
+        return Some(virtual_no_auth_connection(provider));
+    }
+
+    None
+}
+
+fn is_no_auth_provider(provider: &str) -> bool {
+    matches!(
+        provider,
+        "opencode" | "edge-tts" | "google-tts" | "local-device"
+    )
+}
+
+fn virtual_no_auth_connection(provider: &str) -> ProviderConnection {
+    let mut connection = ProviderConnection::default();
+    connection.id = "noauth".to_string();
+    connection.provider = provider.to_string();
+    connection.auth_type = "none".to_string();
+    connection.name = Some("Public".to_string());
+    connection.is_active = Some(true);
+    connection.access_token = Some("public".to_string());
+    connection
 }
 
 fn connection_has_credentials(connection: &ProviderConnection) -> bool {

--- a/src/server/api/mod.rs
+++ b/src/server/api/mod.rs
@@ -55,6 +55,7 @@ pub fn routes() -> Router<AppState> {
     Router::new()
         .route("/health", get(health))
         .route("/api/health", get(api_health))
+        .route("/api/catalog", get(api_catalog))
         .route("/v1/health", get(health))
         .merge(v1_api_chat::routes())
         .merge(v1_models::routes())
@@ -163,6 +164,17 @@ async fn health() -> Json<HealthResponse> {
 
 async fn api_health() -> Response {
     Json(json!({ "ok": true })).into_response()
+}
+
+async fn api_catalog() -> Response {
+    // Serve the embedded provider catalog as static JSON. Public (no auth)
+    // because it contains only model metadata that the dashboard renders.
+    static CATALOG_JSON: &str = include_str!("../../core/model/provider_catalog.json");
+    (
+        [(axum::http::header::CONTENT_TYPE, "application/json")],
+        CATALOG_JSON,
+    )
+        .into_response()
 }
 
 async fn get_version_api() -> Response {
@@ -778,7 +790,7 @@ async fn create_key_api(
     }
 }
 
-fn consistent_machine_id() -> String {
+pub fn consistent_machine_id() -> String {
     let salt =
         std::env::var("MACHINE_ID_SALT").unwrap_or_else(|_| "endpoint-proxy-salt".to_string());
 

--- a/src/server/api/providers.rs
+++ b/src/server/api/providers.rs
@@ -76,14 +76,11 @@ fn filter_suggested_models(kind: &str, values: &[Value]) -> Result<Vec<Value>, S
 }
 
 async fn get_suggested_models(
-    State(state): State<AppState>,
-    headers: HeaderMap,
     Query(query): Query<SuggestedModelsQuery>,
 ) -> Response {
-    if let Err(response) = require_management_access(&headers, &state) {
-        return response;
-    }
-
+    // Public route: matches 9router's UX. The endpoint is a pure passthrough
+    // proxy that fetches a public provider models URL (e.g. opencode.ai,
+    // openrouter.ai) and filters the response. No secrets are returned.
     let Some(url) = query
         .url
         .as_deref()

--- a/web/astro.config.mjs
+++ b/web/astro.config.mjs
@@ -29,6 +29,15 @@ export default defineConfig({
   vite: {
     server: {
       hmr: false,
+      // Dev-only: forward backend API + asset routes to the Rust server on :4623
+      // so the dashboard works when running `astro dev` on :4624 against a
+      // separate `cargo run -- --port 4623` process.
+      proxy: {
+        '/api': { target: 'http://127.0.0.1:4623', changeOrigin: true },
+        '/v1': { target: 'http://127.0.0.1:4623', changeOrigin: true },
+        '/health': { target: 'http://127.0.0.1:4623', changeOrigin: true },
+        '/oauth': { target: 'http://127.0.0.1:4623', changeOrigin: true },
+      },
     },
     resolve: {
       alias: {

--- a/web/src/components/BasicChatPageClient.tsx
+++ b/web/src/components/BasicChatPageClient.tsx
@@ -243,6 +243,7 @@ function pickPreferredModel(group: ProviderGroup | null): Model | null {
 }
 
 export default function BasicChatPageClient() {
+  useEnsureCatalog();
   const [providerGroups, setProviderGroups] = useState<ProviderGroup[]>([]);
   const [loadingData, setLoadingData] = useState<boolean>(true);
   const [loadError, setLoadError] = useState<string>("");
@@ -1037,4 +1038,3 @@ export default function BasicChatPageClient() {
     </div>
   );
 }
-  useEnsureCatalog();

--- a/web/src/components/BasicChatPageClient.tsx
+++ b/web/src/components/BasicChatPageClient.tsx
@@ -2,7 +2,7 @@
 
 import { useEffect, useMemo, useRef, useState } from "react";
 import { Badge, Button } from "@/shared/components";
-import { getModelsByProviderId } from "@/shared/constants/models";
+import { getModelsByProviderId, useEnsureCatalog } from "@/shared/constants/models";
 import { isAnthropicCompatibleProvider, isOpenAICompatibleProvider } from "@/shared/constants/providers";
 
 const STORAGE_KEYS: Record<string, string> = {
@@ -1037,3 +1037,4 @@ export default function BasicChatPageClient() {
     </div>
   );
 }
+  useEnsureCatalog();

--- a/web/src/components/CLIToolsPageClient.tsx
+++ b/web/src/components/CLIToolsPageClient.tsx
@@ -3,7 +3,7 @@
 import { useState, useEffect, useCallback } from "react";
 import { Card, CardSkeleton } from "@/shared/components";
 import { CLI_TOOLS } from "@/shared/constants/cliTools";
-import { getModelsByProviderId, PROVIDER_ID_TO_ALIAS } from "@/shared/constants/models";
+import { getModelsByProviderId, PROVIDER_ID_TO_ALIAS, useEnsureCatalog } from "@/shared/constants/models";
 import { ClaudeToolCard, ClineToolCard, KiloToolCard, CodexToolCard, DroidToolCard, OpenClawToolCard, HermesToolCard, DefaultToolCard, OpenCodeToolCard, CoworkToolCard, MitmLinkCard } from "./cli-tools";
 import { MITM_TOOLS } from "@/shared/constants/cliTools";
 
@@ -242,3 +242,4 @@ export default function CLIToolsPageClient({ machineId }: CLIToolsPageClientProp
     </div>
   );
 }
+  useEnsureCatalog();

--- a/web/src/components/CLIToolsPageClient.tsx
+++ b/web/src/components/CLIToolsPageClient.tsx
@@ -27,6 +27,7 @@ interface CLIToolsPageClientProps {
 }
 
 export default function CLIToolsPageClient({ machineId }: CLIToolsPageClientProps) {
+  useEnsureCatalog();
   const [connections, setConnections] = useState<any[]>([]);
   const [loading, setLoading] = useState<boolean>(true);
   const [expandedTool, setExpandedTool] = useState<string | null>(null);
@@ -242,4 +243,3 @@ export default function CLIToolsPageClient({ machineId }: CLIToolsPageClientProp
     </div>
   );
 }
-  useEnsureCatalog();

--- a/web/src/components/MitmPageClient.tsx
+++ b/web/src/components/MitmPageClient.tsx
@@ -16,6 +16,7 @@ interface MitmStatus {
 }
 
 export default function MitmPageClient() {
+  useEnsureCatalog();
   const [connections, setConnections] = useState<any[]>([]);
   const [apiKeys, setApiKeys] = useState<any[]>([]);
   const [modelAliases, setModelAliases] = useState<Record<string, any>>({});
@@ -124,4 +125,3 @@ export default function MitmPageClient() {
     </div>
   );
 }
-  useEnsureCatalog();

--- a/web/src/components/MitmPageClient.tsx
+++ b/web/src/components/MitmPageClient.tsx
@@ -2,7 +2,7 @@
 
 import { useState, useEffect } from "react";
 import { MITM_TOOLS } from "@/shared/constants/cliTools";
-import { getModelsByProviderId } from "@/shared/constants/models";
+import { getModelsByProviderId, useEnsureCatalog } from "@/shared/constants/models";
 import { isOpenAICompatibleProvider, isAnthropicCompatibleProvider } from "@/shared/constants/providers";
 import { MitmServerCard, MitmToolCard } from "@/components/cli-tools";
 
@@ -124,3 +124,4 @@ export default function MitmPageClient() {
     </div>
   );
 }
+  useEnsureCatalog();

--- a/web/src/components/providers/ModelsCard.tsx
+++ b/web/src/components/providers/ModelsCard.tsx
@@ -2,7 +2,7 @@
 
 import { useState, useCallback, useEffect } from "react";
 import { Card, Button, Modal } from "@/shared/components";
-import { getModelsByProviderId } from "@/shared/constants/models";
+import { getModelsByProviderId, useEnsureCatalog } from "@/shared/constants/models";
 import { getProviderAlias } from "@/shared/constants/providers";
 import { useCopyToClipboard } from "@/shared/hooks/useCopyToClipboard";
 
@@ -293,3 +293,4 @@ export default function ModelsCard({ providerId, kindFilter, providerAliasOverri
     </>
   );
 }
+  useEnsureCatalog();

--- a/web/src/components/providers/ModelsCard.tsx
+++ b/web/src/components/providers/ModelsCard.tsx
@@ -122,6 +122,7 @@ interface ModelsCardProps {
 // Self-contained card: shows models for a provider, filtered by optional `kindFilter`.
 // kindFilter: if provided, only shows models with matching type/kinds field.
 export default function ModelsCard({ providerId, kindFilter, providerAliasOverride }: ModelsCardProps) {
+  useEnsureCatalog();
   const { copied, copy } = useCopyToClipboard();
   const [modelAliases, setModelAliases] = useState<Record<string, string>>({});
   const [customModels, setCustomModels] = useState<Array<{ providerAlias: string; id: string; name?: string; type?: string }>>([]);
@@ -293,4 +294,3 @@ export default function ModelsCard({ providerId, kindFilter, providerAliasOverri
     </>
   );
 }
-  useEnsureCatalog();

--- a/web/src/components/providers/ProviderDetailPageClient.tsx
+++ b/web/src/components/providers/ProviderDetailPageClient.tsx
@@ -4,7 +4,7 @@ import { useState, useEffect, useCallback } from "react";
 // import Image from "next/image";  // ported: next.js -> Astro+React
 import { Card, Button, Badge, Input, Modal, CardSkeleton, OAuthModal, KiroOAuthWrapper, CursorAuthModal, IFlowCookieModal, GitLabAuthModal, Toggle, Select, EditConnectionModal, NoAuthProxyCard } from "@/shared/components";
 import { OAUTH_PROVIDERS, APIKEY_PROVIDERS, FREE_PROVIDERS, FREE_TIER_PROVIDERS, WEB_COOKIE_PROVIDERS, getProviderAlias, isOpenAICompatibleProvider, isAnthropicCompatibleProvider, AI_PROVIDERS, THINKING_CONFIG } from "@/shared/constants/providers";
-import { getModelsByProviderId } from "@/shared/constants/models";
+import { getModelsByProviderId, useEnsureCatalog } from "@/shared/constants/models";
 import { useCopyToClipboard } from "@/shared/hooks/useCopyToClipboard";
 import { fetchSuggestedModels } from "@/shared/utils/providerModelsFetcher";
 import ModelRow from "./ModelRow";
@@ -19,6 +19,7 @@ export default function ProviderDetailPageClient() {
   // useParams/useRouter shims for Astro (no Next.js runtime)
   const [params, setParams] = useState<{ id: string }>({ id: "" });
   const [mounted, setMounted] = useState<boolean>(false);
+  useEnsureCatalog();
   useEffect(() => {
     setMounted(true);
     setParams({ id: window.location.pathname.split("/").filter(Boolean).pop() || "" });

--- a/web/src/shared/components/ModelSelectModal.tsx
+++ b/web/src/shared/components/ModelSelectModal.tsx
@@ -3,7 +3,7 @@
 import { useState, useMemo, useEffect } from "react";
 import Modal from "./Modal";
 import Button from "./Button";
-import { getModelsByProviderId } from "@/shared/constants/models";
+import { getModelsByProviderId, useEnsureCatalog } from "@/shared/constants/models";
 import { OAUTH_PROVIDERS, APIKEY_PROVIDERS, FREE_PROVIDERS, FREE_TIER_PROVIDERS, AI_PROVIDERS, isOpenAICompatibleProvider, isAnthropicCompatibleProvider, getProviderAlias } from "@/shared/constants/providers";
 import React from "react";
 
@@ -83,6 +83,7 @@ export default function ModelSelectModal({
   kindFilter = null,
   closeOnSelect = true,
 }: ModelSelectModalProps) {
+  useEnsureCatalog();
   // Filter activeProviders by serviceKinds when kindFilter set (e.g. "webSearch", "webFetch")
   const filteredActiveProviders = useMemo(() => {
     if (!kindFilter) return activeProviders;

--- a/web/src/shared/constants/models.ts
+++ b/web/src/shared/constants/models.ts
@@ -1,36 +1,86 @@
-// Import directly from file to avoid pulling in server-side dependencies via index.js
-// export {
-//   PROVIDER_MODELS,
-//   getProviderModels,
-//   getDefaultModel,
-//   isValidModel as isValidModelCore,
-//   findModelName,
-//   getModelTargetFormat,
-//   getModelStrip,
-//   PROVIDER_ID_TO_ALIAS,
-//   getModelsByProviderId,
-//   getModelUpstreamId,
-//   getModelQuotaFamily
-// } from "open-sse/config/providerModels.jsx";
+// Model catalog accessors. The actual data is loaded asynchronously from the
+// Rust backend via GET /api/catalog (see src/core/model/provider_catalog.json,
+// served by api_catalog in src/server/api/mod.rs).
+//
+// useEnsureCatalog() is the React hook components call so they re-render when
+// the data arrives. The plain accessors below read the latest snapshot.
 
 import { AI_PROVIDERS, isOpenAICompatibleProvider } from "./providers";
-// import { PROVIDER_MODELS as MODELS } from "open-sse/config/providerModels.jsx";
-
+import { useCatalogStore, useEnsureCatalog } from "@/store/catalogStore";
 import type { Model } from "../../types";
 
-// Temporary stubs
-export const PROVIDER_MODELS: Record<string, Model[]> = {};
-export const getProviderModels = (): Model[] => [];
-export const getDefaultModel = (): string => "";
-export const isValidModelCore = (): boolean => true;
-export const findModelName = (): string => "";
-export const getModelTargetFormat = (): string => "";
-export const getModelStrip = (): string => "";
-export const PROVIDER_ID_TO_ALIAS: Record<string, string> = {};
-export const getModelsByProviderId = (): Model[] => [];
-export const getModelUpstreamId = (): string => "";
-export const getModelQuotaFamily = (): string => "";
-export const MODELS: Record<string, Model[]> = {};
+export { useEnsureCatalog };
+
+function snapshot() {
+  return useCatalogStore.getState();
+}
+
+function aliasFor(providerId: string): string {
+  const { providerIdToAlias } = snapshot();
+  return providerIdToAlias[providerId] || providerId;
+}
+
+export function getModelsByProviderId(providerId: string): Model[] {
+  const { modelsByAlias } = snapshot();
+  const alias = aliasFor(providerId);
+  return (modelsByAlias[alias] || []) as unknown as Model[];
+}
+
+export function getProviderModels(aliasOrId: string): Model[] {
+  const { modelsByAlias, providerIdToAlias } = snapshot();
+  // Treat the argument as either a provider id or alias.
+  const alias = providerIdToAlias[aliasOrId] || aliasOrId;
+  return (modelsByAlias[alias] || []) as unknown as Model[];
+}
+
+export function getDefaultModel(aliasOrId: string): string {
+  const models = getProviderModels(aliasOrId);
+  return models[0]?.id || "";
+}
+
+export function findModelName(aliasOrId: string, modelId: string): string {
+  const found = getProviderModels(aliasOrId).find((m) => m.id === modelId);
+  return found?.name || modelId;
+}
+
+export function getModelTargetFormat(_aliasOrId: string, _modelId: string): string {
+  return "";
+}
+
+export function getModelStrip(_aliasOrId: string, _modelId: string): string[] {
+  return [];
+}
+
+export function getModelUpstreamId(_aliasOrId: string, modelId: string): string {
+  return modelId;
+}
+
+export function getModelQuotaFamily(_aliasOrId: string, _modelId: string): string {
+  return "normal";
+}
+
+export const PROVIDER_MODELS: Record<string, Model[]> = new Proxy(
+  {},
+  {
+    get: (_target, key: string) => {
+      const { modelsByAlias } = snapshot();
+      return (modelsByAlias[key] || []) as unknown as Model[];
+    },
+    ownKeys: () => Object.keys(snapshot().modelsByAlias),
+    getOwnPropertyDescriptor: () => ({ enumerable: true, configurable: true }),
+  }
+) as Record<string, Model[]>;
+
+export const PROVIDER_ID_TO_ALIAS: Record<string, string> = new Proxy(
+  {},
+  {
+    get: (_target, key: string) => snapshot().providerIdToAlias[key],
+    ownKeys: () => Object.keys(snapshot().providerIdToAlias),
+    getOwnPropertyDescriptor: () => ({ enumerable: true, configurable: true }),
+  }
+) as Record<string, string>;
+
+export const MODELS = PROVIDER_MODELS;
 
 // Providers that accept any model (passthrough)
 const PASSTHROUGH_PROVIDERS: Set<string> = new Set(
@@ -39,23 +89,30 @@ const PASSTHROUGH_PROVIDERS: Set<string> = new Set(
     .map(([key]) => key)
 );
 
-// Wrap isValidModel with passthrough providers
+export function isValidModelCore(aliasOrId: string, modelId: string): boolean {
+  const models = snapshot().modelsByAlias[aliasOrId];
+  if (!models) return false;
+  return models.some((m) => m.id === modelId);
+}
+
 export function isValidModel(aliasOrId: string, modelId: string): boolean {
   if (isOpenAICompatibleProvider(aliasOrId)) return true;
   if (PASSTHROUGH_PROVIDERS.has(aliasOrId)) return true;
-  const models = MODELS[aliasOrId];
-  if (!models) return false;
-  return models.some(m => m.id === modelId);
+  return isValidModelCore(aliasOrId, modelId);
 }
 
-// Interface for AI model entries
 interface AIModelEntry {
   provider: string;
   model: string;
   name: string;
 }
 
-// Legacy AI_MODELS for backward compatibility
-export const AI_MODELS: AIModelEntry[] = Object.entries(MODELS).flatMap(([alias, models]) =>
-  models.map(m => ({ provider: alias, model: m.id, name: m.name }))
-);
+// Legacy AI_MODELS for backward compatibility — built from the current snapshot.
+export const AI_MODELS: AIModelEntry[] = (() => {
+  const out: AIModelEntry[] = [];
+  const { modelsByAlias } = snapshot();
+  for (const [alias, models] of Object.entries(modelsByAlias)) {
+    for (const m of models) out.push({ provider: alias, model: m.id, name: m.name || m.id });
+  }
+  return out;
+})();

--- a/web/src/store/catalogStore.ts
+++ b/web/src/store/catalogStore.ts
@@ -1,0 +1,76 @@
+import { create } from "zustand";
+
+// Catalog returned by GET /api/catalog (mirrors src/core/model/provider_catalog.json).
+interface CatalogModel {
+  id: string;
+  name?: string;
+  kind: string;
+}
+
+interface CatalogModelsEntry {
+  alias: string;
+  models: CatalogModel[];
+}
+
+interface CatalogResponse {
+  providerIdToAlias?: Record<string, string>;
+  providerModels?: CatalogModelsEntry[];
+}
+
+interface CatalogState {
+  loaded: boolean;
+  loading: boolean;
+  modelsByAlias: Record<string, CatalogModel[]>;
+  providerIdToAlias: Record<string, string>;
+  load: () => Promise<void>;
+}
+
+export const useCatalogStore = create<CatalogState>((set, get) => ({
+  loaded: false,
+  loading: false,
+  modelsByAlias: {},
+  providerIdToAlias: {},
+  load: async () => {
+    const state = get();
+    if (state.loaded || state.loading) return;
+    set({ loading: true });
+    try {
+      const res = await fetch("/api/catalog", { cache: "no-store" });
+      if (!res.ok) {
+        set({ loading: false });
+        return;
+      }
+      const data: CatalogResponse = await res.json();
+      const modelsByAlias: Record<string, CatalogModel[]> = {};
+      for (const entry of data.providerModels || []) {
+        if (entry?.alias) modelsByAlias[entry.alias] = entry.models || [];
+      }
+      set({
+        loaded: true,
+        loading: false,
+        modelsByAlias,
+        providerIdToAlias: data.providerIdToAlias || {},
+      });
+    } catch {
+      set({ loading: false });
+    }
+  },
+}));
+
+// Kick off the fetch on module import in the browser.
+if (typeof window !== "undefined") {
+  useCatalogStore.getState().load();
+}
+
+/**
+ * React hook that ensures the catalog is loaded and re-renders the caller
+ * when it arrives. Returns true once data is available.
+ */
+export function useEnsureCatalog(): boolean {
+  const loaded = useCatalogStore((s) => s.loaded);
+  const loading = useCatalogStore((s) => s.loading);
+  if (!loaded && !loading && typeof window !== "undefined") {
+    useCatalogStore.getState().load();
+  }
+  return loaded;
+}


### PR DESCRIPTION
## Summary

Brings dashboard UX in line with [9router](https://github.com/decolua/9router) for free providers (OpenCode Free, Ollama Cloud, etc.) and unblocks the model list / model test flow.

## Changes

### Backend

- `GET /api/catalog` (new, public): serves the embedded provider catalog from `src/core/model/provider_catalog.json` so the dashboard reads model data from the backend instead of duplicating it in TS.
- `GET /api/providers/suggested-models` is now public — it is a passthrough proxy that fetches public provider model URLs (`opencode.ai`, `openrouter.ai`).
- `select_connection` injects a virtual "Public" connection for noAuth providers (`opencode`, `edge-tts`, `google-tts`, `local-device`) so they route requests without manual setup. Mirrors 9router's `getProviderCredentials`.
- `main.rs` auto-seeds a default API key on first launch when `apiKeys` is empty so dashboard self-calls (`/api/models/test` → `/v1/chat/completions`) authenticate out of the box.

### Frontend

- New Zustand store `web/src/store/catalogStore.ts` lazy-loads `/api/catalog`. The `useEnsureCatalog()` hook keeps consumers re-rendering as the snapshot updates.
- `web/src/shared/constants/models.ts` now reads from the catalog store rather than returning empty stubs.
- Wired `useEnsureCatalog()` into the components that render model lists: `ProviderDetailPageClient`, `ModelsCard`, `CLIToolsPageClient`, `BasicChatPageClient`, `MitmPageClient`, `ModelSelectModal`.
- Vite dev proxy in `astro.config.mjs` forwards `/api`, `/v1`, `/health`, `/oauth` from `:4624` → `:4623` so `pnpm dev` works against a separate `cargo run` backend.

## Tested

- `/dashboard/providers/opencode` lists static + suggested free models. Test buttons succeed for `oc/deepseek-v4-flash-free` and `oc/minimax-m2.5-free`.
- `/dashboard/providers/ollama` shows all 6 hardcoded Ollama Cloud models.
- `/dashboard/providers/openrouter` lists embedded models.
- `/dashboard/cli-tools` renders all 12 tool cards plus MITM tools.
- `curl /api/catalog` and `/api/providers/suggested-models?…opencode-free` return 200 from both `:4623` and `:4624`.
- `cargo build` clean.

## Notes

- The 9router `open-sse/config/*.js` files in this repo are unchanged; the dashboard no longer imports them.
- Auto-seeded key prints to stderr on first launch only (when DB has no keys); subsequent launches are silent.