### PR TITLE
feat(db-backups): port OmniRoute db-backups auto-snapshot + retention + restore

### DIFF
--- a/src/db/backups.rs
+++ b/src/db/backups.rs
@@ -1,0 +1,589 @@
+//! Database backup snapshot/restore operations for openproxy.
+//!
+//! Ported from OmniRoute's `src/lib/db/backup.ts` and adapted for the JSON
+//! `db.json` store used by openproxy. Each snapshot is a single timestamped
+//! file under `${DATA_DIR}/db_backups/` of the form
+//! `db_<utc-iso-no-colons>_<reason>.json`.
+//!
+//! Retention is governed by two environment variables:
+//! * `DB_BACKUP_MAX_FILES`   — keep at most N newest snapshots (default 20)
+//! * `DB_BACKUP_RETENTION_DAYS` — also drop snapshots older than D days
+//!   (default 0 = disabled, only the max-files limit applies)
+//!
+//! The auto-backup loop can be disabled with `DISABLE_AUTO_BACKUP=1`. Manual
+//! and pre-restore/pre-import snapshots are never auto-disabled.
+
+use std::path::{Path, PathBuf};
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::time::SystemTime;
+
+use chrono::{DateTime, SecondsFormat, Utc};
+use serde::Serialize;
+use serde_json::Value;
+use tokio::fs;
+
+use crate::types::AppDb;
+
+const BACKUP_THROTTLE_MS: u64 = 60 * 60 * 1000; // 60 minutes
+const DEFAULT_MAX_FILES: usize = 20;
+const DEFAULT_RETENTION_DAYS: u64 = 0;
+/// Smallest plausible db.json — "{}\n" is 3 bytes. Anything smaller is treated
+/// as corruption and skipped.
+const MIN_BACKUP_BYTES: u64 = 3;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum BackupReason {
+    Auto,
+    Manual,
+    PreRestore,
+    PreImport,
+}
+
+impl BackupReason {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            BackupReason::Auto => "auto",
+            BackupReason::Manual => "manual",
+            BackupReason::PreRestore => "pre-restore",
+            BackupReason::PreImport => "pre-import",
+        }
+    }
+
+    fn from_str(s: &str) -> Option<Self> {
+        match s {
+            "auto" => Some(BackupReason::Auto),
+            "manual" => Some(BackupReason::Manual),
+            "pre-restore" => Some(BackupReason::PreRestore),
+            "pre-import" => Some(BackupReason::PreImport),
+            _ => None,
+        }
+    }
+
+    fn skips_throttle(self) -> bool {
+        matches!(
+            self,
+            BackupReason::Manual | BackupReason::PreRestore | BackupReason::PreImport
+        )
+    }
+}
+
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct BackupInfo {
+    pub id: String,
+    pub filename: String,
+    pub created_at: String,
+    pub size: u64,
+    pub reason: String,
+    pub provider_count: usize,
+    pub combo_count: usize,
+    pub api_key_count: usize,
+}
+
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct CleanupResult {
+    pub deleted_files: usize,
+    pub kept_files: usize,
+    pub max_files: usize,
+    pub retention_days: u64,
+}
+
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct RestoreResult {
+    pub restored: bool,
+    pub backup_id: String,
+    pub provider_count: usize,
+    pub combo_count: usize,
+    pub api_key_count: usize,
+}
+
+pub struct BackupManager {
+    backup_dir: PathBuf,
+    db_path: PathBuf,
+    last_backup_ms: AtomicU64,
+}
+
+impl BackupManager {
+    pub fn new(data_dir: &Path) -> Self {
+        Self {
+            backup_dir: data_dir.join("db_backups"),
+            db_path: data_dir.join("db.json"),
+            last_backup_ms: AtomicU64::new(0),
+        }
+    }
+
+    pub fn backup_dir(&self) -> &Path {
+        &self.backup_dir
+    }
+
+    pub fn max_files() -> usize {
+        std::env::var("DB_BACKUP_MAX_FILES")
+            .ok()
+            .and_then(|v| v.parse::<usize>().ok())
+            .filter(|n| *n > 0)
+            .unwrap_or(DEFAULT_MAX_FILES)
+    }
+
+    pub fn retention_days() -> u64 {
+        std::env::var("DB_BACKUP_RETENTION_DAYS")
+            .ok()
+            .and_then(|v| v.parse::<u64>().ok())
+            .unwrap_or(DEFAULT_RETENTION_DAYS)
+    }
+
+    pub fn is_auto_disabled() -> bool {
+        std::env::var("DISABLE_AUTO_BACKUP")
+            .ok()
+            .map(|v| {
+                matches!(
+                    v.trim().to_ascii_lowercase().as_str(),
+                    "1" | "true" | "yes" | "on"
+                )
+            })
+            .unwrap_or(false)
+    }
+
+    /// Create a snapshot of `db.json` under `db_backups/`. Returns `None`
+    /// if the backup was throttled or skipped (e.g. db.json is missing or
+    /// suspiciously small).
+    pub async fn create(&self, reason: BackupReason) -> anyhow::Result<Option<BackupInfo>> {
+        if reason == BackupReason::Auto && Self::is_auto_disabled() {
+            return Ok(None);
+        }
+
+        if !fs::try_exists(&self.db_path).await? {
+            return Ok(None);
+        }
+
+        let stat = fs::metadata(&self.db_path).await?;
+        if stat.len() < MIN_BACKUP_BYTES {
+            tracing::warn!(
+                target: "openproxy::db::backups",
+                size = stat.len(),
+                "skipping backup — db.json too small to be valid"
+            );
+            return Ok(None);
+        }
+
+        if !reason.skips_throttle() {
+            let now_ms = now_millis();
+            let last = self.last_backup_ms.load(Ordering::Relaxed);
+            if last > 0 && now_ms.saturating_sub(last) < BACKUP_THROTTLE_MS {
+                return Ok(None);
+            }
+            self.last_backup_ms.store(now_ms, Ordering::Relaxed);
+        } else {
+            // Manual/pre-* still updates the timestamp so the next auto
+            // throttle window starts now.
+            self.last_backup_ms.store(now_millis(), Ordering::Relaxed);
+        }
+
+        fs::create_dir_all(&self.backup_dir).await?;
+
+        // Shrink-detection guard for auto backups only — never block a manual
+        // or pre-* operator action.
+        if reason == BackupReason::Auto {
+            if let Some(latest) = self.latest_backup_size().await? {
+                if latest > MIN_BACKUP_BYTES && stat.len() < latest / 2 {
+                    tracing::warn!(
+                        target: "openproxy::db::backups",
+                        previous = latest,
+                        current = stat.len(),
+                        "skipping backup — db.json shrank by >50% since last snapshot"
+                    );
+                    return Ok(None);
+                }
+            }
+        }
+
+        let timestamp = Utc::now().to_rfc3339_opts(SecondsFormat::Millis, true);
+        let safe_timestamp = timestamp.replace([':', '.'], "-");
+        let filename = format!("db_{}_{}.json", safe_timestamp, reason.as_str());
+        let dest = self.backup_dir.join(&filename);
+
+        fs::copy(&self.db_path, &dest).await?;
+
+        let info = describe_backup(&self.backup_dir, &filename).await?;
+        tracing::info!(
+            target: "openproxy::db::backups",
+            id = %info.id,
+            size = info.size,
+            reason = %info.reason,
+            "created db backup"
+        );
+
+        // Best-effort retention pass after each new snapshot.
+        if reason != BackupReason::PreRestore && reason != BackupReason::PreImport {
+            let _ = self
+                .cleanup(Self::max_files(), Self::retention_days())
+                .await;
+        }
+
+        Ok(Some(info))
+    }
+
+    /// List backup files sorted by `created_at` descending (newest first).
+    pub async fn list(&self) -> anyhow::Result<Vec<BackupInfo>> {
+        if !fs::try_exists(&self.backup_dir).await? {
+            return Ok(Vec::new());
+        }
+
+        let mut entries = Vec::new();
+        let mut read_dir = fs::read_dir(&self.backup_dir).await?;
+        while let Some(entry) = read_dir.next_entry().await? {
+            let name = entry.file_name();
+            let Some(name_str) = name.to_str() else {
+                continue;
+            };
+            if !is_backup_filename(name_str) {
+                continue;
+            }
+            match describe_backup(&self.backup_dir, name_str).await {
+                Ok(info) => entries.push(info),
+                Err(err) => {
+                    tracing::warn!(
+                        target: "openproxy::db::backups",
+                        file = %name_str,
+                        error = %err,
+                        "skipping unreadable backup file"
+                    );
+                }
+            }
+        }
+
+        entries.sort_by(|a, b| b.created_at.cmp(&a.created_at));
+        Ok(entries)
+    }
+
+    /// Restore a specific backup. Takes a pre-restore safety snapshot first,
+    /// validates the backup is valid JSON, then atomically replaces
+    /// `db.json`. The caller is responsible for reloading the in-memory DB.
+    pub async fn read_backup(&self, backup_id: &str) -> anyhow::Result<AppDb> {
+        validate_backup_id(backup_id)?;
+        let backup_path = self.backup_dir.join(backup_id);
+
+        if !fs::try_exists(&backup_path).await? {
+            anyhow::bail!("Backup not found: {backup_id}");
+        }
+
+        let bytes = fs::read(&backup_path).await?;
+        let parsed: Value = serde_json::from_slice(&bytes)
+            .map_err(|e| anyhow::anyhow!("Backup file is not valid JSON: {e}"))?;
+        if !parsed.is_object() {
+            anyhow::bail!("Backup root must be a JSON object");
+        }
+        Ok(AppDb::from_json_value(parsed))
+    }
+
+    /// Delete a single backup file.
+    pub async fn delete(&self, backup_id: &str) -> anyhow::Result<()> {
+        validate_backup_id(backup_id)?;
+        let path = self.backup_dir.join(backup_id);
+        if fs::try_exists(&path).await? {
+            fs::remove_file(&path).await?;
+            tracing::info!(
+                target: "openproxy::db::backups",
+                id = %backup_id,
+                "deleted db backup"
+            );
+        }
+        Ok(())
+    }
+
+    /// Prune backups using `max_files` newest + `retention_days` cutoff.
+    /// Always keeps at least the single newest file even when limits are 0.
+    pub async fn cleanup(
+        &self,
+        max_files: usize,
+        retention_days: u64,
+    ) -> anyhow::Result<CleanupResult> {
+        let entries = self.list().await?;
+        let total = entries.len();
+        let max_files = max_files.max(1);
+
+        let cutoff_ms: Option<i64> = if retention_days > 0 {
+            let cutoff = Utc::now() - chrono::Duration::days(retention_days as i64);
+            Some(cutoff.timestamp_millis())
+        } else {
+            None
+        };
+
+        let mut deleted = 0usize;
+        for (idx, info) in entries.iter().enumerate() {
+            let exceeds_max = idx >= max_files;
+            let expired = cutoff_ms
+                .map(|cutoff| {
+                    DateTime::parse_from_rfc3339(&info.created_at)
+                        .map(|dt| dt.timestamp_millis() < cutoff)
+                        .unwrap_or(false)
+                })
+                .unwrap_or(false);
+
+            if !exceeds_max && !expired {
+                continue;
+            }
+            // Never let the prune pass delete the most recent snapshot.
+            if idx == 0 {
+                continue;
+            }
+
+            let path = self.backup_dir.join(&info.id);
+            if let Err(err) = fs::remove_file(&path).await {
+                tracing::warn!(
+                    target: "openproxy::db::backups",
+                    id = %info.id,
+                    error = %err,
+                    "failed to delete backup"
+                );
+                continue;
+            }
+            deleted += 1;
+        }
+
+        Ok(CleanupResult {
+            deleted_files: deleted,
+            kept_files: total.saturating_sub(deleted),
+            max_files,
+            retention_days,
+        })
+    }
+
+    async fn latest_backup_size(&self) -> anyhow::Result<Option<u64>> {
+        if !fs::try_exists(&self.backup_dir).await? {
+            return Ok(None);
+        }
+        let mut latest_mtime: Option<SystemTime> = None;
+        let mut latest_size: Option<u64> = None;
+        let mut read_dir = fs::read_dir(&self.backup_dir).await?;
+        while let Some(entry) = read_dir.next_entry().await? {
+            let name = entry.file_name();
+            let Some(name_str) = name.to_str() else {
+                continue;
+            };
+            if !is_backup_filename(name_str) {
+                continue;
+            }
+            let meta = match entry.metadata().await {
+                Ok(m) => m,
+                Err(_) => continue,
+            };
+            let mtime = meta.modified().unwrap_or(SystemTime::UNIX_EPOCH);
+            if latest_mtime.is_none_or(|prev| mtime > prev) {
+                latest_mtime = Some(mtime);
+                latest_size = Some(meta.len());
+            }
+        }
+        Ok(latest_size)
+    }
+}
+
+fn is_backup_filename(name: &str) -> bool {
+    name.starts_with("db_") && name.ends_with(".json")
+}
+
+fn parse_reason_from_filename(name: &str) -> &str {
+    // expected: db_<timestamp>_<reason>.json
+    let stem = name.trim_end_matches(".json");
+    if let Some(rest) = stem.strip_prefix("db_") {
+        if let Some(idx) = rest.rfind('_') {
+            let candidate = &rest[idx + 1..];
+            if BackupReason::from_str(candidate).is_some() {
+                return match candidate {
+                    "auto" => "auto",
+                    "manual" => "manual",
+                    "pre-restore" => "pre-restore",
+                    "pre-import" => "pre-import",
+                    _ => "unknown",
+                };
+            }
+        }
+    }
+    "unknown"
+}
+
+fn validate_backup_id(id: &str) -> anyhow::Result<()> {
+    if !is_backup_filename(id) {
+        anyhow::bail!("Invalid backup id");
+    }
+    if id.contains('/') || id.contains('\\') || id.contains("..") {
+        anyhow::bail!("Invalid backup id: path traversal detected");
+    }
+    Ok(())
+}
+
+async fn describe_backup(backup_dir: &Path, filename: &str) -> anyhow::Result<BackupInfo> {
+    let path = backup_dir.join(filename);
+    let meta = fs::metadata(&path).await?;
+    let mtime = meta.modified().unwrap_or(SystemTime::UNIX_EPOCH);
+    let mtime_chrono = DateTime::<Utc>::from(mtime);
+    let created_at = mtime_chrono.to_rfc3339_opts(SecondsFormat::Millis, true);
+    let reason = parse_reason_from_filename(filename).to_string();
+
+    // Cheap object count: parse JSON only when describing list entries.
+    let (provider_count, combo_count, api_key_count) = match fs::read(&path).await {
+        Ok(bytes) => match serde_json::from_slice::<Value>(&bytes) {
+            Ok(value) => count_objects(&value),
+            Err(_) => (0, 0, 0),
+        },
+        Err(_) => (0, 0, 0),
+    };
+
+    Ok(BackupInfo {
+        id: filename.to_string(),
+        filename: filename.to_string(),
+        created_at,
+        size: meta.len(),
+        reason,
+        provider_count,
+        combo_count,
+        api_key_count,
+    })
+}
+
+fn count_objects(value: &Value) -> (usize, usize, usize) {
+    let providers = value
+        .get("providerConnections")
+        .and_then(|v| v.as_array())
+        .map(|a| a.len())
+        .unwrap_or(0);
+    let combos = value
+        .get("combos")
+        .and_then(|v| v.as_array())
+        .map(|a| a.len())
+        .unwrap_or(0);
+    let api_keys = value
+        .get("apiKeys")
+        .and_then(|v| v.as_array())
+        .map(|a| a.len())
+        .unwrap_or(0);
+    (providers, combos, api_keys)
+}
+
+fn now_millis() -> u64 {
+    SystemTime::now()
+        .duration_since(SystemTime::UNIX_EPOCH)
+        .map(|d| d.as_millis() as u64)
+        .unwrap_or(0)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tempfile::tempdir;
+
+    fn seed_app_db() -> AppDb {
+        let mut db = AppDb::default();
+        // Make it non-trivial so backups aren't skipped.
+        db.api_keys = vec![crate::types::ApiKey {
+            id: "k1".into(),
+            name: "test".into(),
+            key: "ak".into(),
+            machine_id: None,
+            is_active: Some(true),
+            created_at: None,
+            extra: std::collections::BTreeMap::new(),
+        }];
+        db
+    }
+
+    async fn write_db(path: &Path, db: &AppDb) {
+        let bytes = serde_json::to_vec_pretty(db).unwrap();
+        fs::write(path, bytes).await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn create_then_list_then_restore_round_trip() {
+        let dir = tempdir().unwrap();
+        let db_path = dir.path().join("db.json");
+        write_db(&db_path, &seed_app_db()).await;
+
+        let mgr = BackupManager::new(dir.path());
+        let info = mgr
+            .create(BackupReason::Manual)
+            .await
+            .unwrap()
+            .expect("backup created");
+        assert!(info.id.starts_with("db_"));
+        assert!(info.id.ends_with("_manual.json"));
+        assert_eq!(info.api_key_count, 1);
+
+        let list = mgr.list().await.unwrap();
+        assert_eq!(list.len(), 1);
+        assert_eq!(list[0].id, info.id);
+
+        let restored = mgr.read_backup(&info.id).await.unwrap();
+        assert_eq!(restored.api_keys.len(), 1);
+    }
+
+    #[tokio::test]
+    async fn auto_backup_is_throttled() {
+        let dir = tempdir().unwrap();
+        let db_path = dir.path().join("db.json");
+        write_db(&db_path, &seed_app_db()).await;
+
+        let mgr = BackupManager::new(dir.path());
+        let first = mgr.create(BackupReason::Auto).await.unwrap();
+        assert!(first.is_some());
+        let second = mgr.create(BackupReason::Auto).await.unwrap();
+        assert!(second.is_none(), "auto backup should be throttled");
+    }
+
+    #[tokio::test]
+    async fn manual_backup_skips_throttle() {
+        let dir = tempdir().unwrap();
+        let db_path = dir.path().join("db.json");
+        write_db(&db_path, &seed_app_db()).await;
+
+        let mgr = BackupManager::new(dir.path());
+        let first = mgr.create(BackupReason::Auto).await.unwrap().unwrap();
+        // Manual immediately after auto must still succeed.
+        let second = mgr
+            .create(BackupReason::Manual)
+            .await
+            .unwrap()
+            .expect("manual backup");
+        assert_ne!(first.id, second.id);
+    }
+
+    #[tokio::test]
+    async fn cleanup_respects_max_files() {
+        let dir = tempdir().unwrap();
+        let db_path = dir.path().join("db.json");
+        write_db(&db_path, &seed_app_db()).await;
+        let mgr = BackupManager::new(dir.path());
+
+        // Manual backups don't share the auto throttle; create 5 of them.
+        for _ in 0..5 {
+            mgr.create(BackupReason::Manual).await.unwrap();
+            // Tiny sleep so each timestamp differs.
+            tokio::time::sleep(std::time::Duration::from_millis(2)).await;
+        }
+        let pre = mgr.list().await.unwrap();
+        assert_eq!(pre.len(), 5);
+
+        let result = mgr.cleanup(2, 0).await.unwrap();
+        assert_eq!(result.deleted_files, 3);
+        let post = mgr.list().await.unwrap();
+        assert_eq!(post.len(), 2);
+    }
+
+    #[tokio::test]
+    async fn rejects_path_traversal() {
+        let dir = tempdir().unwrap();
+        let mgr = BackupManager::new(dir.path());
+        assert!(mgr.delete("../etc/passwd").await.is_err());
+        assert!(mgr.read_backup("../db.json").await.is_err());
+    }
+
+    #[tokio::test]
+    async fn skips_when_db_too_small() {
+        let dir = tempdir().unwrap();
+        let db_path = dir.path().join("db.json");
+        fs::write(&db_path, b"{").await.unwrap();
+        let mgr = BackupManager::new(dir.path());
+        let result = mgr.create(BackupReason::Manual).await.unwrap();
+        assert!(result.is_none(), "tiny db.json must not be backed up");
+    }
+}

--- a/src/db/mod.rs
+++ b/src/db/mod.rs
@@ -10,6 +10,7 @@ use uuid::Uuid;
 
 use crate::types::{AppDb, Combo, ModelAliasTarget, ProviderConnection, ProviderNode, UsageDb};
 
+pub mod backups;
 pub mod watcher;
 
 #[derive(Debug, Clone, Default)]
@@ -153,6 +154,22 @@ impl Db {
         write_json_atomic(&self.usage_path, &next).await?;
         let next = Arc::new(next);
         self.usage_snapshot.store(next.clone());
+        Ok(next)
+    }
+
+    /// Atomically replace the in-memory and on-disk app db with the value
+    /// produced by `make_next`. Used by the backup-restore / import flows
+    /// where the entire payload comes from a foreign snapshot.
+    pub async fn replace_app_db<F>(&self, make_next: F) -> anyhow::Result<Arc<AppDb>>
+    where
+        F: FnOnce() -> AppDb,
+    {
+        let _guard = self.write_lock.write().await;
+        let mut next = make_next();
+        next.normalize();
+        write_json_atomic(&self.db_path, &next).await?;
+        let next = Arc::new(next);
+        self.snapshot.store(next.clone());
         Ok(next)
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -373,6 +373,7 @@ async fn main() -> anyhow::Result<()> {
     seed_default_api_key_if_missing(&db).await?;
     let db = Arc::new(db);
     spawn_watcher(db.clone());
+    spawn_auto_backup(db.clone());
     let state = AppState::new(db)
         .with_dashboard_sidecar_url(cli.dashboard_sidecar_url.clone())
         .with_web_dir(cli.web_dir.clone());
@@ -445,6 +446,42 @@ fn is_stdout_tty() -> bool {
     // Conservative default on non-Unix: assume interactive. Users on Windows
     // can opt out with --no-open if needed.
     true
+}
+
+/// Background task that snapshots `db.json` once per hour. The throttle and
+/// retention are enforced inside `BackupManager::create` / `cleanup`, so the
+/// loop just nudges the manager on a fixed interval. Honors
+/// `DISABLE_AUTO_BACKUP=1`.
+fn spawn_auto_backup(db: Arc<Db>) {
+    use openproxy::db::backups::{BackupManager, BackupReason};
+
+    if BackupManager::is_auto_disabled() {
+        tracing::info!(target: "openproxy::db::backups", "auto-backup disabled via DISABLE_AUTO_BACKUP");
+        return;
+    }
+
+    tokio::spawn(async move {
+        // Small startup delay so the very first request doesn't compete with
+        // a fresh-DB snapshot.
+        tokio::time::sleep(std::time::Duration::from_secs(30)).await;
+        let mgr = BackupManager::new(&db.data_dir);
+        loop {
+            match mgr.create(BackupReason::Auto).await {
+                Ok(Some(info)) => tracing::debug!(
+                    target: "openproxy::db::backups",
+                    id = %info.id,
+                    "auto backup created"
+                ),
+                Ok(None) => {}
+                Err(err) => tracing::warn!(
+                    target: "openproxy::db::backups",
+                    error = %err,
+                    "auto backup failed"
+                ),
+            }
+            tokio::time::sleep(std::time::Duration::from_secs(60 * 60)).await;
+        }
+    });
 }
 
 async fn seed_default_api_key_if_missing(db: &Db) -> anyhow::Result<()> {

--- a/src/server/api/db_backups.rs
+++ b/src/server/api/db_backups.rs
@@ -1,0 +1,323 @@
+//! HTTP routes for managing `db.json` snapshots (auto-backup, manual
+//! snapshot, restore, prune, export, import). See `crate::db::backups`
+//! for the underlying file management.
+
+use axum::body::Body;
+use axum::extract::{Multipart, Path, State};
+use axum::http::{header, HeaderMap, StatusCode};
+use axum::response::{IntoResponse, Response};
+use axum::routing::{delete, get, post, put};
+use axum::{Json, Router};
+use chrono::{SecondsFormat, Utc};
+use serde::Deserialize;
+use serde_json::{json, Value};
+
+use crate::db::backups::{BackupManager, BackupReason};
+use crate::server::state::AppState;
+use crate::types::AppDb;
+
+use super::require_dashboard_or_management_api_key;
+
+pub fn routes() -> Router<AppState> {
+    Router::new()
+        .route("/api/db-backups", get(list_handler))
+        .route("/api/db-backups", put(create_handler))
+        .route("/api/db-backups", delete(cleanup_handler))
+        .route("/api/db-backups/restore", post(restore_handler))
+        .route("/api/db-backups/export", get(export_handler))
+        .route("/api/db-backups/import", post(import_handler))
+        .route("/api/db-backups/{id}", delete(delete_one_handler))
+}
+
+fn manager(state: &AppState) -> BackupManager {
+    BackupManager::new(&state.db.data_dir)
+}
+
+async fn list_handler(State(state): State<AppState>, headers: HeaderMap) -> Response {
+    if let Err(response) = require_dashboard_or_management_api_key(&headers, &state) {
+        return response;
+    }
+
+    match manager(&state).list().await {
+        Ok(backups) => Json(json!({
+            "backups": backups,
+            "maxFiles": BackupManager::max_files(),
+            "retentionDays": BackupManager::retention_days(),
+            "autoDisabled": BackupManager::is_auto_disabled(),
+        }))
+        .into_response(),
+        Err(err) => internal_error(err),
+    }
+}
+
+async fn create_handler(State(state): State<AppState>, headers: HeaderMap) -> Response {
+    if let Err(response) = require_dashboard_or_management_api_key(&headers, &state) {
+        return response;
+    }
+
+    match manager(&state).create(BackupReason::Manual).await {
+        Ok(Some(info)) => Json(json!({ "created": true, "backup": info })).into_response(),
+        Ok(None) => Json(json!({ "created": false, "message": "Backup skipped (db missing or invalid)" }))
+            .into_response(),
+        Err(err) => internal_error(err),
+    }
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct RestoreBody {
+    backup_id: String,
+}
+
+async fn restore_handler(
+    State(state): State<AppState>,
+    headers: HeaderMap,
+    body: Result<Json<RestoreBody>, axum::extract::rejection::JsonRejection>,
+) -> Response {
+    if let Err(response) = require_dashboard_or_management_api_key(&headers, &state) {
+        return response;
+    }
+
+    let Json(payload) = match body {
+        Ok(b) => b,
+        Err(_) => {
+            return (
+                StatusCode::BAD_REQUEST,
+                Json(json!({ "error": "Missing or invalid backupId" })),
+            )
+                .into_response()
+        }
+    };
+
+    let mgr = manager(&state);
+
+    let next_db = match mgr.read_backup(&payload.backup_id).await {
+        Ok(db) => db,
+        Err(err) => {
+            return (
+                StatusCode::BAD_REQUEST,
+                Json(json!({ "error": err.to_string() })),
+            )
+                .into_response();
+        }
+    };
+
+    // Safety snapshot of the current db before we swap.
+    if let Err(err) = mgr.create(BackupReason::PreRestore).await {
+        tracing::warn!(
+            target: "openproxy::db::backups",
+            error = %err,
+            "pre-restore backup failed; aborting restore"
+        );
+        return internal_error(err);
+    }
+
+    match state.db.replace_app_db(move || next_db).await {
+        Ok(snapshot) => Json(json!({
+            "restored": true,
+            "backupId": payload.backup_id,
+            "providerCount": snapshot.provider_connections.len(),
+            "comboCount": snapshot.combos.len(),
+            "apiKeyCount": snapshot.api_keys.len(),
+        }))
+        .into_response(),
+        Err(err) => internal_error(err),
+    }
+}
+
+#[derive(Debug, Deserialize, Default)]
+#[serde(rename_all = "camelCase")]
+struct CleanupBody {
+    keep_latest: Option<usize>,
+    retention_days: Option<u64>,
+}
+
+async fn cleanup_handler(
+    State(state): State<AppState>,
+    headers: HeaderMap,
+    body: Result<Json<CleanupBody>, axum::extract::rejection::JsonRejection>,
+) -> Response {
+    if let Err(response) = require_dashboard_or_management_api_key(&headers, &state) {
+        return response;
+    }
+
+    let body = body.map(|Json(b)| b).unwrap_or_default();
+    let max_files = body.keep_latest.unwrap_or_else(BackupManager::max_files);
+    let retention_days = body
+        .retention_days
+        .unwrap_or_else(BackupManager::retention_days);
+
+    match manager(&state).cleanup(max_files, retention_days).await {
+        Ok(result) => Json(json!({ "cleaned": true, "result": result })).into_response(),
+        Err(err) => internal_error(err),
+    }
+}
+
+async fn delete_one_handler(
+    State(state): State<AppState>,
+    headers: HeaderMap,
+    Path(id): Path<String>,
+) -> Response {
+    if let Err(response) = require_dashboard_or_management_api_key(&headers, &state) {
+        return response;
+    }
+
+    match manager(&state).delete(&id).await {
+        Ok(()) => Json(json!({ "deleted": true, "id": id })).into_response(),
+        Err(err) => (
+            StatusCode::BAD_REQUEST,
+            Json(json!({ "error": err.to_string() })),
+        )
+            .into_response(),
+    }
+}
+
+async fn export_handler(State(state): State<AppState>, headers: HeaderMap) -> Response {
+    if let Err(response) = require_dashboard_or_management_api_key(&headers, &state) {
+        return response;
+    }
+
+    let snapshot = state.db.snapshot();
+    let bytes = match serde_json::to_vec_pretty(snapshot.as_ref()) {
+        Ok(b) => b,
+        Err(err) => return internal_error(anyhow::anyhow!(err)),
+    };
+
+    let timestamp = Utc::now()
+        .to_rfc3339_opts(SecondsFormat::Millis, true)
+        .replace([':', '.'], "-");
+    let filename = format!("openproxy-backup-{}.json", timestamp);
+
+    Response::builder()
+        .status(StatusCode::OK)
+        .header(header::CONTENT_TYPE, "application/json")
+        .header(
+            header::CONTENT_DISPOSITION,
+            format!("attachment; filename=\"{filename}\""),
+        )
+        .header(header::CACHE_CONTROL, "no-cache, no-store")
+        .header(header::CONTENT_LENGTH, bytes.len().to_string())
+        .body(Body::from(bytes))
+        .unwrap_or_else(|err| internal_error(anyhow::anyhow!(err)))
+}
+
+const MAX_IMPORT_BYTES: usize = 100 * 1024 * 1024; // 100 MB
+
+async fn import_handler(
+    State(state): State<AppState>,
+    headers: HeaderMap,
+    multipart: Multipart,
+) -> Response {
+    if let Err(response) = require_dashboard_or_management_api_key(&headers, &state) {
+        return response;
+    }
+
+    let bytes = match collect_multipart_payload(multipart).await {
+        Ok(bytes) => bytes,
+        Err(err) => return err.into_response(),
+    };
+
+    if bytes.len() > MAX_IMPORT_BYTES {
+        return (
+            StatusCode::PAYLOAD_TOO_LARGE,
+            Json(json!({
+                "error": format!(
+                    "File too large. Maximum allowed size is {} MB.",
+                    MAX_IMPORT_BYTES / (1024 * 1024)
+                )
+            })),
+        )
+            .into_response();
+    }
+
+    let parsed: Value = match serde_json::from_slice(&bytes) {
+        Ok(v) => v,
+        Err(err) => {
+            return (
+                StatusCode::BAD_REQUEST,
+                Json(json!({ "error": format!("Invalid JSON: {err}") })),
+            )
+                .into_response();
+        }
+    };
+
+    if !parsed.is_object() {
+        return (
+            StatusCode::BAD_REQUEST,
+            Json(json!({ "error": "Import payload must be a JSON object" })),
+        )
+            .into_response();
+    }
+
+    // Pre-import safety snapshot.
+    if let Err(err) = manager(&state).create(BackupReason::PreImport).await {
+        tracing::warn!(
+            target: "openproxy::db::backups",
+            error = %err,
+            "pre-import backup failed; aborting import"
+        );
+        return internal_error(err);
+    }
+
+    let next = AppDb::from_json_value(parsed);
+    match state.db.replace_app_db(move || next).await {
+        Ok(snapshot) => Json(json!({
+            "imported": true,
+            "providerCount": snapshot.provider_connections.len(),
+            "comboCount": snapshot.combos.len(),
+            "apiKeyCount": snapshot.api_keys.len(),
+        }))
+        .into_response(),
+        Err(err) => internal_error(err),
+    }
+}
+
+enum ImportError {
+    BadRequest(String),
+}
+
+impl ImportError {
+    fn into_response(self) -> Response {
+        match self {
+            ImportError::BadRequest(msg) => (
+                StatusCode::BAD_REQUEST,
+                Json(json!({ "error": msg })),
+            )
+                .into_response(),
+        }
+    }
+}
+
+async fn collect_multipart_payload(mut multipart: Multipart) -> Result<Vec<u8>, ImportError> {
+    while let Some(field) = multipart
+        .next_field()
+        .await
+        .map_err(|e| ImportError::BadRequest(e.to_string()))?
+    {
+        let name = field.name().unwrap_or("").to_string();
+        if name != "file" {
+            continue;
+        }
+        let bytes = field
+            .bytes()
+            .await
+            .map_err(|e| ImportError::BadRequest(e.to_string()))?;
+        return Ok(bytes.to_vec());
+    }
+    Err(ImportError::BadRequest(
+        "No 'file' field in multipart upload".into(),
+    ))
+}
+
+fn internal_error(err: anyhow::Error) -> Response {
+    tracing::error!(
+        target: "openproxy::db::backups",
+        error = %err,
+        "db-backup operation failed"
+    );
+    (
+        StatusCode::INTERNAL_SERVER_ERROR,
+        Json(json!({ "error": err.to_string() })),
+    )
+        .into_response()
+}

--- a/src/server/api/db_backups.rs
+++ b/src/server/api/db_backups.rs
@@ -57,8 +57,10 @@ async fn create_handler(State(state): State<AppState>, headers: HeaderMap) -> Re
 
     match manager(&state).create(BackupReason::Manual).await {
         Ok(Some(info)) => Json(json!({ "created": true, "backup": info })).into_response(),
-        Ok(None) => Json(json!({ "created": false, "message": "Backup skipped (db missing or invalid)" }))
-            .into_response(),
+        Ok(None) => {
+            Json(json!({ "created": false, "message": "Backup skipped (db missing or invalid)" }))
+                .into_response()
+        }
         Err(err) => internal_error(err),
     }
 }
@@ -279,11 +281,9 @@ enum ImportError {
 impl ImportError {
     fn into_response(self) -> Response {
         match self {
-            ImportError::BadRequest(msg) => (
-                StatusCode::BAD_REQUEST,
-                Json(json!({ "error": msg })),
-            )
-                .into_response(),
+            ImportError::BadRequest(msg) => {
+                (StatusCode::BAD_REQUEST, Json(json!({ "error": msg }))).into_response()
+            }
         }
     }
 }

--- a/src/server/api/mod.rs
+++ b/src/server/api/mod.rs
@@ -5,6 +5,7 @@ pub mod cli_tools;
 pub mod cloud_credentials;
 pub mod cloud_sync;
 pub mod compat;
+pub mod db_backups;
 pub mod locale;
 pub mod mcp;
 pub mod media;
@@ -158,6 +159,7 @@ pub fn routes() -> Router<AppState> {
         .merge(shutdown::routes())
         .merge(cli_tools::routes())
         .merge(settings_payload_rules::routes())
+        .merge(db_backups::routes())
 }
 
 async fn health() -> Json<HealthResponse> {

--- a/tests/db_backups_api.rs
+++ b/tests/db_backups_api.rs
@@ -1,0 +1,269 @@
+use std::collections::BTreeMap;
+use std::sync::Arc;
+
+use axum::body::{to_bytes, Body};
+use axum::http::{Request, StatusCode};
+use openproxy::db::Db;
+use openproxy::server::state::AppState;
+use openproxy::types::ApiKey;
+use serde_json::{json, Value};
+use tempfile::tempdir;
+use tower::util::ServiceExt;
+
+const TEST_KEY: &str = "db-backups-api-test-key";
+
+fn active_key() -> ApiKey {
+    ApiKey {
+        id: "key-1".into(),
+        name: "Local".into(),
+        key: TEST_KEY.into(),
+        machine_id: None,
+        is_active: Some(true),
+        created_at: None,
+        extra: BTreeMap::new(),
+    }
+}
+
+async fn app_state_with(temp_path: &std::path::Path) -> AppState {
+    let db = Arc::new(Db::load_from(temp_path).await.expect("db"));
+    db.update(|state| {
+        state.api_keys = vec![active_key()];
+        state
+            .settings
+            .extra
+            .insert("password".into(), Value::String("hashed-secret".into()));
+        state.settings.require_login = true;
+    })
+    .await
+    .expect("seed db");
+    AppState::new(db)
+}
+
+async fn drain_body(body: Body) -> Value {
+    let bytes = to_bytes(body, usize::MAX).await.expect("body");
+    serde_json::from_slice(&bytes).expect("json")
+}
+
+#[tokio::test]
+async fn list_requires_auth() {
+    let temp = tempdir().unwrap();
+    let app = openproxy::build_app(app_state_with(temp.path()).await);
+    let res = app
+        .oneshot(
+            Request::builder()
+                .uri("/api/db-backups")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(res.status(), StatusCode::UNAUTHORIZED);
+}
+
+#[tokio::test]
+async fn put_then_list_then_delete_round_trip() {
+    let temp = tempdir().unwrap();
+    let app = openproxy::build_app(app_state_with(temp.path()).await);
+
+    // PUT: create manual backup
+    let put = app
+        .clone()
+        .oneshot(
+            Request::builder()
+                .method("PUT")
+                .uri("/api/db-backups")
+                .header("authorization", format!("Bearer {TEST_KEY}"))
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(put.status(), StatusCode::OK);
+    let put_body = drain_body(put.into_body()).await;
+    assert_eq!(put_body["created"], Value::Bool(true));
+    let backup_id = put_body["backup"]["id"]
+        .as_str()
+        .expect("backup id present")
+        .to_string();
+    assert!(backup_id.starts_with("db_"));
+    assert!(backup_id.ends_with("_manual.json"));
+
+    // GET: list
+    let list = app
+        .clone()
+        .oneshot(
+            Request::builder()
+                .uri("/api/db-backups")
+                .header("authorization", format!("Bearer {TEST_KEY}"))
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(list.status(), StatusCode::OK);
+    let list_body = drain_body(list.into_body()).await;
+    let backups = list_body["backups"].as_array().expect("backups array");
+    assert_eq!(backups.len(), 1);
+    assert_eq!(backups[0]["id"], backup_id);
+    assert_eq!(backups[0]["reason"], "manual");
+    assert_eq!(backups[0]["apiKeyCount"], 1);
+
+    // DELETE one
+    let del = app
+        .clone()
+        .oneshot(
+            Request::builder()
+                .method("DELETE")
+                .uri(format!("/api/db-backups/{backup_id}"))
+                .header("authorization", format!("Bearer {TEST_KEY}"))
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(del.status(), StatusCode::OK);
+
+    // GET: empty
+    let list2 = app
+        .oneshot(
+            Request::builder()
+                .uri("/api/db-backups")
+                .header("authorization", format!("Bearer {TEST_KEY}"))
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    let list2_body = drain_body(list2.into_body()).await;
+    assert!(list2_body["backups"].as_array().unwrap().is_empty());
+}
+
+#[tokio::test]
+async fn restore_takes_pre_restore_snapshot_and_swaps_db() {
+    let temp = tempdir().unwrap();
+    let app = openproxy::build_app(app_state_with(temp.path()).await);
+
+    // Create first snapshot with 1 api key.
+    let snap = app
+        .clone()
+        .oneshot(
+            Request::builder()
+                .method("PUT")
+                .uri("/api/db-backups")
+                .header("authorization", format!("Bearer {TEST_KEY}"))
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    let snap_body = drain_body(snap.into_body()).await;
+    let backup_id = snap_body["backup"]["id"].as_str().unwrap().to_string();
+
+    // Mutate db.json on disk: rewrite the same file directly via fs so the
+    // in-memory snapshot drifts. Simpler: hit our own settings PATCH? We
+    // instead just clear api_keys via direct write — the restore handler
+    // will rebuild AppDb from the saved backup file.
+    let db_path = temp.path().join("db.json");
+    let cleared = json!({
+        "providerConnections": [],
+        "providerNodes": [],
+        "combos": [],
+        "apiKeys": [],
+        "settings": {},
+    });
+    tokio::fs::write(&db_path, serde_json::to_vec_pretty(&cleared).unwrap())
+        .await
+        .unwrap();
+    // We do not need to reload the in-memory snapshot for this assertion —
+    // we're checking that restore writes the backup back to disk and updates
+    // the in-memory snapshot.
+
+    // Tiny delay so the pre-restore snapshot lands in a distinct timestamp.
+    tokio::time::sleep(std::time::Duration::from_millis(5)).await;
+
+    // POST /restore
+    let restore = app
+        .clone()
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri("/api/db-backups/restore")
+                .header("authorization", format!("Bearer {TEST_KEY}"))
+                .header("content-type", "application/json")
+                .body(Body::from(json!({ "backupId": backup_id }).to_string()))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(restore.status(), StatusCode::OK);
+    let restore_body = drain_body(restore.into_body()).await;
+    assert_eq!(restore_body["restored"], Value::Bool(true));
+    assert_eq!(restore_body["apiKeyCount"], 1);
+
+    // A pre-restore snapshot should now exist alongside the manual one.
+    let list = app
+        .oneshot(
+            Request::builder()
+                .uri("/api/db-backups")
+                .header("authorization", format!("Bearer {TEST_KEY}"))
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    let body = drain_body(list.into_body()).await;
+    let backups = body["backups"].as_array().unwrap();
+    assert!(
+        backups.iter().any(|b| b["reason"] == "pre-restore"),
+        "expected a pre-restore snapshot to be created: {body:?}"
+    );
+}
+
+#[tokio::test]
+async fn export_returns_attachment() {
+    let temp = tempdir().unwrap();
+    let app = openproxy::build_app(app_state_with(temp.path()).await);
+    let res = app
+        .oneshot(
+            Request::builder()
+                .uri("/api/db-backups/export")
+                .header("authorization", format!("Bearer {TEST_KEY}"))
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(res.status(), StatusCode::OK);
+    let disposition = res
+        .headers()
+        .get(axum::http::header::CONTENT_DISPOSITION)
+        .expect("content-disposition")
+        .to_str()
+        .unwrap()
+        .to_string();
+    assert!(disposition.contains("openproxy-backup-"));
+    assert!(disposition.contains(".json"));
+    let body = drain_body(res.into_body()).await;
+    assert_eq!(body["apiKeys"].as_array().unwrap().len(), 1);
+}
+
+#[tokio::test]
+async fn restore_rejects_path_traversal() {
+    let temp = tempdir().unwrap();
+    let app = openproxy::build_app(app_state_with(temp.path()).await);
+    let res = app
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri("/api/db-backups/restore")
+                .header("authorization", format!("Bearer {TEST_KEY}"))
+                .header("content-type", "application/json")
+                .body(Body::from(
+                    json!({ "backupId": "../db.json" }).to_string(),
+                ))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(res.status(), StatusCode::BAD_REQUEST);
+}

--- a/tests/db_backups_api.rs
+++ b/tests/db_backups_api.rs
@@ -258,9 +258,7 @@ async fn restore_rejects_path_traversal() {
                 .uri("/api/db-backups/restore")
                 .header("authorization", format!("Bearer {TEST_KEY}"))
                 .header("content-type", "application/json")
-                .body(Body::from(
-                    json!({ "backupId": "../db.json" }).to_string(),
-                ))
+                .body(Body::from(json!({ "backupId": "../db.json" }).to_string()))
                 .unwrap(),
         )
         .await

--- a/web/src/components/DbBackupsPageClient.tsx
+++ b/web/src/components/DbBackupsPageClient.tsx
@@ -1,0 +1,406 @@
+"use client";
+
+import { useCallback, useEffect, useRef, useState } from "react";
+import { Button, Card } from "@/shared/components";
+
+// ──────────────────────────────────────────────────────────────────────
+// Types — mirror src/db/backups.rs and src/server/api/db_backups.rs.
+// ──────────────────────────────────────────────────────────────────────
+
+interface BackupInfo {
+  id: string;
+  filename: string;
+  createdAt: string;
+  size: number;
+  reason: string;
+  providerCount: number;
+  comboCount: number;
+  apiKeyCount: number;
+}
+
+interface ListResponse {
+  backups: BackupInfo[];
+  maxFiles: number;
+  retentionDays: number;
+  autoDisabled: boolean;
+}
+
+type StatusMessage = { type: "success" | "error" | "info"; text: string };
+
+const REASON_LABEL: Record<string, string> = {
+  auto: "Auto",
+  manual: "Manual",
+  "pre-restore": "Pre-restore",
+  "pre-import": "Pre-import",
+};
+
+function StatusAlert({ status }: { status: StatusMessage | null }) {
+  if (!status) return null;
+  const cls =
+    status.type === "success"
+      ? "border-green-300 bg-green-50 text-green-800 dark:border-green-700 dark:bg-green-900/30 dark:text-green-200"
+      : status.type === "error"
+      ? "border-red-300 bg-red-50 text-red-800 dark:border-red-700 dark:bg-red-900/30 dark:text-red-200"
+      : "border-blue-300 bg-blue-50 text-blue-800 dark:border-blue-700 dark:bg-blue-900/30 dark:text-blue-200";
+  return (
+    <div className={`mt-3 rounded-md border px-3 py-2 text-sm ${cls}`}>{status.text}</div>
+  );
+}
+
+function formatSize(bytes: number): string {
+  if (bytes < 1024) return `${bytes} B`;
+  if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(1)} KB`;
+  return `${(bytes / (1024 * 1024)).toFixed(2)} MB`;
+}
+
+function formatTime(iso: string): string {
+  try {
+    return new Date(iso).toLocaleString();
+  } catch {
+    return iso;
+  }
+}
+
+export default function DbBackupsPageClient() {
+  const [data, setData] = useState<ListResponse | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [busy, setBusy] = useState(false);
+  const [status, setStatus] = useState<StatusMessage | null>(null);
+  const [pendingRestore, setPendingRestore] = useState<BackupInfo | null>(null);
+  const fileInputRef = useRef<HTMLInputElement>(null);
+
+  const fetchList = useCallback(async () => {
+    setLoading(true);
+    try {
+      const res = await fetch("/api/db-backups");
+      if (!res.ok) throw new Error(`Server returned ${res.status}`);
+      const json = (await res.json()) as ListResponse;
+      setData(json);
+    } catch (err) {
+      setStatus({
+        type: "error",
+        text: err instanceof Error ? `Failed to load backups: ${err.message}` : "Failed to load backups",
+      });
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    void fetchList();
+  }, [fetchList]);
+
+  const handleCreate = useCallback(async () => {
+    setBusy(true);
+    setStatus(null);
+    try {
+      const res = await fetch("/api/db-backups", { method: "PUT" });
+      if (!res.ok) throw new Error(`Server returned ${res.status}`);
+      const json = await res.json();
+      if (json?.created === false) {
+        setStatus({ type: "info", text: json?.message || "Backup skipped." });
+      } else {
+        setStatus({ type: "success", text: `Snapshot created: ${json?.backup?.id ?? "(no id)"}` });
+      }
+      await fetchList();
+    } catch (err) {
+      setStatus({
+        type: "error",
+        text: err instanceof Error ? `Failed to create backup: ${err.message}` : "Failed to create backup",
+      });
+    } finally {
+      setBusy(false);
+    }
+  }, [fetchList]);
+
+  const handleDelete = useCallback(
+    async (id: string) => {
+      if (!confirm(`Delete backup ${id}?`)) return;
+      setBusy(true);
+      setStatus(null);
+      try {
+        const res = await fetch(`/api/db-backups/${encodeURIComponent(id)}`, { method: "DELETE" });
+        if (!res.ok) throw new Error(`Server returned ${res.status}`);
+        setStatus({ type: "success", text: "Backup deleted." });
+        await fetchList();
+      } catch (err) {
+        setStatus({
+          type: "error",
+          text: err instanceof Error ? `Failed to delete: ${err.message}` : "Failed to delete",
+        });
+      } finally {
+        setBusy(false);
+      }
+    },
+    [fetchList]
+  );
+
+  const handleCleanup = useCallback(async () => {
+    if (!confirm("Prune backups using the current retention settings?")) return;
+    setBusy(true);
+    setStatus(null);
+    try {
+      const res = await fetch("/api/db-backups", {
+        method: "DELETE",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({}),
+      });
+      if (!res.ok) throw new Error(`Server returned ${res.status}`);
+      const json = await res.json();
+      const r = json?.result;
+      setStatus({
+        type: "success",
+        text: `Cleanup ran (deleted ${r?.deletedFiles ?? 0}, kept ${r?.keptFiles ?? 0}).`,
+      });
+      await fetchList();
+    } catch (err) {
+      setStatus({
+        type: "error",
+        text: err instanceof Error ? `Cleanup failed: ${err.message}` : "Cleanup failed",
+      });
+    } finally {
+      setBusy(false);
+    }
+  }, [fetchList]);
+
+  const confirmRestore = useCallback(async () => {
+    const target = pendingRestore;
+    if (!target) return;
+    setPendingRestore(null);
+    setBusy(true);
+    setStatus(null);
+    try {
+      const res = await fetch("/api/db-backups/restore", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ backupId: target.id }),
+      });
+      if (!res.ok) {
+        const text = await res.text();
+        throw new Error(text || `Server returned ${res.status}`);
+      }
+      const json = await res.json();
+      setStatus({
+        type: "success",
+        text: `Restored ${target.id} — ${json?.providerCount ?? 0} providers, ${
+          json?.comboCount ?? 0
+        } combos, ${json?.apiKeyCount ?? 0} API keys.`,
+      });
+      await fetchList();
+    } catch (err) {
+      setStatus({
+        type: "error",
+        text: err instanceof Error ? `Restore failed: ${err.message}` : "Restore failed",
+      });
+    } finally {
+      setBusy(false);
+    }
+  }, [pendingRestore, fetchList]);
+
+  const handleExport = useCallback(() => {
+    // Browser handles the download via the response's Content-Disposition.
+    window.location.href = "/api/db-backups/export";
+  }, []);
+
+  const handleImportClick = useCallback(() => {
+    fileInputRef.current?.click();
+  }, []);
+
+  const handleImportFile = useCallback(
+    async (event: React.ChangeEvent<HTMLInputElement>) => {
+      const file = event.target.files?.[0];
+      event.target.value = "";
+      if (!file) return;
+      if (
+        !confirm(
+          `Import ${file.name}? This replaces the current database. A pre-import snapshot will be created automatically.`
+        )
+      ) {
+        return;
+      }
+      setBusy(true);
+      setStatus(null);
+      try {
+        const form = new FormData();
+        form.append("file", file);
+        const res = await fetch("/api/db-backups/import", { method: "POST", body: form });
+        if (!res.ok) {
+          const text = await res.text();
+          throw new Error(text || `Server returned ${res.status}`);
+        }
+        const json = await res.json();
+        setStatus({
+          type: "success",
+          text: `Imported ${file.name} — ${json?.providerCount ?? 0} providers, ${
+            json?.comboCount ?? 0
+          } combos, ${json?.apiKeyCount ?? 0} API keys.`,
+        });
+        await fetchList();
+      } catch (err) {
+        setStatus({
+          type: "error",
+          text: err instanceof Error ? `Import failed: ${err.message}` : "Import failed",
+        });
+      } finally {
+        setBusy(false);
+      }
+    },
+    [fetchList]
+  );
+
+  const backups = data?.backups ?? [];
+
+  return (
+    <div className="space-y-6">
+      <div>
+        <h1 className="text-2xl font-semibold text-ink">Database Backups</h1>
+        <p className="text-sm text-body mt-1">
+          Hourly snapshots of <code>db.json</code> with retention. Restore, export,
+          and import full databases here.
+        </p>
+      </div>
+
+      <Card>
+        <div className="p-4 flex flex-wrap items-center gap-2 justify-between">
+          <div className="text-sm text-body">
+            {data ? (
+              <>
+                <span className="font-medium text-ink">{backups.length}</span> snapshot
+                {backups.length === 1 ? "" : "s"} · retention: max{" "}
+                <span className="font-medium text-ink">{data.maxFiles}</span> files
+                {data.retentionDays > 0 ? `, ${data.retentionDays} days` : ", no day cutoff"}
+                {data.autoDisabled ? " · auto-backup DISABLED" : ""}
+              </>
+            ) : (
+              "Loading…"
+            )}
+          </div>
+          <div className="flex flex-wrap gap-2">
+            <Button variant="secondary" onClick={() => void fetchList()} disabled={loading || busy}>
+              Refresh
+            </Button>
+            <Button onClick={() => void handleCreate()} disabled={busy}>
+              {busy ? "Working…" : "Create snapshot"}
+            </Button>
+            <Button variant="secondary" onClick={() => void handleCleanup()} disabled={busy}>
+              Prune
+            </Button>
+            <Button variant="secondary" onClick={handleExport} disabled={busy}>
+              Export db.json
+            </Button>
+            <Button variant="secondary" onClick={handleImportClick} disabled={busy}>
+              Import db.json
+            </Button>
+            <input
+              ref={fileInputRef}
+              type="file"
+              accept=".json,application/json"
+              className="hidden"
+              onChange={handleImportFile}
+            />
+          </div>
+        </div>
+        <StatusAlert status={status} />
+      </Card>
+
+      <Card>
+        <div className="overflow-x-auto">
+          <table className="min-w-full text-sm">
+            <thead className="text-left text-body uppercase text-xs tracking-wide">
+              <tr>
+                <th className="px-4 py-2">Snapshot</th>
+                <th className="px-4 py-2">Reason</th>
+                <th className="px-4 py-2">Created</th>
+                <th className="px-4 py-2">Size</th>
+                <th className="px-4 py-2">Providers</th>
+                <th className="px-4 py-2">Combos</th>
+                <th className="px-4 py-2">API keys</th>
+                <th className="px-4 py-2 text-right">Actions</th>
+              </tr>
+            </thead>
+            <tbody className="divide-y divide-line">
+              {loading && (
+                <tr>
+                  <td colSpan={8} className="px-4 py-6 text-center text-body">
+                    Loading backups…
+                  </td>
+                </tr>
+              )}
+              {!loading && backups.length === 0 && (
+                <tr>
+                  <td colSpan={8} className="px-4 py-6 text-center text-body">
+                    No backups yet. Click <span className="font-medium">Create snapshot</span> to
+                    save one now, or wait for the hourly auto-backup.
+                  </td>
+                </tr>
+              )}
+              {!loading &&
+                backups.map((b) => (
+                  <tr key={b.id} className="hover:bg-surface-soft">
+                    <td className="px-4 py-2 font-mono text-xs text-ink">{b.id}</td>
+                    <td className="px-4 py-2 text-body">
+                      {REASON_LABEL[b.reason] || b.reason}
+                    </td>
+                    <td className="px-4 py-2 text-body">{formatTime(b.createdAt)}</td>
+                    <td className="px-4 py-2 text-body">{formatSize(b.size)}</td>
+                    <td className="px-4 py-2 text-body">{b.providerCount}</td>
+                    <td className="px-4 py-2 text-body">{b.comboCount}</td>
+                    <td className="px-4 py-2 text-body">{b.apiKeyCount}</td>
+                    <td className="px-4 py-2 text-right">
+                      <div className="inline-flex gap-2">
+                        <Button
+                          variant="secondary"
+                          onClick={() => setPendingRestore(b)}
+                          disabled={busy}
+                        >
+                          Restore
+                        </Button>
+                        <Button
+                          variant="secondary"
+                          onClick={() => void handleDelete(b.id)}
+                          disabled={busy}
+                        >
+                          Delete
+                        </Button>
+                      </div>
+                    </td>
+                  </tr>
+                ))}
+            </tbody>
+          </table>
+        </div>
+      </Card>
+
+      {pendingRestore && (
+        <div
+          className="fixed inset-0 z-50 flex items-center justify-center bg-black/40"
+          onClick={() => setPendingRestore(null)}
+        >
+          <div
+            className="max-w-md rounded-lg bg-surface-card p-6 shadow-xl"
+            onClick={(e) => e.stopPropagation()}
+          >
+            <h2 className="text-lg font-semibold text-ink">Restore snapshot?</h2>
+            <p className="mt-2 text-sm text-body">
+              This will replace the current database with the contents of{" "}
+              <span className="font-mono">{pendingRestore.id}</span>. A pre-restore safety
+              snapshot will be created first.
+            </p>
+            <p className="mt-2 text-sm text-body">
+              {pendingRestore.providerCount} providers · {pendingRestore.comboCount} combos ·{" "}
+              {pendingRestore.apiKeyCount} API keys.
+            </p>
+            <div className="mt-4 flex justify-end gap-2">
+              <Button variant="secondary" onClick={() => setPendingRestore(null)}>
+                Cancel
+              </Button>
+              <Button onClick={() => void confirmRestore()} disabled={busy}>
+                Restore
+              </Button>
+            </div>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/web/src/pages/dashboard/db-backups/index.astro
+++ b/web/src/pages/dashboard/db-backups/index.astro
@@ -1,0 +1,10 @@
+---
+import Layout from '@/layouts/Layout.astro';
+import DbBackupsPageClient from '@/components/DbBackupsPageClient';
+import DashboardLayout from '@/shared/components/layouts/DashboardLayout';
+---
+<Layout>
+  <DashboardLayout client:only="react">
+    <DbBackupsPageClient client:only="react" />
+  </DashboardLayout>
+</Layout>

--- a/web/src/shared/components/Sidebar.tsx
+++ b/web/src/shared/components/Sidebar.tsx
@@ -42,6 +42,7 @@ const navItems: NavItem[] = [
   { href: "/dashboard/providers", label: "Providers", icon: "dns" },
   { href: "/dashboard/combos", label: "Combos", icon: "layers" },
   { href: "/dashboard/payload-rules", label: "Payload Rules", icon: "tune" },
+  { href: "/dashboard/db-backups", label: "DB Backups", icon: "backup" },
   { href: "/dashboard/usage", label: "Usage", icon: "bar_chart" },
   { href: "/dashboard/quota", label: "Quota Tracker", icon: "data_usage" },
   { href: "/dashboard/mitm", label: "MITM", icon: "security" },


### PR DESCRIPTION
## Summary

Sprint A · PR **A2** (after A1 #57 — payload-rules). Ports OmniRoute's
db-backups subsystem (`src/lib/db/backup.ts` + `/api/db-backups/*` routes)
into openproxy and adapts it for the JSON `db.json` store.

### Backend (`src/db/backups.rs`, ~570 LOC + 6 unit tests)

- `BackupManager` per-`DATA_DIR` snapshot manager
- Snapshot file family: `${DATA_DIR}/db_backups/db_<utc-iso-no-colons>_<reason>.json`
- Four reasons: `auto`, `manual`, `pre-restore`, `pre-import`
- Throttle: 60 min for `auto`; `manual`/`pre-*` skip the throttle
- Shrink guard: skip auto-backup when db.json is < 50% of the latest snapshot's size
- Retention env vars (matching OmniRoute):
  - `DB_BACKUP_MAX_FILES` — keep at most N newest (default **20**)
  - `DB_BACKUP_RETENTION_DAYS` — also drop snapshots older than D days (default **0** = disabled)
  - `DISABLE_AUTO_BACKUP=1` — turn off the hourly loop (`manual` / `pre-*` still work)
- Path-traversal hardening on every backup id (`..`, `/`, `\` rejected; must match `db_*.json`)
- `Db::replace_app_db()` helper in `src/db/mod.rs` — atomic in-memory + on-disk swap under the existing write lock; used by restore + import

### HTTP routes (`src/server/api/db_backups.rs`, ~340 LOC)

Auth: `require_dashboard_or_management_api_key` (same as the payload-rules / settings routes).

| Method | Path                          | Notes                                             |
| ------ | ----------------------------- | ------------------------------------------------- |
| GET    | `/api/db-backups`             | List + retention settings + auto-disabled flag    |
| PUT    | `/api/db-backups`             | Manual snapshot                                   |
| DELETE | `/api/db-backups`             | Prune (body: `{ keepLatest?, retentionDays? }`)   |
| POST   | `/api/db-backups/restore`     | Body: `{ backupId }` — creates pre-restore safety snapshot before swapping |
| DELETE | `/api/db-backups/{id}`        | Delete one snapshot                               |
| GET    | `/api/db-backups/export`      | Download current db.json as a timestamped attachment |
| POST   | `/api/db-backups/import`      | multipart/form-data `file=<json>` (≤ 100 MB) — pre-import safety snapshot |

### Auto-backup loop (`src/main.rs`)

`spawn_auto_backup(db)` after `spawn_watcher(db)`: 30 s startup delay, then snapshot once per hour. Honors `DISABLE_AUTO_BACKUP`. Retention is applied inside `BackupManager::create` after each successful auto snapshot.

### Web UI (`/dashboard/db-backups`, ~340 LOC)

- Sidebar entry `DB Backups` (`backup` icon) between **Payload Rules** and **Usage**
- Page: table of snapshots (id, reason, created, size, providers/combos/api-keys) + actions toolbar
- Toolbar: `Refresh`, `Create snapshot`, `Prune`, `Export db.json`, `Import db.json`
- Restore: confirmation modal with the snapshot's counts before the destructive swap
- File picker for import (`.json` only, browser-side accept filter; 100 MB server cap)

### Test coverage

| Suite                               | Tests              |
| ----------------------------------- | ------------------ |
| `src/db/backups.rs` unit            | 6 — round-trip, throttle, manual-skips-throttle, cleanup-max-files, path-traversal-rejected, too-small-skip |
| `tests/db_backups_api.rs` integration | 5 — list-requires-auth, put-list-delete round-trip, restore creates pre-restore snapshot + counts, export attachment headers, restore rejects path traversal |
| Lib tests                           | 632 passed (was 626; 6 new)                                                                                 |

```
test result: ok. 6 passed; 0 failed   (cargo test --lib db::backups)
test result: ok. 5 passed; 0 failed   (cargo test --test db_backups_api)
test result: ok. 632 passed; 0 failed (cargo test --lib)
```

`cargo clippy --lib --tests --no-deps` is clean for the new code (only the same 4 pre-existing warnings in unrelated files). One `codex_executor::execute_all_params_copied` integration test fails with a network timeout to `api.openai.com` — same pre-existing flake observed on PR #57; unrelated to this change.

## Review & Testing Checklist for Human

This is a medium-risk change: it writes to disk under the user's `DATA_DIR` and the restore/import paths intentionally replace the in-memory `db.json`. Please double-check:

- [ ] Auto-backup creates `${DATA_DIR}/db_backups/db_<…>_auto.json` after roughly an hour of uptime, **and** is throttled (no second auto snapshot inside the same hour). The 30 s startup delay + 60 min loop is in <code>src/main.rs::spawn_auto_backup</code>.
- [ ] `DISABLE_AUTO_BACKUP=1` skips the loop entirely (check logs for `auto-backup disabled via DISABLE_AUTO_BACKUP`). Manual / pre-* still work.
- [ ] `Restore` from the dashboard takes a `pre-restore` snapshot first, then swaps the in-memory db. After confirm, the table shows both the original snapshot AND a new `pre-restore` entry above it.
- [ ] `Import` from the dashboard takes a `pre-import` snapshot first, accepts any valid JSON object that deserialises into AppDb (forward/backward compatible via `from_json_value`), and rejects non-object or non-JSON payloads with a 400.
- [ ] `Export` downloads a file named `openproxy-backup-<utc>.json` containing the current db.json contents (verify with `jq '.apiKeys | length'`).
- [ ] Path-traversal: hitting `DELETE /api/db-backups/../db.json` or `POST /api/db-backups/restore` with `backupId: "../db.json"` both return 400 without touching the file (`tests/db_backups_api.rs::restore_rejects_path_traversal` covers the restore side).

### Suggested manual test plan

```bash
# 1. Start server with a fresh data dir
DATA_DIR=/tmp/op-a2 ./target/debug/openproxy server start --robot

# 2. Open http://localhost:4623/dashboard/db-backups → "Create snapshot"
#    Expect: 1 row, reason=Manual, providerCount/comboCount/apiKeyCount > 0.

# 3. Make a change in another tab (e.g. add a provider), then "Restore"
#    the snapshot from step 2. Expect: provider disappears, table now has
#    one "pre-restore" row above the manual row.

# 4. Click "Export db.json" — browser downloads openproxy-backup-<ts>.json.

# 5. Click "Import db.json" → pick the file from step 4 → confirm. Expect:
#    success toast + new "pre-import" row appears in the table.

# 6. ENV check: stop server, restart with
#      DB_BACKUP_MAX_FILES=2 DATA_DIR=/tmp/op-a2 ./target/debug/openproxy server start
#    From the UI create 5 manual snapshots, click "Prune". Expect: only
#    2 most recent rows remain.

# 7. DISABLE check: stop, restart with
#      DISABLE_AUTO_BACKUP=1 DATA_DIR=/tmp/op-a2 ./target/debug/openproxy server start
#    Logs should show `auto-backup disabled via DISABLE_AUTO_BACKUP`.
#    Manual snapshot from the UI still works.
```

### Notes

- This is part of Sprint A (port OmniRoute features openproxy is missing):
  A1 #57 = payload-rules + system-prompt override (merged); A2 = this PR;
  A3 = combo wizard refactor + intelligent panel + auto-catalog (next).
- Forward/backward compatibility: restore + import go through
  `AppDb::from_json_value` so old/new exports work even if the schema
  grows new fields.
- `defaultRaw` payload-rule application (from A1's TODO list) is still
  out of scope here — A2 only touches db-backups.
- Existing `/api/db/export` and `/api/settings/database` routes are left
  untouched; the new `/api/db-backups/*` namespace exists alongside them.

Link to Devin session: https://app.devin.ai/sessions/4137db57f49a49299e42ad42627d3c81
Requested by: @quangdang46