### PR TITLE
chore: downgrade manifests to v0.1.0 for initial release

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "openproxy"
-version = "0.1.6"
+version = "0.1.0"
 edition = "2021"
 
 [dependencies]

--- a/packages/openproxy/package.json
+++ b/packages/openproxy/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openprx/openproxy",
-  "version": "0.1.6",
+  "version": "0.1.0",
   "description": "OpenProxy — single-binary AI router with embedded web dashboard. Routes Claude Code, Codex, Cursor, Cline, and other AI CLI tools to 40+ providers with auto-fallback and quota tracking.",
   "keywords": [
     "ai",
@@ -33,9 +33,9 @@
     "node": ">=18"
   },
   "optionalDependencies": {
-    "@openprx/openproxy-linux-x64": "0.1.6",
-    "@openprx/openproxy-linux-arm64": "0.1.6",
-    "@openprx/openproxy-darwin-x64": "0.1.6",
-    "@openprx/openproxy-darwin-arm64": "0.1.6"
+    "@openprx/openproxy-linux-x64": "0.1.0",
+    "@openprx/openproxy-linux-arm64": "0.1.0",
+    "@openprx/openproxy-darwin-x64": "0.1.0",
+    "@openprx/openproxy-darwin-arm64": "0.1.0"
   }
 }

--- a/packages/platform/darwin-arm64/package.json
+++ b/packages/platform/darwin-arm64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openprx/openproxy-darwin-arm64",
-  "version": "0.1.6",
+  "version": "0.1.0",
   "description": "OpenProxy native binary for darwin arm64. Installed automatically as an optional dependency of the openproxy meta package.",
   "homepage": "https://github.com/quangdang46/openproxy#readme",
   "repository": {

--- a/packages/platform/darwin-x64/package.json
+++ b/packages/platform/darwin-x64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openprx/openproxy-darwin-x64",
-  "version": "0.1.6",
+  "version": "0.1.0",
   "description": "OpenProxy native binary for darwin x64. Installed automatically as an optional dependency of the openproxy meta package.",
   "homepage": "https://github.com/quangdang46/openproxy#readme",
   "repository": {

--- a/packages/platform/linux-arm64/package.json
+++ b/packages/platform/linux-arm64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openprx/openproxy-linux-arm64",
-  "version": "0.1.6",
+  "version": "0.1.0",
   "description": "OpenProxy native binary for linux arm64. Installed automatically as an optional dependency of the openproxy meta package.",
   "homepage": "https://github.com/quangdang46/openproxy#readme",
   "repository": {

--- a/packages/platform/linux-x64/package.json
+++ b/packages/platform/linux-x64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openprx/openproxy-linux-x64",
-  "version": "0.1.6",
+  "version": "0.1.0",
   "description": "OpenProxy native binary for linux x64. Installed automatically as an optional dependency of the openproxy meta package.",
   "homepage": "https://github.com/quangdang46/openproxy#readme",
   "repository": {


### PR DESCRIPTION
Downgrades all version manifests from 0.1.6 to 0.1.0 for initial release.