### PR TITLE
p2.2-antigravity-exec

### DIFF
--- a/src/core/executor/antigravity.rs
+++ b/src/core/executor/antigravity.rs
@@ -24,9 +24,10 @@ use reqwest::header::{HeaderMap, HeaderValue, ACCEPT, AUTHORIZATION, CONTENT_TYP
 use serde_json::{json, Map, Value};
 
 use crate::core::config::app_constants::{
-    ag_chat_user_agent, AG_DEFAULT_TOOLS, INTERNAL_REQUEST_HEADER_NAME,
-    INTERNAL_REQUEST_HEADER_VALUE,
+    ag_chat_user_agent, cloud_code_api, load_code_assist_metadata, AG_DEFAULT_TOOLS,
+    INTERNAL_REQUEST_HEADER_NAME, INTERNAL_REQUEST_HEADER_VALUE,
 };
+use crate::core::utils::project_id_cache;
 use crate::core::proxy::ProxyTarget;
 use crate::core::utils::session_manager::derive_session_id;
 use crate::types::{ProviderConnection, ProviderNode};
@@ -164,6 +165,147 @@ impl AntigravityExecutor {
         }
 
         Ok(headers)
+    }
+
+    /// Build the Client-Metadata + api-client headers that Antigravity's
+    /// Cloud Code endpoint expects. These are sent alongside the standard
+    /// auth headers produced by [`build_headers`].
+    ///
+    /// - `User-Agent: google-api-nodejs-client/9.15.1`
+    /// - `X-Goog-Api-Client: google-cloud-sdk vscode_cloudshelleditor/0.1`
+    /// - `Client-Metadata: {"ideType":9,"platform":<enum>,"pluginType":2}`
+    pub fn build_antigravity_headers() -> Result<HeaderMap, AntigravityExecutorError> {
+        let mut headers = HeaderMap::new();
+        headers.insert(
+            "User-Agent",
+            HeaderValue::from_static("google-api-nodejs-client/9.15.1"),
+        );
+        headers.insert(
+            "X-Goog-Api-Client",
+            HeaderValue::from_static("google-cloud-sdk vscode_cloudshelleditor/0.1"),
+        );
+        let metadata = json!({
+            "ideType": 9,
+            "platform": crate::core::config::app_constants::current_platform() as u8,
+            "pluginType": 2,
+        });
+        headers.insert(
+            "Client-Metadata",
+            HeaderValue::from_str(&serde_json::to_string(&metadata)?)?,
+        );
+        Ok(headers)
+    }
+
+    /// Resolve the project ID for the given Antigravity connection.
+    ///
+    /// 1. Check the [`ProjectIdCache`] first (5-minute TTL).
+    /// 2. On cache miss: POST `loadCodeAssist`, extract the project id
+    ///    from the response, cache it, and return.
+    /// 3. Returns an empty string if the lookup fails (caller should
+    ///    proceed without a project id in that case).
+    pub async fn get_project_id(
+        connection_id: &str,
+        access_token: &str,
+    ) -> String {
+        // Check cache.
+        if let Some(pid) = project_id_cache::get_cached_project_id(connection_id) {
+            return pid;
+        }
+
+        // Cache miss: call loadCodeAssist.
+        let client = reqwest::Client::new();
+        let metadata = load_code_assist_metadata();
+        let metadata_json = serde_json::to_string(&metadata).unwrap_or_default();
+
+        let response = client
+            .post(cloud_code_api::LOAD_CODE_ASSIST)
+            .header("Authorization", format!("Bearer {access_token}"))
+            .header("Content-Type", "application/json")
+            .header("User-Agent", "google-api-nodejs-client/9.15.1")
+            .header(
+                "X-Goog-Api-Client",
+                "google-cloud-sdk vscode_cloudshelleditor/0.1",
+            )
+            .header("Client-Metadata", &metadata_json)
+            .json(&json!({ "metadata": metadata }))
+            .send()
+            .await;
+
+        match response {
+            Ok(resp) if resp.status().is_success() => {
+                if let Ok(payload) = resp.json::<Value>().await {
+                    if let Some(pid) =
+                        crate::core::utils::project_id_cache::extract_google_project_id(&payload)
+                    {
+                        project_id_cache::set_cached_project_id(connection_id, pid.clone());
+                        return pid;
+                    }
+                }
+            }
+            _ => {}
+        }
+
+        String::new()
+    }
+
+    /// POST `onboardUser` and poll (5 s interval, up to 10 attempts) until
+    /// the server responds with `{"done": true}`.
+    ///
+    /// This is a best-effort fire-and-forget call: network errors silently
+    /// return `Ok(())` so the caller is never blocked by an unreachable
+    /// onboard endpoint.
+    pub async fn on_user_onboard(
+        access_token: &str,
+        project_id: &str,
+    ) -> Result<(), AntigravityExecutorError> {
+        let client = reqwest::Client::new();
+        let metadata = load_code_assist_metadata();
+        let metadata_json = serde_json::to_string(&metadata).unwrap_or_default();
+        let onboard_url = cloud_code_api::ONBOARD_USER;
+
+        for attempt in 0..10 {
+            let response = client
+                .post(onboard_url)
+                .header("Authorization", format!("Bearer {access_token}"))
+                .header("Content-Type", "application/json")
+                .header("User-Agent", "google-api-nodejs-client/9.15.1")
+                .header(
+                    "X-Goog-Api-Client",
+                    "google-cloud-sdk vscode_cloudshelleditor/0.1",
+                )
+                .header("Client-Metadata", &metadata_json)
+                .json(&json!({
+                    "tierId": "legacy-tier",
+                    "projectId": project_id,
+                    "metadata": metadata,
+                }))
+                .send()
+                .await;
+
+            match response {
+                Ok(resp) if resp.status().is_success() => {
+                    let result = resp.json::<Value>().await.unwrap_or(Value::Null);
+                    if result.get("done").and_then(Value::as_bool) == Some(true) {
+                        tracing::info!(
+                            "antigravity onboardUser succeeded after {} poll(s)",
+                            attempt + 1
+                        );
+                        return Ok(());
+                    }
+                }
+                Err(_) => {
+                    // Network error during onboard is non-fatal — the API
+                    // will onboard on first request anyway.
+                    return Ok(());
+                }
+                _ => {}
+            }
+
+            tokio::time::sleep(std::time::Duration::from_secs(5)).await;
+        }
+
+        tracing::warn!("antigravity onboardUser did not complete after 10 polls");
+        Ok(())
     }
 
     /// Sanitize a tool function name so it matches Gemini's allowed
@@ -534,9 +676,40 @@ impl AntigravityExecutor {
             request.body = json!({"request": inner});
         }
 
+        // Resolve the project ID (cached or via loadCodeAssist) and inject
+        // it into the request body so the upstream sees a valid GCP project.
+        let connection_id = request
+            .credentials
+            .email
+            .as_deref()
+            .or_else(|| request.credentials.id.as_str().into())
+            .unwrap_or("");
+        let project_id = Self::get_project_id(connection_id, &access_token).await;
+        if !project_id.is_empty() {
+            if let Some(req) = request.body.get_mut("request").and_then(|v| v.as_object_mut()) {
+                req.insert("projectId".into(), Value::String(project_id.clone()));
+            }
+        }
+
+        // Spawn best-effort onboardUser notification in the background so
+        // it does not block the critical path.
+        if !project_id.is_empty() {
+            let at = access_token.clone();
+            let pid = project_id.clone();
+            tokio::spawn(async move {
+                let _ = Self::on_user_onboard(&at, &pid).await;
+            });
+        }
+
         let session_id = Self::transform_request(&mut request.body, &request.credentials)?;
         let url = Self::build_url(request.stream);
-        let headers = Self::build_headers(&access_token, request.stream, Some(&session_id))?;
+        let mut headers = Self::build_headers(&access_token, request.stream, Some(&session_id))?;
+
+        // Add Antigravity-specific headers (Client-Metadata, etc.).
+        let ag_headers = Self::build_antigravity_headers()?;
+        for (key, value) in ag_headers.iter() {
+            headers.insert(key, value.clone());
+        }
 
         let client = self.pool.get("antigravity", request.proxy.as_ref())?;
         let response = client
@@ -776,7 +949,43 @@ mod tests {
             "contents should be preserved after wrapping"
         );
     }
-}
 
-// `ProviderConnection` derives `Default` upstream — we just rely on that
-// inside the unit tests above.
+    #[test]
+    fn build_antigravity_headers_sets_expected_statics() {
+        let headers = AntigravityExecutor::build_antigravity_headers().unwrap();
+        assert_eq!(
+            headers.get("User-Agent").and_then(|v| v.to_str().ok()),
+            Some("google-api-nodejs-client/9.15.1")
+        );
+        assert_eq!(
+            headers.get("X-Goog-Api-Client").and_then(|v| v.to_str().ok()),
+            Some("google-cloud-sdk vscode_cloudshelleditor/0.1")
+        );
+        // Client-Metadata should be valid JSON.
+        let cm = headers
+            .get("Client-Metadata")
+            .and_then(|v| v.to_str().ok())
+            .expect("Client-Metadata header present");
+        let parsed: serde_json::Value =
+            serde_json::from_str(cm).expect("Client-Metadata is valid JSON");
+        assert_eq!(parsed["ideType"], 9);
+        assert!(parsed["platform"].is_number());
+        assert_eq!(parsed["pluginType"], 2);
+    }
+
+    #[test]
+    fn build_antigravity_headers_platform_detection() {
+        let headers = AntigravityExecutor::build_antigravity_headers().unwrap();
+        let cm = headers
+            .get("Client-Metadata")
+            .and_then(|v| v.to_str().ok())
+            .unwrap();
+        let parsed: serde_json::Value = serde_json::from_str(cm).unwrap();
+        let platform = parsed["platform"].as_u64().unwrap();
+        // Platform should be a valid AgPlatform value (1-5 or 0 for unknown).
+        assert!(
+            platform <= 5,
+            "platform value {platform} is in expected range"
+        );
+    }
+}

--- a/src/core/utils/mod.rs
+++ b/src/core/utils/mod.rs
@@ -9,6 +9,7 @@ pub mod claude_header_cache;
 pub mod client_detector;
 pub mod cursor_checksum;
 pub mod error;
+pub mod project_id_cache;
 pub mod reasoning_content_injector;
 pub mod session_manager;
 pub mod tool_deduper;

--- a/src/core/utils/project_id_cache.rs
+++ b/src/core/utils/project_id_cache.rs
@@ -1,0 +1,198 @@
+//! Thread-safe cache for Antigravity project IDs.
+//!
+//! Maps a provider connection's stable database id to a project ID
+//! (obtained from the `loadCodeAssist` endpoint) with a configurable TTL.
+//! Used by the Antigravity executor to avoid re-fetching the project ID
+//! on every request, and invalidated from the token refresh path so a
+//! refreshed token triggers a fresh lookup.
+
+use std::collections::HashMap;
+use std::sync::Mutex;
+use std::sync::OnceLock;
+use std::time::Duration;
+use std::time::Instant;
+
+use serde_json::Value;
+
+// ── Internal cache types ────────────────────────────────────────────────
+
+struct CachedProject {
+    project_id: String,
+    fetched_at: Instant,
+}
+
+/// A TTL-bearing cache for project IDs keyed by connection id.
+///
+/// - `get` returns `None` when the entry is missing or stale.
+/// - `set` inserts or overwrites with the current time.
+/// - `invalidate` removes the entry unconditionally.
+pub struct ProjectIdCache {
+    inner: Mutex<HashMap<String, CachedProject>>,
+    ttl: Duration,
+}
+
+impl ProjectIdCache {
+    /// Create a new cache with the given per-entry TTL.
+    pub fn new(ttl: Duration) -> Self {
+        Self {
+            inner: Mutex::new(HashMap::new()),
+            ttl,
+        }
+    }
+
+    /// Look up a cached project ID. Returns `None` if missing or expired.
+    pub fn get(&self, id: &str) -> Option<String> {
+        let map = self.inner.lock().ok()?;
+        if let Some(cached) = map.get(id) {
+            if cached.fetched_at.elapsed() < self.ttl {
+                return Some(cached.project_id.clone());
+            }
+        }
+        None
+    }
+
+    /// Insert (or update) a cached project ID with the current timestamp.
+    pub fn set(&self, id: &str, project_id: String) {
+        if let Ok(mut map) = self.inner.lock() {
+            map.insert(
+                id.to_string(),
+                CachedProject {
+                    project_id,
+                    fetched_at: Instant::now(),
+                },
+            );
+        }
+    }
+
+    /// Remove a cached entry. Safe to call even if the key does not exist.
+    pub fn invalidate(&self, id: &str) {
+        if let Ok(mut map) = self.inner.lock() {
+            map.remove(id);
+        }
+    }
+}
+
+// ── Global singleton ────────────────────────────────────────────────────
+
+fn cache() -> &'static ProjectIdCache {
+    static CACHE: OnceLock<ProjectIdCache> = OnceLock::new();
+    CACHE.get_or_init(|| ProjectIdCache::new(Duration::from_secs(300))) // 5-minute TTL
+}
+
+/// Get a cached project ID for the given connection id.
+pub fn get_cached_project_id(connection_id: &str) -> Option<String> {
+    cache().get(connection_id)
+}
+
+/// Store a project ID in the cache for the given connection id.
+pub fn set_cached_project_id(connection_id: &str, project_id: String) {
+    cache().set(connection_id, project_id);
+}
+
+/// Invalidate (remove) the cached project ID for the given connection id.
+pub fn invalidate_cached_project_id(connection_id: &str) {
+    cache().invalidate(connection_id);
+}
+
+// ── Helpers ─────────────────────────────────────────────────────────────
+
+/// Extract the Google Cloud project id from a `loadCodeAssist` response
+/// payload.  Returns `None` if the expected key (`cloudaicompanionProject`)
+/// is absent or empty.
+///
+/// Mirrors the identically-named helper in `src/server/api/oauth.rs`.
+pub fn extract_google_project_id(payload: &Value) -> Option<String> {
+    let project = payload.get("cloudaicompanionProject")?;
+    project
+        .get("id")
+        .and_then(Value::as_str)
+        .or_else(|| project.as_str())
+        .map(str::trim)
+        .filter(|s| !s.is_empty())
+        .map(str::to_string)
+}
+
+// ── Tests ───────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    #[test]
+    fn cache_get_miss_returns_none() {
+        let cache = ProjectIdCache::new(Duration::from_secs(300));
+        assert!(cache.get("nonexistent").is_none());
+    }
+
+    #[test]
+    fn cache_set_then_get_works() {
+        let cache = ProjectIdCache::new(Duration::from_secs(300));
+        cache.set("conn-1", "my-project-123".to_string());
+        assert_eq!(cache.get("conn-1").as_deref(), Some("my-project-123"));
+    }
+
+    #[test]
+    fn cache_invalidate_removes_entry() {
+        let cache = ProjectIdCache::new(Duration::from_secs(300));
+        cache.set("conn-1", "my-project-123".to_string());
+        cache.invalidate("conn-1");
+        assert!(cache.get("conn-1").is_none());
+    }
+
+    #[test]
+    fn cache_invalidate_missing_key_is_noop() {
+        let cache = ProjectIdCache::new(Duration::from_secs(300));
+        cache.invalidate("never-set"); // must not panic
+    }
+
+    #[test]
+    fn extract_google_project_id_finds_nested_id() {
+        let payload = json!({
+            "cloudaicompanionProject": {
+                "id": "projects/foo-123"
+            }
+        });
+        assert_eq!(
+            extract_google_project_id(&payload).as_deref(),
+            Some("projects/foo-123")
+        );
+    }
+
+    #[test]
+    fn extract_google_project_id_falls_back_to_flat_string() {
+        let payload = json!({
+            "cloudaicompanionProject": "projects/bar-456"
+        });
+        assert_eq!(
+            extract_google_project_id(&payload).as_deref(),
+            Some("projects/bar-456")
+        );
+    }
+
+    #[test]
+    fn extract_google_project_id_missing_returns_none() {
+        let payload = json!({});
+        assert!(extract_google_project_id(&payload).is_none());
+    }
+
+    #[test]
+    fn extract_google_project_id_empty_string_returns_none() {
+        let payload = json!({
+            "cloudaicompanionProject": {"id": ""}
+        });
+        assert!(extract_google_project_id(&payload).is_none());
+    }
+
+    #[test]
+    fn global_cache_works() {
+        // Clear any previous state by using a unique key.
+        let key = "global-test-conn";
+        invalidate_cached_project_id(key);
+        assert!(get_cached_project_id(key).is_none());
+        set_cached_project_id(key, "global-proj".to_string());
+        assert_eq!(get_cached_project_id(key).as_deref(), Some("global-proj"));
+        invalidate_cached_project_id(key);
+        assert!(get_cached_project_id(key).is_none());
+    }
+}

--- a/src/server/api/oauth.rs
+++ b/src/server/api/oauth.rs
@@ -37,6 +37,8 @@ use crate::server::auth::{extract_api_key, require_api_key};
 use crate::server::state::AppState;
 use crate::types::ProviderConnection;
 
+use crate::core::utils::project_id_cache;
+
 const PKCE_FLOW_TTL_SECS: i64 = 600;
 const DEVICE_FLOW_TTL_SECS: i64 = 900;
 const CLAUDE_CLIENT_ID: &str = "9d1c250a-e61b-44d9-88ed-5944d1962f5e";
@@ -4356,6 +4358,16 @@ pub async fn refresh_token(
             "storage_error",
             &provider,
         );
+    }
+
+    // When the antigravity access token is refreshed the cached project ID
+    // may become stale (e.g. if the underlying GCP project changed or the
+    // token scope was updated).  Invalidate it so the next executor call
+    // re-fetches from the loadCodeAssist endpoint.
+    if provider == "antigravity" {
+        if let Some(conn) = connection {
+            project_id_cache::invalidate_cached_project_id(&conn.id);
+        }
     }
 
     Json(RefreshResponse {


### PR DESCRIPTION
Add Antigravity executor Client-Metadata numeric enums, loadCodeAssist post-exchange, onboardUser polling, and ProjectIdCache per connection. Closes #94.