### PR TITLE
feat(payload-rules): port OmniRoute payload-rules + system-prompt override

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -23,6 +23,7 @@ pub mod cli;
 pub mod core;
 pub mod db;
 pub mod oauth;
+pub mod payload_rules;
 pub mod server;
 pub mod types;
 

--- a/src/payload_rules.rs
+++ b/src/payload_rules.rs
@@ -1,0 +1,698 @@
+//! Payload rules — per-request transformations applied to the chat
+//! completions body before it is forwarded upstream.
+//!
+//! Modeled after OmniRoute's `payloadRules` (MIT) but rewritten in Rust.
+//! Four rule kinds, all selected by a wildcard match against the request's
+//! `model` field (and optionally a `protocol` tag):
+//!
+//! * `default`  — set params when the caller did not supply them
+//! * `override` — force params, replacing any caller-supplied value
+//! * `filter`   — strip JSON pointer-style paths from the outgoing payload
+//! * `default_raw` — `default`-style fill but applied to the raw upstream
+//!   payload after format conversion. In openproxy today most providers
+//!   accept the body verbatim, so this currently behaves identically to
+//!   `default`. Kept as a distinct slot so we can wire it after the
+//!   per-provider transform layer lands without another schema bump.
+//!
+//! The rule set is persisted under `Settings::payload_rules` in `db.json`
+//! and edited live via `PUT /api/settings/payload-rules`.
+
+use std::collections::BTreeMap;
+
+use serde::{Deserialize, Serialize};
+use serde_json::{Map, Value};
+
+/// One entry in a rule's `models` array.
+#[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub struct PayloadRuleModelSpec {
+    pub name: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub protocol: Option<String>,
+}
+
+/// A rule that injects (default) or forces (override / default_raw) params.
+#[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq)]
+#[serde(rename_all = "camelCase")]
+pub struct PayloadMutationRule {
+    pub models: Vec<PayloadRuleModelSpec>,
+    /// Object whose keys (dot-separated) describe where to set values.
+    /// Example: `{ "temperature": 0.2, "metadata.user_id": "redacted" }`
+    /// becomes `body.temperature = 0.2` and `body.metadata.user_id =
+    /// "redacted"`.
+    #[serde(default)]
+    pub params: Map<String, Value>,
+}
+
+/// A rule that strips dot-paths from the outgoing payload.
+#[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq)]
+#[serde(rename_all = "camelCase")]
+pub struct PayloadFilterRule {
+    pub models: Vec<PayloadRuleModelSpec>,
+    #[serde(default)]
+    pub params: Vec<String>,
+}
+
+/// Persisted top-level config. All four lists default to empty so an
+/// upgraded `db.json` from a previous release deserialises cleanly.
+#[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq)]
+#[serde(rename_all = "camelCase")]
+pub struct PayloadRulesConfig {
+    #[serde(default)]
+    pub default: Vec<PayloadMutationRule>,
+    #[serde(default)]
+    pub r#override: Vec<PayloadMutationRule>,
+    #[serde(default)]
+    pub filter: Vec<PayloadFilterRule>,
+    #[serde(default)]
+    pub default_raw: Vec<PayloadMutationRule>,
+}
+
+impl PayloadRulesConfig {
+    pub fn is_empty(&self) -> bool {
+        self.default.is_empty()
+            && self.r#override.is_empty()
+            && self.filter.is_empty()
+            && self.default_raw.is_empty()
+    }
+
+    /// Trim, drop empty entries, and normalize order so the persisted form
+    /// is stable across saves.
+    pub fn normalize(&mut self) {
+        normalize_mutation_rules(&mut self.default);
+        normalize_mutation_rules(&mut self.r#override);
+        normalize_filter_rules(&mut self.filter);
+        normalize_mutation_rules(&mut self.default_raw);
+    }
+
+    pub fn summary(&self) -> PayloadRulesSummary {
+        PayloadRulesSummary {
+            default: self.default.len(),
+            r#override: self.r#override.len(),
+            filter: self.filter.len(),
+            default_raw: self.default_raw.len(),
+        }
+    }
+}
+
+/// Counts surfaced in the UI summary card.
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub struct PayloadRulesSummary {
+    pub default: usize,
+    pub r#override: usize,
+    pub filter: usize,
+    pub default_raw: usize,
+}
+
+fn normalize_mutation_rules(rules: &mut Vec<PayloadMutationRule>) {
+    rules.retain(|rule| !rule.models.is_empty() && !rule.params.is_empty());
+    for rule in rules.iter_mut() {
+        rule.models.retain(|m| !m.name.trim().is_empty());
+        for spec in rule.models.iter_mut() {
+            spec.name = spec.name.trim().to_string();
+            spec.protocol = spec.protocol.as_ref().and_then(|p| {
+                let t = p.trim();
+                if t.is_empty() {
+                    None
+                } else {
+                    Some(t.to_string())
+                }
+            });
+        }
+    }
+}
+
+fn normalize_filter_rules(rules: &mut Vec<PayloadFilterRule>) {
+    rules.retain(|rule| !rule.models.is_empty() && !rule.params.is_empty());
+    for rule in rules.iter_mut() {
+        rule.models.retain(|m| !m.name.trim().is_empty());
+        rule.params.retain(|p| !p.trim().is_empty());
+        for spec in rule.models.iter_mut() {
+            spec.name = spec.name.trim().to_string();
+            spec.protocol = spec.protocol.as_ref().and_then(|p| {
+                let t = p.trim();
+                if t.is_empty() {
+                    None
+                } else {
+                    Some(t.to_string())
+                }
+            });
+        }
+    }
+}
+
+/// Apply `default`, `override`, and `filter` rules to a request body in
+/// place. Each rule is checked against `(model_name, protocol)` using glob
+/// matching against the rule's `models` array; matching rules are applied
+/// in the order they appear in the config.
+///
+/// Returns `true` if any rule modified the body. The caller can use this
+/// for logging / observability.
+pub fn apply_request_rules(
+    body: &mut Value,
+    model_name: &str,
+    protocol: Option<&str>,
+    config: &PayloadRulesConfig,
+) -> bool {
+    let body_obj = match body.as_object_mut() {
+        Some(obj) => obj,
+        None => return false,
+    };
+
+    let mut mutated = false;
+
+    // default — fill in missing values
+    for rule in &config.default {
+        if !rule_matches(&rule.models, model_name, protocol) {
+            continue;
+        }
+        for (path, value) in &rule.params {
+            if set_path_if_absent(body_obj, path, value.clone()) {
+                mutated = true;
+            }
+        }
+    }
+
+    // override — force values
+    for rule in &config.r#override {
+        if !rule_matches(&rule.models, model_name, protocol) {
+            continue;
+        }
+        for (path, value) in &rule.params {
+            set_path(body_obj, path, value.clone());
+            mutated = true;
+        }
+    }
+
+    // filter — strip paths
+    for rule in &config.filter {
+        if !rule_matches(&rule.models, model_name, protocol) {
+            continue;
+        }
+        for path in &rule.params {
+            if remove_path(body_obj, path) {
+                mutated = true;
+            }
+        }
+    }
+
+    mutated
+}
+
+/// `default_raw` is applied after format-conversion. In openproxy's
+/// current pipeline the body is forwarded mostly verbatim, so we expose
+/// this as a separate entry point that callers can choose to invoke after
+/// they perform any provider-specific transform.
+pub fn apply_raw_rules(
+    body: &mut Value,
+    model_name: &str,
+    protocol: Option<&str>,
+    config: &PayloadRulesConfig,
+) -> bool {
+    let body_obj = match body.as_object_mut() {
+        Some(obj) => obj,
+        None => return false,
+    };
+
+    let mut mutated = false;
+    for rule in &config.default_raw {
+        if !rule_matches(&rule.models, model_name, protocol) {
+            continue;
+        }
+        for (path, value) in &rule.params {
+            if set_path_if_absent(body_obj, path, value.clone()) {
+                mutated = true;
+            }
+        }
+    }
+    mutated
+}
+
+fn rule_matches(specs: &[PayloadRuleModelSpec], model_name: &str, protocol: Option<&str>) -> bool {
+    specs.iter().any(|spec| {
+        if !wildcard_match(&spec.name, model_name) {
+            return false;
+        }
+        match spec.protocol.as_deref() {
+            None => true,
+            Some(want) => protocol.map(|got| got == want).unwrap_or(false),
+        }
+    })
+}
+
+/// Glob matcher: `*` matches any run of characters (including empty),
+/// `?` matches a single character, everything else is literal. Matching
+/// is case-insensitive — model names like `GPT-4.1` and `gpt-4.1` are
+/// treated identically.
+pub fn wildcard_match(pattern: &str, value: &str) -> bool {
+    let pat: Vec<char> = pattern.chars().flat_map(char::to_lowercase).collect();
+    let val: Vec<char> = value.chars().flat_map(char::to_lowercase).collect();
+    let (m, n) = (pat.len(), val.len());
+
+    // Dynamic-programming match for `*` and `?`. `dp[i][j]` is true if
+    // the first `i` pattern chars match the first `j` value chars.
+    let mut dp = vec![vec![false; n + 1]; m + 1];
+    dp[0][0] = true;
+    for i in 1..=m {
+        if pat[i - 1] == '*' {
+            dp[i][0] = dp[i - 1][0];
+        }
+    }
+    for i in 1..=m {
+        for j in 1..=n {
+            dp[i][j] = match pat[i - 1] {
+                '*' => dp[i - 1][j] || dp[i][j - 1],
+                '?' => dp[i - 1][j - 1],
+                c => dp[i - 1][j - 1] && c == val[j - 1],
+            };
+        }
+    }
+    dp[m][n]
+}
+
+fn split_path(path: &str) -> Vec<String> {
+    path.split('.')
+        .map(|s| s.trim().to_string())
+        .filter(|s| !s.is_empty())
+        .collect()
+}
+
+fn set_path(root: &mut Map<String, Value>, path: &str, value: Value) {
+    let parts = split_path(path);
+    if parts.is_empty() {
+        return;
+    }
+    set_path_segments(root, &parts, value, /*only_if_absent=*/ false);
+}
+
+fn set_path_if_absent(root: &mut Map<String, Value>, path: &str, value: Value) -> bool {
+    let parts = split_path(path);
+    if parts.is_empty() {
+        return false;
+    }
+    set_path_segments(root, &parts, value, /*only_if_absent=*/ true)
+}
+
+fn set_path_segments(
+    root: &mut Map<String, Value>,
+    parts: &[String],
+    value: Value,
+    only_if_absent: bool,
+) -> bool {
+    if parts.is_empty() {
+        return false;
+    }
+    if parts.len() == 1 {
+        let key = &parts[0];
+        if only_if_absent && root.contains_key(key) {
+            return false;
+        }
+        root.insert(key.clone(), value);
+        return true;
+    }
+    let key = &parts[0];
+    let child = root
+        .entry(key.clone())
+        .or_insert_with(|| Value::Object(Map::new()));
+    if !child.is_object() {
+        if only_if_absent {
+            return false;
+        }
+        *child = Value::Object(Map::new());
+    }
+    set_path_segments(
+        child.as_object_mut().expect("child is object"),
+        &parts[1..],
+        value,
+        only_if_absent,
+    )
+}
+
+fn remove_path(root: &mut Map<String, Value>, path: &str) -> bool {
+    let parts = split_path(path);
+    if parts.is_empty() {
+        return false;
+    }
+    remove_path_segments(root, &parts)
+}
+
+fn remove_path_segments(root: &mut Map<String, Value>, parts: &[String]) -> bool {
+    if parts.is_empty() {
+        return false;
+    }
+    if parts.len() == 1 {
+        return root.remove(&parts[0]).is_some();
+    }
+    let key = &parts[0];
+    let Some(child) = root.get_mut(key) else {
+        return false;
+    };
+    let Some(child_obj) = child.as_object_mut() else {
+        return false;
+    };
+    remove_path_segments(child_obj, &parts[1..])
+}
+
+/// System-prompt override. Modeled after OmniRoute's
+/// `api/settings/system-prompt`. Two modes:
+///
+/// * `Off` — do nothing.
+/// * `Prepend` — insert the override as the first `system` message if no
+///   system message exists yet, otherwise leave the caller's prompt alone.
+/// * `Override` — replace any existing system message with the override.
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq, Default)]
+#[serde(rename_all = "lowercase")]
+pub enum SystemPromptMode {
+    #[default]
+    Off,
+    Prepend,
+    Override,
+}
+
+#[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub struct SystemPromptConfig {
+    #[serde(default)]
+    pub mode: SystemPromptMode,
+    #[serde(default)]
+    pub content: String,
+}
+
+impl SystemPromptConfig {
+    pub fn is_active(&self) -> bool {
+        !matches!(self.mode, SystemPromptMode::Off) && !self.content.trim().is_empty()
+    }
+
+    pub fn normalize(&mut self) {
+        self.content = self.content.trim().to_string();
+        if self.content.is_empty() {
+            self.mode = SystemPromptMode::Off;
+        }
+    }
+}
+
+/// Apply the system-prompt override to an OpenAI-style chat completions
+/// body. Mutates `body["messages"]` in place. Returns `true` if any
+/// modification was made.
+pub fn apply_system_prompt(body: &mut Value, config: &SystemPromptConfig) -> bool {
+    if !config.is_active() {
+        return false;
+    }
+    let Some(obj) = body.as_object_mut() else {
+        return false;
+    };
+
+    // OpenAI-style `messages` array of objects with `role` + `content`.
+    if let Some(messages) = obj.get_mut("messages").and_then(Value::as_array_mut) {
+        let has_system = messages
+            .iter()
+            .any(|m| m.get("role").and_then(Value::as_str) == Some("system"));
+
+        match config.mode {
+            SystemPromptMode::Off => return false,
+            SystemPromptMode::Prepend => {
+                if !has_system {
+                    messages.insert(
+                        0,
+                        serde_json::json!({ "role": "system", "content": config.content.clone() }),
+                    );
+                    return true;
+                }
+                return false;
+            }
+            SystemPromptMode::Override => {
+                let mut replaced = false;
+                let mut first_system_seen = false;
+                messages.retain_mut(|m| {
+                    let is_system = m.get("role").and_then(Value::as_str) == Some("system");
+                    if !is_system {
+                        return true;
+                    }
+                    if first_system_seen {
+                        replaced = true;
+                        return false;
+                    }
+                    first_system_seen = true;
+                    if let Some(map) = m.as_object_mut() {
+                        map.insert("content".to_string(), Value::String(config.content.clone()));
+                    }
+                    replaced = true;
+                    true
+                });
+                if !first_system_seen {
+                    messages.insert(
+                        0,
+                        serde_json::json!({ "role": "system", "content": config.content.clone() }),
+                    );
+                    replaced = true;
+                }
+                return replaced;
+            }
+        }
+    }
+
+    // Anthropic-style top-level `system` field. (Not always present
+    // because openproxy mostly sees OpenAI-format requests, but worth
+    // handling for the Anthropic-compat endpoint.)
+    let system_field = obj.get("system");
+    match config.mode {
+        SystemPromptMode::Prepend => {
+            if system_field.is_none() {
+                obj.insert("system".to_string(), Value::String(config.content.clone()));
+                return true;
+            }
+            false
+        }
+        SystemPromptMode::Override => {
+            obj.insert("system".to_string(), Value::String(config.content.clone()));
+            true
+        }
+        SystemPromptMode::Off => false,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    #[test]
+    fn wildcard_matches_literal_and_glob() {
+        assert!(wildcard_match("gpt-4", "gpt-4"));
+        assert!(wildcard_match("gpt-*", "gpt-4o"));
+        assert!(wildcard_match("*", "anything"));
+        assert!(wildcard_match("claude-?", "claude-3"));
+        assert!(wildcard_match("GPT-4*", "gpt-4-turbo")); // case-insensitive
+        assert!(!wildcard_match("gpt-4", "gpt-3"));
+        assert!(!wildcard_match("claude-?", "claude-3.5"));
+    }
+
+    #[test]
+    fn default_only_fills_missing() {
+        let cfg = PayloadRulesConfig {
+            default: vec![PayloadMutationRule {
+                models: vec![PayloadRuleModelSpec {
+                    name: "gpt-*".into(),
+                    protocol: None,
+                }],
+                params: serde_json::from_value(json!({ "temperature": 0.2 })).unwrap(),
+            }],
+            ..Default::default()
+        };
+
+        let mut body = json!({ "model": "gpt-4", "messages": [] });
+        apply_request_rules(&mut body, "gpt-4", None, &cfg);
+        assert_eq!(body["temperature"], json!(0.2));
+
+        let mut body2 = json!({ "model": "gpt-4", "temperature": 0.9 });
+        apply_request_rules(&mut body2, "gpt-4", None, &cfg);
+        assert_eq!(
+            body2["temperature"],
+            json!(0.9),
+            "default must not overwrite"
+        );
+    }
+
+    #[test]
+    fn override_forces_value() {
+        let cfg = PayloadRulesConfig {
+            r#override: vec![PayloadMutationRule {
+                models: vec![PayloadRuleModelSpec {
+                    name: "o1*".into(),
+                    protocol: Some("openai".into()),
+                }],
+                params: serde_json::from_value(json!({ "reasoning_effort": "medium" })).unwrap(),
+            }],
+            ..Default::default()
+        };
+
+        let mut body = json!({ "model": "o1-mini", "reasoning_effort": "high" });
+        let changed = apply_request_rules(&mut body, "o1-mini", Some("openai"), &cfg);
+        assert!(changed);
+        assert_eq!(body["reasoning_effort"], json!("medium"));
+    }
+
+    #[test]
+    fn protocol_gating() {
+        let cfg = PayloadRulesConfig {
+            r#override: vec![PayloadMutationRule {
+                models: vec![PayloadRuleModelSpec {
+                    name: "*".into(),
+                    protocol: Some("anthropic".into()),
+                }],
+                params: serde_json::from_value(json!({ "max_tokens": 1024 })).unwrap(),
+            }],
+            ..Default::default()
+        };
+
+        let mut body = json!({ "model": "claude-3", "max_tokens": 8 });
+        apply_request_rules(&mut body, "claude-3", Some("openai"), &cfg);
+        assert_eq!(
+            body["max_tokens"],
+            json!(8),
+            "different protocol must not match"
+        );
+
+        apply_request_rules(&mut body, "claude-3", Some("anthropic"), &cfg);
+        assert_eq!(body["max_tokens"], json!(1024));
+    }
+
+    #[test]
+    fn filter_strips_dot_path() {
+        let cfg = PayloadRulesConfig {
+            filter: vec![PayloadFilterRule {
+                models: vec![PayloadRuleModelSpec {
+                    name: "*".into(),
+                    protocol: None,
+                }],
+                params: vec!["metadata.user_id".into()],
+            }],
+            ..Default::default()
+        };
+
+        let mut body = json!({
+            "model": "gpt-4",
+            "metadata": { "user_id": "u123", "session": "s9" }
+        });
+        apply_request_rules(&mut body, "gpt-4", None, &cfg);
+        assert!(body["metadata"].get("user_id").is_none());
+        assert_eq!(body["metadata"]["session"], json!("s9"));
+    }
+
+    #[test]
+    fn system_prompt_prepend_adds_only_when_missing() {
+        let cfg = SystemPromptConfig {
+            mode: SystemPromptMode::Prepend,
+            content: "You are helpful.".into(),
+        };
+
+        let mut body = json!({ "messages": [{ "role": "user", "content": "hi" }] });
+        apply_system_prompt(&mut body, &cfg);
+        assert_eq!(body["messages"][0]["role"], "system");
+        assert_eq!(body["messages"][0]["content"], "You are helpful.");
+
+        let mut body2 = json!({
+            "messages": [
+                { "role": "system", "content": "Caller's prompt" },
+                { "role": "user", "content": "hi" }
+            ]
+        });
+        apply_system_prompt(&mut body2, &cfg);
+        assert_eq!(body2["messages"][0]["content"], "Caller's prompt");
+    }
+
+    #[test]
+    fn system_prompt_override_replaces() {
+        let cfg = SystemPromptConfig {
+            mode: SystemPromptMode::Override,
+            content: "Forced prompt.".into(),
+        };
+
+        let mut body = json!({
+            "messages": [
+                { "role": "system", "content": "Old prompt" },
+                { "role": "system", "content": "Second old" },
+                { "role": "user", "content": "hi" }
+            ]
+        });
+        apply_system_prompt(&mut body, &cfg);
+        let messages = body["messages"].as_array().unwrap();
+        assert_eq!(messages.len(), 2);
+        assert_eq!(messages[0]["content"], "Forced prompt.");
+        assert_eq!(messages[1]["role"], "user");
+    }
+
+    #[test]
+    fn nested_set_path_creates_intermediate_objects() {
+        let cfg = PayloadRulesConfig {
+            r#override: vec![PayloadMutationRule {
+                models: vec![PayloadRuleModelSpec {
+                    name: "*".into(),
+                    protocol: None,
+                }],
+                params: serde_json::from_value(json!({ "stream_options.include_usage": true }))
+                    .unwrap(),
+            }],
+            ..Default::default()
+        };
+
+        let mut body = json!({ "model": "gpt-4" });
+        apply_request_rules(&mut body, "gpt-4", None, &cfg);
+        assert_eq!(body["stream_options"]["include_usage"], json!(true));
+    }
+
+    #[test]
+    fn normalize_drops_empty_rules() {
+        let mut cfg = PayloadRulesConfig {
+            default: vec![PayloadMutationRule {
+                models: vec![PayloadRuleModelSpec {
+                    name: "  ".into(),
+                    protocol: None,
+                }],
+                params: Default::default(),
+            }],
+            r#override: vec![PayloadMutationRule {
+                models: vec![PayloadRuleModelSpec {
+                    name: "gpt-*".into(),
+                    protocol: None,
+                }],
+                params: serde_json::from_value(json!({ "temperature": 0.1 })).unwrap(),
+            }],
+            ..Default::default()
+        };
+        cfg.normalize();
+        assert!(cfg.default.is_empty());
+        assert_eq!(cfg.r#override.len(), 1);
+    }
+
+    // Belt-and-braces: deserialize / re-serialize a representative
+    // payload-rules JSON and make sure the shape round-trips so future
+    // edits don't silently drop fields.
+    #[test]
+    fn deserialize_omniroute_style_config() {
+        let raw = json!({
+            "default": [
+                { "models": [{"name": "gpt-4*"}], "params": { "temperature": 0.2 } }
+            ],
+            "override": [
+                { "models": [{"name": "o1*", "protocol": "openai"}],
+                  "params": { "reasoning_effort": "medium", "max_tokens": 4096 } }
+            ],
+            "filter": [
+                { "models": [{"name": "claude-*"}], "params": ["metadata.user_id"] }
+            ],
+            "defaultRaw": [
+                { "models": [{"name": "*"}], "params": { "stream_options": { "include_usage": true } } }
+            ]
+        });
+        let cfg: PayloadRulesConfig = serde_json::from_value(raw.clone()).unwrap();
+        assert_eq!(cfg.default.len(), 1);
+        assert_eq!(cfg.r#override.len(), 1);
+        assert_eq!(cfg.filter.len(), 1);
+        assert_eq!(cfg.default_raw.len(), 1);
+        let back = serde_json::to_value(&cfg).unwrap();
+        assert_eq!(back["default"][0]["params"]["temperature"], json!(0.2));
+        assert_eq!(back["defaultRaw"][0]["models"][0]["name"], json!("*"));
+    }
+}

--- a/src/server/api/chat.rs
+++ b/src/server/api/chat.rs
@@ -24,6 +24,7 @@ use crate::core::proxy::resolve_proxy_target;
 use crate::core::rtk::apply_request_preprocessing;
 use crate::core::translator::registry::{self, Format};
 use crate::core::translator::response_transform::{transform_sse_stream, transformer_for_provider};
+use crate::payload_rules::{apply_request_rules, apply_system_prompt};
 use crate::server::auth::{extract_api_key, require_api_key};
 use crate::server::state::AppState;
 use crate::types::{AppDb, ProviderConnection, TokenUsage};
@@ -180,7 +181,7 @@ async fn chat_completions_impl(
         }
     }
 
-    let Json(body) = match body {
+    let Json(mut body) = match body {
         Ok(body) => body,
         Err(_) => return json_error_response(StatusCode::BAD_REQUEST, "Invalid JSON body"),
     };
@@ -190,12 +191,23 @@ async fn chat_completions_impl(
         .and_then(Value::as_str)
         .map(str::trim)
         .filter(|value| !value.is_empty())
+        .map(str::to_string)
     else {
         return json_error_response(StatusCode::BAD_REQUEST, "Missing model");
     };
+    let model_str = model_str.as_str();
 
     let snapshot = state.db.snapshot();
     let resolved = get_model_info(model_str, &snapshot);
+
+    // Payload-rules + system-prompt override (OmniRoute-style).
+    // Applied here, after the model field has been validated but before
+    // we fan out into combo / direct dispatch — so both branches see the
+    // same transformed body. Wildcard matching uses the user-facing
+    // `model` field; the protocol tag is left empty for now (it can be
+    // wired in once we surface upstream protocol metadata at this layer).
+    apply_system_prompt(&mut body, &snapshot.settings.system_prompt);
+    apply_request_rules(&mut body, model_str, None, &snapshot.settings.payload_rules);
 
     match resolved.route_kind {
         ModelRouteKind::Combo => {

--- a/src/server/api/mod.rs
+++ b/src/server/api/mod.rs
@@ -23,6 +23,7 @@ mod provider_models;
 pub mod provider_nodes;
 mod provider_validate;
 pub mod providers;
+pub mod settings_payload_rules;
 pub mod shutdown;
 pub mod stt;
 pub mod tags;
@@ -156,6 +157,7 @@ pub fn routes() -> Router<AppState> {
         .merge(auth::routes())
         .merge(shutdown::routes())
         .merge(cli_tools::routes())
+        .merge(settings_payload_rules::routes())
 }
 
 async fn health() -> Json<HealthResponse> {

--- a/src/server/api/settings_payload_rules.rs
+++ b/src/server/api/settings_payload_rules.rs
@@ -1,0 +1,174 @@
+//! `/api/settings/payload-rules` and `/api/settings/system-prompt`.
+//!
+//! Modeled after OmniRoute's equivalent routes. Both are guarded by the
+//! dashboard / management-API key auth used by the rest of `/api/settings`.
+//!
+//! - `GET  /api/settings/payload-rules`  → returns the current config
+//! - `PUT  /api/settings/payload-rules`  → replaces the config (full
+//!   document; normalized on save)
+//! - `GET  /api/settings/system-prompt`  → returns the override config
+//! - `PUT  /api/settings/system-prompt`  → updates the override config
+
+use axum::extract::State;
+use axum::http::{HeaderMap, StatusCode};
+use axum::response::{IntoResponse, Response};
+use axum::routing::{get, put};
+use axum::{Json, Router};
+use serde::Deserialize;
+use serde_json::{json, Value};
+
+use crate::payload_rules::{PayloadRulesConfig, SystemPromptConfig, SystemPromptMode};
+use crate::server::state::AppState;
+
+use super::require_dashboard_or_management_api_key;
+
+pub fn routes() -> Router<AppState> {
+    Router::new()
+        .route(
+            "/api/settings/payload-rules",
+            get(get_payload_rules_api).put(update_payload_rules_api),
+        )
+        .route(
+            "/api/settings/system-prompt",
+            get(get_system_prompt_api).put(update_system_prompt_api),
+        )
+}
+
+fn payload_rules_response(config: &PayloadRulesConfig) -> Value {
+    json!({
+        "config": config,
+        "summary": config.summary(),
+    })
+}
+
+async fn get_payload_rules_api(State(state): State<AppState>, headers: HeaderMap) -> Response {
+    if let Err(response) = require_dashboard_or_management_api_key(&headers, &state) {
+        return response;
+    }
+    let snapshot = state.db.snapshot();
+    Json(payload_rules_response(&snapshot.settings.payload_rules)).into_response()
+}
+
+async fn update_payload_rules_api(
+    State(state): State<AppState>,
+    headers: HeaderMap,
+    Json(req): Json<PayloadRulesConfig>,
+) -> Response {
+    if let Err(response) = require_dashboard_or_management_api_key(&headers, &state) {
+        return response;
+    }
+
+    let result = state
+        .db
+        .update(|db| {
+            db.settings.payload_rules = req;
+            db.settings.payload_rules.normalize();
+        })
+        .await;
+
+    match result {
+        Ok(updated) => {
+            Json(payload_rules_response(&updated.settings.payload_rules)).into_response()
+        }
+        Err(error) => (
+            StatusCode::INTERNAL_SERVER_ERROR,
+            Json(json!({ "error": format!("Failed to save payload rules: {error}") })),
+        )
+            .into_response(),
+    }
+}
+
+async fn get_system_prompt_api(State(state): State<AppState>, headers: HeaderMap) -> Response {
+    if let Err(response) = require_dashboard_or_management_api_key(&headers, &state) {
+        return response;
+    }
+    let snapshot = state.db.snapshot();
+    Json(json!({
+        "mode": snapshot.settings.system_prompt.mode,
+        "content": snapshot.settings.system_prompt.content,
+        "active": snapshot.settings.system_prompt.is_active(),
+    }))
+    .into_response()
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct UpdateSystemPromptRequest {
+    mode: Option<SystemPromptMode>,
+    content: Option<String>,
+}
+
+async fn update_system_prompt_api(
+    State(state): State<AppState>,
+    headers: HeaderMap,
+    Json(req): Json<UpdateSystemPromptRequest>,
+) -> Response {
+    if let Err(response) = require_dashboard_or_management_api_key(&headers, &state) {
+        return response;
+    }
+
+    let result = state
+        .db
+        .update(|db| {
+            if let Some(mode) = req.mode {
+                db.settings.system_prompt.mode = mode;
+            }
+            if let Some(content) = req.content {
+                db.settings.system_prompt.content = content;
+            }
+            db.settings.system_prompt.normalize();
+        })
+        .await;
+
+    match result {
+        Ok(updated) => Json(json!({
+            "mode": updated.settings.system_prompt.mode,
+            "content": updated.settings.system_prompt.content,
+            "active": updated.settings.system_prompt.is_active(),
+        }))
+        .into_response(),
+        Err(error) => (
+            StatusCode::INTERNAL_SERVER_ERROR,
+            Json(json!({ "error": format!("Failed to save system prompt: {error}") })),
+        )
+            .into_response(),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::payload_rules::SystemPromptMode;
+
+    // Sanity-check the JSON shape we return to the dashboard so a future
+    // refactor doesn't silently break the UI contract.
+    #[test]
+    fn payload_rules_response_contains_config_and_summary() {
+        let cfg = PayloadRulesConfig::default();
+        let body = payload_rules_response(&cfg);
+        assert!(body.get("config").is_some());
+        assert!(body.get("summary").is_some());
+        let summary = &body["summary"];
+        assert_eq!(summary["default"], 0);
+        assert_eq!(summary["override"], 0);
+        assert_eq!(summary["filter"], 0);
+        assert_eq!(summary["defaultRaw"], 0);
+    }
+
+    #[test]
+    fn system_prompt_mode_serializes_lowercase() {
+        // We rely on lowercase tags in the dashboard radio buttons.
+        assert_eq!(
+            serde_json::to_value(SystemPromptMode::Off).unwrap(),
+            json!("off")
+        );
+        assert_eq!(
+            serde_json::to_value(SystemPromptMode::Prepend).unwrap(),
+            json!("prepend")
+        );
+        assert_eq!(
+            serde_json::to_value(SystemPromptMode::Override).unwrap(),
+            json!("override")
+        );
+    }
+}

--- a/src/types/mod.rs
+++ b/src/types/mod.rs
@@ -3,6 +3,8 @@ use std::collections::BTreeMap;
 use serde::{de::DeserializeOwned, Deserialize, Serialize};
 use serde_json::Value;
 
+use crate::payload_rules::{PayloadRulesConfig, SystemPromptConfig};
+
 pub const DEFAULT_MITM_ROUTER_BASE: &str = "http://localhost:4623";
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Default)]
@@ -353,6 +355,10 @@ pub struct Settings {
         deserialize_with = "deserialize_null_default"
     )]
     pub caveman_level: String,
+    #[serde(default, deserialize_with = "deserialize_null_default")]
+    pub payload_rules: PayloadRulesConfig,
+    #[serde(default, deserialize_with = "deserialize_null_default")]
+    pub system_prompt: SystemPromptConfig,
     #[serde(default, skip_serializing)]
     pub password: Option<String>,
     #[serde(flatten)]
@@ -387,6 +393,8 @@ impl Default for Settings {
             rtk_enabled: true,
             caveman_enabled: false,
             caveman_level: default_caveman_level(),
+            payload_rules: PayloadRulesConfig::default(),
+            system_prompt: SystemPromptConfig::default(),
             password: None,
             extra: BTreeMap::new(),
         }
@@ -400,6 +408,8 @@ impl Settings {
         }
 
         self.caveman_level = normalize_caveman_level_value(&self.caveman_level);
+        self.payload_rules.normalize();
+        self.system_prompt.normalize();
     }
 }
 

--- a/tests/payload_rules_api.rs
+++ b/tests/payload_rules_api.rs
@@ -1,0 +1,199 @@
+use std::collections::BTreeMap;
+use std::sync::Arc;
+
+use axum::body::Body;
+use axum::http::{Request, StatusCode};
+use openproxy::db::Db;
+use openproxy::server::state::AppState;
+use openproxy::types::ApiKey;
+use serde_json::{json, Value};
+use tempfile::tempdir;
+use tower::util::ServiceExt;
+
+const TEST_KEY: &str = "payload-rules-api-test-key";
+
+fn active_key() -> ApiKey {
+    ApiKey {
+        id: "key-1".into(),
+        name: "Local".into(),
+        key: TEST_KEY.into(),
+        machine_id: None,
+        is_active: Some(true),
+        created_at: None,
+        extra: BTreeMap::new(),
+    }
+}
+
+async fn app_state() -> AppState {
+    let temp = tempdir().expect("tempdir");
+    let db = Arc::new(Db::load_from(temp.path()).await.expect("db"));
+    db.update(|state| {
+        state.api_keys = vec![active_key()];
+        state
+            .settings
+            .extra
+            .insert("password".into(), Value::String("hashed-secret".into()));
+        state.settings.require_login = true;
+    })
+    .await
+    .expect("seed db");
+    AppState::new(db)
+}
+
+#[tokio::test]
+async fn get_payload_rules_requires_auth() {
+    let app = openproxy::build_app(app_state().await);
+
+    let unauthenticated = app
+        .oneshot(
+            Request::builder()
+                .uri("/api/settings/payload-rules")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(unauthenticated.status(), StatusCode::UNAUTHORIZED);
+}
+
+#[tokio::test]
+async fn put_payload_rules_persists_and_normalizes() {
+    let app = openproxy::build_app(app_state().await);
+
+    let put = app
+        .clone()
+        .oneshot(
+            Request::builder()
+                .method("PUT")
+                .uri("/api/settings/payload-rules")
+                .header("authorization", format!("Bearer {TEST_KEY}"))
+                .header("content-type", "application/json")
+                .body(Body::from(
+                    json!({
+                        "default": [
+                            {
+                                "models": [{ "name": "gpt-4*" }],
+                                "params": { "temperature": 0.2 }
+                            }
+                        ],
+                        "override": [
+                            {
+                                "models": [{ "name": "o1*", "protocol": "openai" }],
+                                "params": {
+                                    "reasoning_effort": "medium",
+                                    "max_tokens": 4096
+                                }
+                            }
+                        ],
+                        "filter": [
+                            {
+                                "models": [{ "name": "claude-*" }],
+                                "params": ["metadata.user_id"]
+                            }
+                        ],
+                        "defaultRaw": [
+                            // Empty params block — should be dropped by normalize().
+                            { "models": [{ "name": "*" }], "params": {} }
+                        ]
+                    })
+                    .to_string(),
+                ))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(put.status(), StatusCode::OK);
+    let body = axum::body::to_bytes(put.into_body(), 8192).await.unwrap();
+    let json: Value = serde_json::from_slice(&body).unwrap();
+
+    assert_eq!(json["summary"]["default"], 1);
+    assert_eq!(json["summary"]["override"], 1);
+    assert_eq!(json["summary"]["filter"], 1);
+    assert_eq!(json["summary"]["defaultRaw"], 0); // dropped — empty params
+    assert_eq!(
+        json["config"]["override"][0]["params"]["reasoning_effort"],
+        "medium"
+    );
+
+    let get = app
+        .oneshot(
+            Request::builder()
+                .uri("/api/settings/payload-rules")
+                .header("authorization", format!("Bearer {TEST_KEY}"))
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(get.status(), StatusCode::OK);
+    let body = axum::body::to_bytes(get.into_body(), 8192).await.unwrap();
+    let json: Value = serde_json::from_slice(&body).unwrap();
+    assert_eq!(json["summary"]["default"], 1);
+    assert_eq!(json["summary"]["override"], 1);
+}
+
+#[tokio::test]
+async fn system_prompt_round_trip() {
+    let app = openproxy::build_app(app_state().await);
+
+    let put = app
+        .clone()
+        .oneshot(
+            Request::builder()
+                .method("PUT")
+                .uri("/api/settings/system-prompt")
+                .header("authorization", format!("Bearer {TEST_KEY}"))
+                .header("content-type", "application/json")
+                .body(Body::from(
+                    json!({
+                        "mode": "override",
+                        "content": "You are an internal helper."
+                    })
+                    .to_string(),
+                ))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(put.status(), StatusCode::OK);
+    let body = axum::body::to_bytes(put.into_body(), 4096).await.unwrap();
+    let json: Value = serde_json::from_slice(&body).unwrap();
+    assert_eq!(json["mode"], "override");
+    assert_eq!(json["active"], true);
+
+    let get = app
+        .clone()
+        .oneshot(
+            Request::builder()
+                .uri("/api/settings/system-prompt")
+                .header("authorization", format!("Bearer {TEST_KEY}"))
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    let body = axum::body::to_bytes(get.into_body(), 4096).await.unwrap();
+    let json: Value = serde_json::from_slice(&body).unwrap();
+    assert_eq!(json["mode"], "override");
+    assert_eq!(json["content"], "You are an internal helper.");
+
+    // Switching to Off makes it inactive even with content present.
+    let put = app
+        .oneshot(
+            Request::builder()
+                .method("PUT")
+                .uri("/api/settings/system-prompt")
+                .header("authorization", format!("Bearer {TEST_KEY}"))
+                .header("content-type", "application/json")
+                .body(Body::from(json!({ "mode": "off" }).to_string()))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    let body = axum::body::to_bytes(put.into_body(), 4096).await.unwrap();
+    let json: Value = serde_json::from_slice(&body).unwrap();
+    assert_eq!(json["mode"], "off");
+    assert_eq!(json["active"], false);
+}

--- a/web/src/components/PayloadRulesPageClient.tsx
+++ b/web/src/components/PayloadRulesPageClient.tsx
@@ -1,0 +1,459 @@
+"use client";
+
+import { useCallback, useEffect, useMemo, useState } from "react";
+import { Card, Button, CardSkeleton } from "@/shared/components";
+
+// ──────────────────────────────────────────────────────────────────────
+// Types — mirror the Rust backend (src/payload_rules.rs).
+// ──────────────────────────────────────────────────────────────────────
+
+interface ModelSpec {
+  name: string;
+  protocol?: string;
+}
+
+interface MutationRule {
+  models: ModelSpec[];
+  params: Record<string, unknown>;
+}
+
+interface FilterRule {
+  models: ModelSpec[];
+  params: string[];
+}
+
+interface PayloadRulesConfig {
+  default: MutationRule[];
+  override: MutationRule[];
+  filter: FilterRule[];
+  defaultRaw: MutationRule[];
+}
+
+interface PayloadRulesSummary {
+  default: number;
+  override: number;
+  filter: number;
+  defaultRaw: number;
+}
+
+type SystemPromptMode = "off" | "prepend" | "override";
+
+interface SystemPromptConfig {
+  mode: SystemPromptMode;
+  content: string;
+  active?: boolean;
+}
+
+type StatusMessage = { type: "success" | "error" | "info"; text: string };
+
+const EMPTY_CONFIG: PayloadRulesConfig = {
+  default: [],
+  override: [],
+  filter: [],
+  defaultRaw: [],
+};
+const EMPTY_CONFIG_TEXT = JSON.stringify(EMPTY_CONFIG, null, 2);
+
+// Example shown above the editor — copy-paste friendly, mirrors the
+// shape described in PR-A1's commit message.
+const EXAMPLE_CONFIG = `{
+  "default": [
+    { "models": [{ "name": "gpt-4*" }],
+      "params": { "temperature": 0.2 } }
+  ],
+  "override": [
+    { "models": [{ "name": "o1*", "protocol": "openai" }],
+      "params": { "reasoning_effort": "medium", "max_tokens": 4096 } }
+  ],
+  "filter": [
+    { "models": [{ "name": "claude-*" }],
+      "params": ["metadata.user_id"] }
+  ],
+  "defaultRaw": [
+    { "models": [{ "name": "*" }],
+      "params": { "stream_options": { "include_usage": true } } }
+  ]
+}`;
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return !!value && typeof value === "object" && !Array.isArray(value);
+}
+
+function summarize(config: PayloadRulesConfig | null): PayloadRulesSummary {
+  if (!config) return { default: 0, override: 0, filter: 0, defaultRaw: 0 };
+  return {
+    default: config.default?.length ?? 0,
+    override: config.override?.length ?? 0,
+    filter: config.filter?.length ?? 0,
+    defaultRaw: config.defaultRaw?.length ?? 0,
+  };
+}
+
+function StatusAlert({ status }: { status: StatusMessage | null }) {
+  if (!status) return null;
+  const cls =
+    status.type === "success"
+      ? "border-green-300 bg-green-50 text-green-800 dark:border-green-700 dark:bg-green-900/30 dark:text-green-200"
+      : status.type === "error"
+      ? "border-red-300 bg-red-50 text-red-800 dark:border-red-700 dark:bg-red-900/30 dark:text-red-200"
+      : "border-blue-300 bg-blue-50 text-blue-800 dark:border-blue-700 dark:bg-blue-900/30 dark:text-blue-200";
+  return (
+    <div className={`mt-3 rounded-md border px-3 py-2 text-sm ${cls}`}>{status.text}</div>
+  );
+}
+
+// ──────────────────────────────────────────────────────────────────────
+// Payload-rules editor
+// ──────────────────────────────────────────────────────────────────────
+
+function PayloadRulesEditor() {
+  const [editorValue, setEditorValue] = useState<string>(EMPTY_CONFIG_TEXT);
+  const [loading, setLoading] = useState<boolean>(true);
+  const [saving, setSaving] = useState<boolean>(false);
+  const [serverSummary, setServerSummary] = useState<PayloadRulesSummary | null>(null);
+  const [status, setStatus] = useState<StatusMessage | null>(null);
+
+  const parsed = useMemo(() => {
+    try {
+      const value = JSON.parse(editorValue);
+      if (!isRecord(value)) {
+        return { config: null, error: "Top-level value must be a JSON object." };
+      }
+      return { config: value as PayloadRulesConfig, error: null };
+    } catch (err) {
+      const message = err instanceof Error ? err.message : "Invalid JSON";
+      return { config: null, error: message };
+    }
+  }, [editorValue]);
+
+  const localSummary = summarize(parsed.config);
+
+  useEffect(() => {
+    let cancelled = false;
+    (async () => {
+      try {
+        const res = await fetch("/api/settings/payload-rules");
+        if (!res.ok) {
+          throw new Error(`Server returned ${res.status}`);
+        }
+        const data = await res.json();
+        if (cancelled) return;
+        const cfg = (data?.config as PayloadRulesConfig | undefined) ?? EMPTY_CONFIG;
+        setEditorValue(JSON.stringify(cfg, null, 2));
+        if (data?.summary) setServerSummary(data.summary as PayloadRulesSummary);
+      } catch (err) {
+        if (cancelled) return;
+        setStatus({
+          type: "error",
+          text:
+            err instanceof Error
+              ? `Failed to load payload rules: ${err.message}`
+              : "Failed to load payload rules",
+        });
+      } finally {
+        if (!cancelled) setLoading(false);
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  const handleSave = useCallback(async () => {
+    if (parsed.error || !parsed.config) {
+      setStatus({ type: "error", text: parsed.error || "Invalid JSON" });
+      return;
+    }
+    setSaving(true);
+    setStatus(null);
+    try {
+      const res = await fetch("/api/settings/payload-rules", {
+        method: "PUT",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(parsed.config),
+      });
+      if (!res.ok) {
+        const text = await res.text();
+        throw new Error(text || `Server returned ${res.status}`);
+      }
+      const data = await res.json();
+      const cfg = (data?.config as PayloadRulesConfig | undefined) ?? EMPTY_CONFIG;
+      setEditorValue(JSON.stringify(cfg, null, 2));
+      if (data?.summary) setServerSummary(data.summary as PayloadRulesSummary);
+      setStatus({ type: "success", text: "Payload rules saved." });
+    } catch (err) {
+      setStatus({
+        type: "error",
+        text:
+          err instanceof Error
+            ? `Failed to save: ${err.message}`
+            : "Failed to save payload rules",
+      });
+    } finally {
+      setSaving(false);
+    }
+  }, [parsed]);
+
+  const handleReset = useCallback(() => {
+    setEditorValue(EMPTY_CONFIG_TEXT);
+    setStatus({ type: "info", text: "Cleared editor — click Save to persist." });
+  }, []);
+
+  const handleExample = useCallback(() => {
+    setEditorValue(EXAMPLE_CONFIG);
+    setStatus({ type: "info", text: "Loaded example. Click Save to apply." });
+  }, []);
+
+  if (loading) {
+    return <CardSkeleton />;
+  }
+
+  return (
+    <Card className="p-5">
+      <div className="flex items-start justify-between gap-3">
+        <div className="min-w-0">
+          <h2 className="text-base font-bold text-text-main">Payload Rules</h2>
+          <p className="mt-1 text-xs text-text-muted">
+            Apply request transformations to chat completions based on model name. Four
+            rule kinds (<code>default</code>, <code>override</code>, <code>filter</code>,
+            <code>defaultRaw</code>) match against the request&apos;s <code>model</code> field
+            via glob (<code>*</code>, <code>?</code>).
+          </p>
+        </div>
+        <div className="flex gap-2">
+          <Button size="sm" variant="ghost" onClick={handleExample}>
+            Load example
+          </Button>
+          <Button size="sm" variant="ghost" onClick={handleReset}>
+            Clear
+          </Button>
+        </div>
+      </div>
+
+      <SummaryRow
+        label="On-disk (last saved)"
+        summary={serverSummary ?? { default: 0, override: 0, filter: 0, defaultRaw: 0 }}
+        tone="muted"
+      />
+      <SummaryRow label="Editor (unsaved)" summary={localSummary} tone="primary" />
+
+      <textarea
+        className="mt-3 h-72 w-full resize-y rounded-md border border-border bg-bg-subtle p-3 font-mono text-xs leading-relaxed text-text-main focus:border-primary focus:outline-none"
+        value={editorValue}
+        onChange={(e) => setEditorValue(e.target.value)}
+        spellCheck={false}
+        aria-label="Payload rules JSON editor"
+      />
+
+      {parsed.error ? (
+        <div className="mt-2 rounded-md border border-red-300 bg-red-50 px-3 py-2 text-xs text-red-800 dark:border-red-700 dark:bg-red-900/30 dark:text-red-200">
+          JSON error: {parsed.error}
+        </div>
+      ) : (
+        <div className="mt-2 text-xs text-text-muted">JSON is valid.</div>
+      )}
+
+      <div className="mt-4 flex items-center justify-end gap-2">
+        <Button
+          variant="primary"
+          onClick={handleSave}
+          disabled={!!parsed.error || saving}
+        >
+          {saving ? "Saving…" : "Save"}
+        </Button>
+      </div>
+
+      <StatusAlert status={status} />
+    </Card>
+  );
+}
+
+function SummaryRow({
+  label,
+  summary,
+  tone,
+}: {
+  label: string;
+  summary: PayloadRulesSummary;
+  tone: "muted" | "primary";
+}) {
+  const pill = tone === "primary" ? "bg-primary/10 text-primary" : "bg-black/5 text-text-muted dark:bg-white/5";
+  return (
+    <div className="mt-3 flex flex-wrap items-center gap-2 text-xs">
+      <span className="text-text-muted">{label}:</span>
+      <span className={`rounded-full px-2 py-0.5 ${pill}`}>default {summary.default}</span>
+      <span className={`rounded-full px-2 py-0.5 ${pill}`}>override {summary.override}</span>
+      <span className={`rounded-full px-2 py-0.5 ${pill}`}>filter {summary.filter}</span>
+      <span className={`rounded-full px-2 py-0.5 ${pill}`}>defaultRaw {summary.defaultRaw}</span>
+    </div>
+  );
+}
+
+// ──────────────────────────────────────────────────────────────────────
+// System-prompt override
+// ──────────────────────────────────────────────────────────────────────
+
+function SystemPromptOverride() {
+  const [config, setConfig] = useState<SystemPromptConfig>({ mode: "off", content: "" });
+  const [loading, setLoading] = useState<boolean>(true);
+  const [saving, setSaving] = useState<boolean>(false);
+  const [status, setStatus] = useState<StatusMessage | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+    (async () => {
+      try {
+        const res = await fetch("/api/settings/system-prompt");
+        if (!res.ok) throw new Error(`Server returned ${res.status}`);
+        const data = await res.json();
+        if (cancelled) return;
+        setConfig({
+          mode: (data?.mode as SystemPromptMode) ?? "off",
+          content: typeof data?.content === "string" ? data.content : "",
+          active: !!data?.active,
+        });
+      } catch (err) {
+        if (cancelled) return;
+        setStatus({
+          type: "error",
+          text:
+            err instanceof Error
+              ? `Failed to load system prompt: ${err.message}`
+              : "Failed to load system prompt",
+        });
+      } finally {
+        if (!cancelled) setLoading(false);
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  const handleSave = useCallback(async () => {
+    setSaving(true);
+    setStatus(null);
+    try {
+      const res = await fetch("/api/settings/system-prompt", {
+        method: "PUT",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ mode: config.mode, content: config.content }),
+      });
+      if (!res.ok) {
+        const text = await res.text();
+        throw new Error(text || `Server returned ${res.status}`);
+      }
+      const data = await res.json();
+      setConfig({
+        mode: (data?.mode as SystemPromptMode) ?? "off",
+        content: typeof data?.content === "string" ? data.content : "",
+        active: !!data?.active,
+      });
+      setStatus({ type: "success", text: "System prompt saved." });
+    } catch (err) {
+      setStatus({
+        type: "error",
+        text:
+          err instanceof Error
+            ? `Failed to save: ${err.message}`
+            : "Failed to save system prompt",
+      });
+    } finally {
+      setSaving(false);
+    }
+  }, [config.mode, config.content]);
+
+  if (loading) {
+    return <CardSkeleton />;
+  }
+
+  const modeDescriptions: Record<SystemPromptMode, string> = {
+    off: "Pass through caller's system messages unchanged.",
+    prepend: "Insert this prompt as the first system message ONLY when the caller did not send one.",
+    override: "Replace any caller-supplied system message with this prompt.",
+  };
+
+  return (
+    <Card className="p-5">
+      <div className="flex items-start justify-between gap-3">
+        <div className="min-w-0">
+          <h2 className="text-base font-bold text-text-main">System Prompt Override</h2>
+          <p className="mt-1 text-xs text-text-muted">
+            Inject or replace the <code>system</code> message on every chat
+            completions request. Applied before payload rules.
+          </p>
+        </div>
+        <span
+          className={`rounded-full px-2 py-0.5 text-[10px] font-semibold ${
+            config.active
+              ? "bg-green-100 text-green-800 dark:bg-green-900/40 dark:text-green-200"
+              : "bg-black/5 text-text-muted dark:bg-white/5"
+          }`}
+        >
+          {config.active ? "ACTIVE" : "INACTIVE"}
+        </span>
+      </div>
+
+      <fieldset className="mt-4 space-y-2">
+        {(Object.keys(modeDescriptions) as SystemPromptMode[]).map((mode) => (
+          <label
+            key={mode}
+            className={`flex cursor-pointer items-start gap-3 rounded-md border p-3 text-sm transition-colors ${
+              config.mode === mode
+                ? "border-primary bg-primary/5"
+                : "border-border bg-bg-subtle hover:border-primary/40"
+            }`}
+          >
+            <input
+              type="radio"
+              name="system-prompt-mode"
+              value={mode}
+              checked={config.mode === mode}
+              onChange={() => setConfig((prev) => ({ ...prev, mode }))}
+              className="mt-0.5"
+            />
+            <div className="min-w-0">
+              <div className="font-semibold capitalize text-text-main">{mode}</div>
+              <div className="text-xs text-text-muted">{modeDescriptions[mode]}</div>
+            </div>
+          </label>
+        ))}
+      </fieldset>
+
+      <textarea
+        className="mt-4 h-40 w-full resize-y rounded-md border border-border bg-bg-subtle p-3 font-mono text-xs leading-relaxed text-text-main focus:border-primary focus:outline-none"
+        value={config.content}
+        onChange={(e) => setConfig((prev) => ({ ...prev, content: e.target.value }))}
+        placeholder="Enter the system prompt content to inject / override."
+        disabled={config.mode === "off"}
+        aria-label="System prompt content"
+      />
+
+      <div className="mt-4 flex items-center justify-end gap-2">
+        <Button variant="primary" onClick={handleSave} disabled={saving}>
+          {saving ? "Saving…" : "Save"}
+        </Button>
+      </div>
+
+      <StatusAlert status={status} />
+    </Card>
+  );
+}
+
+export default function PayloadRulesPageClient() {
+  return (
+    <div className="mx-auto flex max-w-5xl flex-col gap-6 p-4 sm:p-6">
+      <header>
+        <h1 className="text-2xl font-bold text-text-main">Payload Rules &amp; System Prompt</h1>
+        <p className="mt-1 text-sm text-text-muted">
+          Tweak request payloads and inject system prompts at the proxy layer —
+          inspired by OmniRoute&apos;s <code>payloadRules</code> and{" "}
+          <code>system-prompt</code> APIs.
+        </p>
+      </header>
+
+      <SystemPromptOverride />
+      <PayloadRulesEditor />
+    </div>
+  );
+}

--- a/web/src/pages/dashboard/payload-rules/index.astro
+++ b/web/src/pages/dashboard/payload-rules/index.astro
@@ -1,0 +1,10 @@
+---
+import Layout from '@/layouts/Layout.astro';
+import PayloadRulesPageClient from '@/components/PayloadRulesPageClient';
+import DashboardLayout from '@/shared/components/layouts/DashboardLayout';
+---
+<Layout>
+  <DashboardLayout client:only="react">
+    <PayloadRulesPageClient client:only="react" />
+  </DashboardLayout>
+</Layout>

--- a/web/src/shared/components/Sidebar.tsx
+++ b/web/src/shared/components/Sidebar.tsx
@@ -41,6 +41,7 @@ const navItems: NavItem[] = [
   { href: "/dashboard/endpoint", label: "Endpoint", icon: "api" },
   { href: "/dashboard/providers", label: "Providers", icon: "dns" },
   { href: "/dashboard/combos", label: "Combos", icon: "layers" },
+  { href: "/dashboard/payload-rules", label: "Payload Rules", icon: "tune" },
   { href: "/dashboard/usage", label: "Usage", icon: "bar_chart" },
   { href: "/dashboard/quota", label: "Quota Tracker", icon: "data_usage" },
   { href: "/dashboard/mitm", label: "MITM", icon: "security" },


### PR DESCRIPTION
## Summary

PR A1 of Sprint A (A1 → A2 → A3 per [previous plan](https://github.com/quangdang46/openproxy/pull/56#issuecomment-3201024225)). Ports OmniRoute's `payloadRules` middleware + `system-prompt` override into openproxy.

**What it does:** lets you transform any outgoing chat-completions request body based on the model name (wildcard match), and inject/replace the `system` message globally.

- **`default`** rules — fill in missing params (e.g. set `temperature: 0.2` for `gpt-4*` if caller didn't send one).
- **`override`** rules — force params regardless of caller value (e.g. force `reasoning_effort: medium` for `o1*`).
- **`filter`** rules — strip JSON dot-paths from the body (e.g. drop `metadata.user_id` for `claude-*`).
- **`defaultRaw`** rules — same as `default` but applies to the upstream-format payload (after translator). Currently stored only — wired in once translator emits a hook (TODO).
- **System prompt** — `off` / `prepend` (only if no system message) / `override` (replace any caller-supplied system message). Works for both OpenAI `messages[]` shape and Anthropic top-level `system` field.

**Inspired by:** [OmniRoute `open-sse/services/payloadRules.ts`](https://github.com/diegosouzapw/OmniRoute) + `api/settings/{payload-rules,system-prompt}/route.ts`. Ported to Rust/Axum, persisted in `db.json` under `settings.payloadRules` and `settings.systemPrompt` (camelCase via serde).

**Files:**
- `src/payload_rules.rs` (new) — schema types, wildcard matcher (DP-based, case-insensitive `*`/`?`), rule applier, system-prompt applier. **10 unit tests.**
- `src/types/mod.rs` — `payload_rules` + `system_prompt` fields on `Settings` (`#[serde(default)]`, normalized on save).
- `src/server/api/settings_payload_rules.rs` (new) — `GET`/`PUT /api/settings/payload-rules` + `/api/settings/system-prompt`. Auth: dashboard session or management-API key (same as existing settings routes).
- `src/server/api/chat.rs` — applies system_prompt then payload_rules right after model validation, before combo/direct dispatch (both branches see the transformed body).
- `web/src/pages/dashboard/payload-rules/index.astro` + `web/src/components/PayloadRulesPageClient.tsx` (new) — dashboard tab: textarea JSON editor with live parse/summary + system-prompt mode picker. Loads example config on demand.
- `web/src/shared/components/Sidebar.tsx` — nav entry between Combos and Usage.
- `tests/payload_rules_api.rs` (new) — **3 integration tests** covering auth, persistence + normalization, system-prompt round-trip.

## Review & Testing Checklist for Human

- [ ] Open `/dashboard/payload-rules`, click "Load example", click Save, refresh — config persists, summary shows `default 1 / override 1 / filter 1 / defaultRaw 1`.
- [ ] On the same page, switch System Prompt to **Override**, paste content, save. Issue a chat-completions request and verify your overriding `system` message appears in the upstream call (use MITM / Observability page).
- [ ] Set a `default` rule for `gpt-4*` with `{"temperature": 0.2}`, send a request without `temperature` → upstream should see `0.2`. Send one *with* `temperature: 0.9` → that wins (default rule does NOT overwrite).
- [ ] Set an `override` rule with `{"max_tokens": 100}` for `*` → every request gets `max_tokens: 100` regardless of caller value.
- [ ] Set a `filter` rule for `*` with `["metadata.user_id"]` → upstream payload no longer contains that path.
- [ ] Old `db.json` files without `payloadRules`/`systemPrompt` fields still load (forward-compat via `#[serde(default)]`).

### Notes

**Scope kept minimal on purpose:**
- `defaultRaw` rules are stored but not yet applied to upstream-format payload — needs a translator hook that we don't currently emit at this layer. Stub left in place; will be wired in a follow-up when A3 (combo wizard refactor) lands.
- Protocol filtering on rules (the `protocol` field) is supported by the matcher but `chat.rs` passes `None` for protocol today — gets wired when `RequestPlan` exposes the upstream provider format here. Doesn't break anything; rules without a `protocol` field still match.
- Used a plain `<textarea>` instead of Monaco editor (despite `@monaco-editor/react` being in deps) to keep the dashboard bundle small and the page first-paint fast.

**Test status:**
- 626 lib unit tests pass (10 new in `payload_rules`, 2 new in `settings_payload_rules`, 614 pre-existing).
- 3 new integration tests in `tests/payload_rules_api.rs` pass.
- Pre-existing `codex_executor` tests still fail with TCP connect timeout to `api.openai.com` — same failure mode as on PR #56's CI run, unrelated to this PR.

**Sequencing:** if this lands cleanly, A2 (auto-backup) is next, then A3 (combo wizard refactor). Each is independent and targets `main`.


Link to Devin session: https://app.devin.ai/sessions/4137db57f49a49299e42ad42627d3c81
Requested by: @quangdang46