### PR TITLE
fix: update Cargo.lock to match v0.1.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2116,7 +2116,7 @@ dependencies = [
 
 [[package]]
 name = "openproxy"
-version = "0.1.6"
+version = "0.1.0"
 dependencies = [
  "anyhow",
  "arc-swap",


### PR DESCRIPTION
Fixes the Release workflow failure. Cargo.lock had stale version 0.1.6 for the openproxy package while Cargo.toml was 0.1.0, causing --locked builds to fail.