### PR TITLE
p2.3-gemini-cli-exec

### DIFF
--- a/src/core/config/app_constants.rs
+++ b/src/core/config/app_constants.rs
@@ -10,7 +10,7 @@ use std::time::Duration;
 
 // ─── Gemini CLI ────────────────────────────────────────────────────────────
 
-pub const GEMINI_CLI_VERSION: &str = "0.31.0";
+pub const GEMINI_CLI_VERSION: &str = "0.34.0";
 pub const GEMINI_CLI_API_CLIENT: &str = "google-genai-sdk/1.41.0 gl-node/v22.19.0";
 
 /// Build the User-Agent string Gemini CLI advertises for `model`.
@@ -18,12 +18,24 @@ pub fn gemini_cli_user_agent(model: &str) -> String {
     let model = if model.is_empty() { "unknown" } else { model };
     let os = std::env::consts::OS;
     format!(
-        "GeminiCLI/{}/{} ({}; {})",
+        "gemini-cli/{}/{} ({}; {}; terminal)",
         GEMINI_CLI_VERSION,
         model,
         os,
         std::env::consts::ARCH
     )
+}
+
+/// Build the Client-Metadata JSON value for Gemini CLI Bearer requests.
+/// - ideType: 9 (same as Antigravity/Cloud Code)
+/// - platform: detected from current host
+/// - pluginType: 2 (Gemini)
+pub fn gemini_cli_client_metadata() -> serde_json::Value {
+    json!({
+        "ideType": IdeType::Antigravity as u8,
+        "platform": current_platform() as u8,
+        "pluginType": AgPluginType::Gemini as u8,
+    })
 }
 
 // ─── GitHub Copilot ────────────────────────────────────────────────────────
@@ -315,7 +327,8 @@ mod tests {
     #[test]
     fn user_agent_contains_version_and_model() {
         let ua = gemini_cli_user_agent("gemini-3-pro");
-        assert!(ua.contains("GeminiCLI/0.31.0"));
+        assert!(ua.contains("gemini-cli/0.34.0"));
         assert!(ua.contains("gemini-3-pro"));
+        assert!(ua.contains("terminal"));
     }
 }

--- a/src/core/executor/gemini_cli.rs
+++ b/src/core/executor/gemini_cli.rs
@@ -5,21 +5,22 @@ use serde::{Deserialize, Serialize};
 use serde_json::Value;
 
 use crate::core::config::app_constants::{
+    gemini_cli_client_metadata, gemini_cli_user_agent, GEMINI_CLI_API_CLIENT,
     INTERNAL_REQUEST_HEADER_NAME, INTERNAL_REQUEST_HEADER_VALUE,
 };
 use crate::core::proxy::ProxyTarget;
 use crate::types::{ProviderConnection, ProviderNode};
 
 use super::{ClientPool, TransportKind, UpstreamResponse};
+use super::project_id_cache::lookup_project_id;
 
 const GEMINI_CLI_BASE_URL: &str = "https://generativelanguage.googleapis.com/v1beta/models";
-const GEMINI_CLI_API_CLIENT: &str = "google-genai-sdk/1.41.0 gl-node/v22.19.0";
-const GEMINI_CLI_VERSION: &str = "0.31.0";
 const GOOGLE_TOKEN_URL: &str = "https://oauth2.googleapis.com/token";
 
 #[derive(Clone)]
 pub struct GeminiCliExecutor {
     pool: Arc<ClientPool>,
+    #[allow(dead_code)]
     provider_node: Option<ProviderNode>,
 }
 
@@ -103,6 +104,7 @@ impl GeminiCliExecutor {
         &self.pool
     }
 
+    /// Build the standard Gemini CLI API URL (no API key in query string).
     fn build_url(&self, model: &str, stream: bool) -> String {
         let action = if stream {
             "streamGenerateContent?alt=sse"
@@ -112,6 +114,80 @@ impl GeminiCliExecutor {
         format!("{}/{}:{}", GEMINI_CLI_BASE_URL, model, action)
     }
 
+    /// Build the Gemini CLI API URL with the API key appended as a query
+    /// parameter (`?key=...` for unary, `&key=...` for SSE).
+    fn build_url_with_api_key(&self, model: &str, stream: bool, api_key: &str) -> String {
+        let base = self.build_url(model, stream);
+        if stream {
+            format!("{}&key={}", base, api_key)
+        } else {
+            format!("{}?key={}", base, api_key)
+        }
+    }
+
+    /// Detect whether this connection uses OAuth (Bearer) or API-key auth.
+    fn is_oauth(credentials: &ProviderConnection) -> bool {
+        credentials
+            .access_token
+            .as_deref()
+            .filter(|s| !s.is_empty())
+            .is_some()
+    }
+
+    /// Build headers for OAuth (Bearer) mode, as emitted by the real
+    /// Gemini CLI SDK.
+    ///
+    /// | Header             | Value                                              |
+    /// |--------------------|----------------------------------------------------|
+    /// | Authorization      | Bearer {access_token}                              |
+    /// | User-Agent         | gemini-cli/0.34.0/{model} ({os}; {arch}; terminal) |
+    /// | X-Goog-Api-Client  | google-genai-sdk/1.41.0 gl-node/v22.19.0           |
+    /// | Client-Metadata    | {"ideType":9,"platform":<enum>,"pluginType":2}     |
+    fn build_gemini_cli_headers(
+        access_token: &str,
+        stream: bool,
+        model: &str,
+    ) -> Result<HeaderMap, GeminiCliExecutorError> {
+        let mut headers = HeaderMap::new();
+        headers.insert(CONTENT_TYPE, HeaderValue::from_static("application/json"));
+
+        let auth = format!("Bearer {}", access_token);
+        headers.insert(AUTHORIZATION, HeaderValue::from_str(&auth)?);
+
+        let ua = gemini_cli_user_agent(model);
+        headers.insert(
+            reqwest::header::USER_AGENT,
+            HeaderValue::from_str(&ua)?,
+        );
+
+        headers.insert(
+            "X-Goog-Api-Client",
+            HeaderValue::from_static(GEMINI_CLI_API_CLIENT),
+        );
+
+        // Client-Metadata: serialised JSON object.
+        let metadata = gemini_cli_client_metadata();
+        let metadata_str = serde_json::to_string(&metadata).unwrap_or_default();
+        if !metadata_str.is_empty() {
+            headers.insert("Client-Metadata", HeaderValue::from_str(&metadata_str)?);
+        }
+
+        headers.insert(
+            INTERNAL_REQUEST_HEADER_NAME,
+            HeaderValue::from_static(INTERNAL_REQUEST_HEADER_VALUE),
+        );
+
+        if stream {
+            headers.insert(ACCEPT, HeaderValue::from_static("text/event-stream"));
+        } else {
+            headers.insert(ACCEPT, HeaderValue::from_static("application/json"));
+        }
+
+        Ok(headers)
+    }
+
+    /// Legacy header builder used for API-key-only connections.
+    /// Kept for backward compatibility with existing callers.
     fn build_headers(
         &self,
         credentials: &ProviderConnection,
@@ -129,7 +205,7 @@ impl GeminiCliExecutor {
             );
         }
 
-        let ua = format!("GeminiCLI/{}/{} (linux; x64)", GEMINI_CLI_VERSION, model);
+        let ua = gemini_cli_user_agent(model);
         headers.insert(
             reqwest::header::USER_AGENT,
             HeaderValue::from_str(&ua).unwrap_or_else(|_| HeaderValue::from_static("")),
@@ -152,13 +228,40 @@ impl GeminiCliExecutor {
         headers
     }
 
+    /// Transform the request body:
+    /// - OAuth mode: inject `project` from the ProjectIdCache.
+    /// - API-key mode (existing behaviour): inject `project` from
+    ///   `provider_specific_data["projectId"]` if present.
     fn transform_request(&self, body: &Value, credentials: &ProviderConnection) -> Value {
+        let is_oauth = Self::is_oauth(credentials);
+        self.transform_request_inner(body, credentials, is_oauth)
+    }
+
+    fn transform_request_inner(
+        &self,
+        body: &Value,
+        credentials: &ProviderConnection,
+        is_oauth: bool,
+    ) -> Value {
         let mut transformed = body.clone();
-        if transformed.get("project").is_none() {
+
+        if transformed.get("project").is_some() {
+            return transformed;
+        }
+
+        if is_oauth {
+            // OAuth mode: resolve projectId via the cache (which checks
+            // provider_specific_data, ProviderConnection.project_id, etc.)
+            if let Some(project_id) = lookup_project_id(credentials) {
+                transformed["project"] = Value::String(project_id);
+            }
+        } else {
+            // API-key mode: original behaviour — read from provider_specific_data.
             if let Some(project_id) = credentials.provider_specific_data.get("projectId") {
                 transformed["project"] = project_id.clone();
             }
         }
+
         transformed
     }
 
@@ -166,8 +269,30 @@ impl GeminiCliExecutor {
         &self,
         request: GeminiCliExecutionRequest,
     ) -> Result<GeminiCliExecutorResponse, GeminiCliExecutorError> {
-        let url = self.build_url(&request.model, request.stream);
-        let headers = self.build_headers(&request.credentials, request.stream, &request.model);
+        let is_oauth = Self::is_oauth(&request.credentials);
+
+        // Pick URL and headers according to auth mode.
+        let (url, headers) = if is_oauth {
+            let access_token = request
+                .credentials
+                .access_token
+                .as_deref()
+                .unwrap_or("");
+            let hdrs =
+                Self::build_gemini_cli_headers(access_token, request.stream, &request.model)?;
+            let url = self.build_url(&request.model, request.stream);
+            (url, hdrs)
+        } else {
+            let api_key = request.credentials.api_key.as_deref().ok_or_else(|| {
+                GeminiCliExecutorError::MissingCredentials(
+                    "neither access_token nor api_key present".to_string(),
+                )
+            })?;
+            let url = self.build_url_with_api_key(&request.model, request.stream, api_key);
+            let hdrs = self.build_headers(&request.credentials, request.stream, &request.model);
+            (url, hdrs)
+        };
+
         let transformed_body = self.transform_request(&request.body, &request.credentials);
 
         let client = self.pool.get("gemini-cli", request.proxy.as_ref())?;
@@ -217,5 +342,169 @@ impl GeminiCliExecutor {
         }
 
         response.json::<GeminiCliTokenResponse>().await.ok()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    #[test]
+    fn build_url_picks_stream_or_unary_path() {
+        let executor = GeminiCliExecutor {
+            pool: Arc::new(ClientPool::new()),
+            provider_node: None,
+        };
+        assert!(executor
+            .build_url("gemini-2.0-flash", true)
+            .contains("streamGenerateContent?alt=sse"));
+        assert!(executor
+            .build_url("gemini-2.0-flash", false)
+            .contains("generateContent"));
+    }
+
+    #[test]
+    fn build_url_with_api_key_appends_correctly() {
+        let executor = GeminiCliExecutor {
+            pool: Arc::new(ClientPool::new()),
+            provider_node: None,
+        };
+        let stream_url = executor.build_url_with_api_key("gemini-2.0-flash", true, "sk-test");
+        assert!(stream_url.ends_with("&key=sk-test"));
+
+        let unary_url = executor.build_url_with_api_key("gemini-2.0-flash", false, "sk-test");
+        assert!(unary_url.ends_with("?key=sk-test"));
+    }
+
+    #[test]
+    fn is_oauth_detects_access_token() {
+        let mut creds = ProviderConnection::default();
+        assert!(!GeminiCliExecutor::is_oauth(&creds));
+
+        creds.access_token = Some("".to_string());
+        assert!(!GeminiCliExecutor::is_oauth(&creds));
+
+        creds.access_token = Some("tok-valid".to_string());
+        assert!(GeminiCliExecutor::is_oauth(&creds));
+    }
+
+    #[test]
+    fn build_gemini_cli_headers_includes_all_expected_headers() {
+        let hdrs =
+            GeminiCliExecutor::build_gemini_cli_headers("tok-test", false, "gemini-2.0-flash")
+                .unwrap();
+
+        assert_eq!(
+            hdrs.get("Authorization").unwrap().to_str().unwrap(),
+            "Bearer tok-test"
+        );
+        assert!(hdrs.get("user-agent").is_some());
+        assert!(hdrs
+            .get("user-agent")
+            .unwrap()
+            .to_str()
+            .unwrap()
+            .contains("gemini-cli/0.34.0"));
+        assert!(hdrs
+            .get("user-agent")
+            .unwrap()
+            .to_str()
+            .unwrap()
+            .contains("terminal"));
+        assert_eq!(
+            hdrs.get("x-goog-api-client").unwrap().to_str().unwrap(),
+            GEMINI_CLI_API_CLIENT
+        );
+        assert!(hdrs.get("client-metadata").is_some());
+        let cm = hdrs.get("client-metadata").unwrap().to_str().unwrap();
+        assert!(cm.contains(r#""ideType":9"#));
+        assert!(cm.contains(r#""pluginType":2"#));
+        assert_eq!(
+            hdrs.get("content-type").unwrap().to_str().unwrap(),
+            "application/json"
+        );
+        assert_eq!(
+            hdrs.get("accept").unwrap().to_str().unwrap(),
+            "application/json"
+        );
+        assert_eq!(
+            hdrs.get("x-request-source").unwrap().to_str().unwrap(),
+            "local"
+        );
+    }
+
+    #[test]
+    fn build_gemini_cli_headers_sets_stream_accept_for_stream() {
+        let hdrs =
+            GeminiCliExecutor::build_gemini_cli_headers("tok-test", true, "gemini-2.0-flash")
+                .unwrap();
+        assert_eq!(
+            hdrs.get("accept").unwrap().to_str().unwrap(),
+            "text/event-stream"
+        );
+    }
+
+    #[test]
+    fn transform_request_injects_project_id_from_cache_for_oauth() {
+        let executor = GeminiCliExecutor {
+            pool: Arc::new(ClientPool::new()),
+            provider_node: None,
+        };
+        let mut creds = ProviderConnection::default();
+        creds.access_token = Some("tok-transform".to_string());
+        creds.project_id = Some("proj-from-cache".to_string());
+
+        let body = json!({"contents": [{"parts": [{"text": "hello"}]}]});
+        let transformed = executor.transform_request_inner(&body, &creds, true);
+        assert_eq!(transformed["project"], "proj-from-cache");
+    }
+
+    #[test]
+    fn transform_request_does_not_overwrite_existing_project() {
+        let executor = GeminiCliExecutor {
+            pool: Arc::new(ClientPool::new()),
+            provider_node: None,
+        };
+        let mut creds = ProviderConnection::default();
+        creds.access_token = Some("tok-exist".to_string());
+        creds.project_id = Some("proj-from-cache".to_string());
+
+        let body = json!({"project": "existing-proj", "contents": []});
+        let transformed = executor.transform_request_inner(&body, &creds, true);
+        assert_eq!(transformed["project"], "existing-proj");
+    }
+
+    #[test]
+    fn transform_request_uses_api_key_mode_when_no_access_token() {
+        let executor = GeminiCliExecutor {
+            pool: Arc::new(ClientPool::new()),
+            provider_node: None,
+        };
+        let mut creds = ProviderConnection::default();
+        // No access_token -- API key mode.
+        let mut data = std::collections::BTreeMap::new();
+        data.insert(
+            "projectId".to_string(),
+            serde_json::Value::String("proj-psd".to_string()),
+        );
+        creds.provider_specific_data = data;
+
+        let body = json!({"contents": [{"parts": [{"text": "hi"}]}]});
+        // false = API key mode
+        let transformed = executor.transform_request_inner(&body, &creds, false);
+        assert_eq!(transformed["project"], "proj-psd");
+    }
+
+    #[test]
+    fn transform_request_skips_project_when_cache_empty_for_oauth() {
+        let executor = GeminiCliExecutor {
+            pool: Arc::new(ClientPool::new()),
+            provider_node: None,
+        };
+        let creds = ProviderConnection::default(); // no access token, no project_id
+        let body = json!({"contents": [{"parts": [{"text": "hi"}]}]});
+        let transformed = executor.transform_request_inner(&body, &creds, true);
+        assert!(transformed.get("project").is_none());
     }
 }

--- a/src/core/executor/mod.rs
+++ b/src/core/executor/mod.rs
@@ -14,6 +14,7 @@ mod kiro;
 mod ollama;
 mod opencode;
 mod opencode_go;
+mod project_id_cache;
 mod provider;
 mod qoder;
 mod qwen;

--- a/src/core/executor/project_id_cache.rs
+++ b/src/core/executor/project_id_cache.rs
@@ -1,0 +1,140 @@
+//! Lightweight in-memory cache mapping access tokens to their resolved GCP
+//! project id. Falls back to `provider_specific_data["projectId"]` and
+//! `ProviderConnection.project_id` when the cache is cold.
+//!
+//! Port of `open-sse/utils/projectIdCache.js` from 9router (P2.2).
+
+use parking_lot::RwLock;
+use std::collections::HashMap;
+use std::sync::OnceLock;
+
+use crate::types::ProviderConnection;
+
+fn cache() -> &'static RwLock<HashMap<String, String>> {
+    static CELL: OnceLock<RwLock<HashMap<String, String>>> = OnceLock::new();
+    CELL.get_or_init(|| RwLock::new(HashMap::new()))
+}
+
+/// Look up the project id for `credentials`. Checks, in order:
+/// 1. In-memory cache keyed by access_token
+/// 2. `provider_specific_data["projectId"]`
+/// 3. `provider_specific_data["project"]`
+/// 4. `credentials.project_id`
+///
+/// If found via 2-4 the result is cached under the current access token so
+/// subsequent lookups for the same connection hit the fast path.
+pub fn lookup_project_id(credentials: &ProviderConnection) -> Option<String> {
+    let access_token = credentials.access_token.as_deref().unwrap_or("");
+
+    // 1. Check cache (only when we have a keyable token).
+    if !access_token.is_empty() {
+        if let Some(cached) = cache().read().get(access_token).cloned() {
+            return Some(cached);
+        }
+    }
+
+    // 2-4. Check fallback sources.
+    let found = credentials
+        .provider_specific_data
+        .get("projectId")
+        .and_then(|v| v.as_str())
+        .map(str::to_string)
+        .or_else(|| {
+            credentials
+                .provider_specific_data
+                .get("project")
+                .and_then(|v| v.as_str())
+                .map(str::to_string)
+        })
+        .or_else(|| credentials.project_id.clone());
+
+    // Cache it so the hot path (1) wins next time.
+    if let Some(ref pid) = found {
+        if !access_token.is_empty() {
+            cache().write().insert(access_token.to_string(), pid.clone());
+        }
+    }
+
+    found
+}
+
+/// Clear the entire cache. Mainly useful for tests.
+#[allow(dead_code)]
+pub fn clear_cache() {
+    cache().write().clear();
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::collections::BTreeMap;
+    use serde_json::Value;
+
+    fn make_creds(
+        access_token: Option<&str>,
+        project_id: Option<&str>,
+        psd: Vec<(&str, &str)>,
+    ) -> ProviderConnection {
+        let mut data = BTreeMap::new();
+        for (k, v) in psd {
+            data.insert(k.to_string(), Value::String(v.to_string()));
+        }
+        ProviderConnection {
+            access_token: access_token.map(|s| s.to_string()),
+            project_id: project_id.map(|s| s.to_string()),
+            provider_specific_data: data,
+            ..ProviderConnection::default()
+        }
+    }
+
+    #[test]
+    fn lookup_from_project_id_field() {
+        let creds = make_creds(Some("tok1"), Some("proj-main"), vec![]);
+        assert_eq!(lookup_project_id(&creds), Some("proj-main".to_string()));
+    }
+
+    #[test]
+    fn lookup_from_provider_specific_data() {
+        let creds = make_creds(Some("tok2"), None, vec![("projectId", "proj-psd")]);
+        assert_eq!(lookup_project_id(&creds), Some("proj-psd".to_string()));
+    }
+
+    #[test]
+    fn lookup_from_provider_specific_project() {
+        let creds = make_creds(Some("tok3"), None, vec![("project", "proj-short")]);
+        assert_eq!(lookup_project_id(&creds), Some("proj-short".to_string()));
+    }
+
+    #[test]
+    fn lookup_caches_by_access_token() {
+        clear_cache();
+        let creds = make_creds(Some("tok-cache"), Some("proj-cached"), vec![]);
+        assert_eq!(lookup_project_id(&creds), Some("proj-cached".to_string()));
+
+        // Changing project_id on the creds shouldn't matter — cache hit.
+        let creds2 = make_creds(Some("tok-cache"), Some("proj-different"), vec![]);
+        assert_eq!(lookup_project_id(&creds2), Some("proj-cached".to_string()));
+    }
+
+    #[test]
+    fn returns_none_when_no_sources() {
+        let creds = make_creds(Some("tok-none"), None, vec![]);
+        assert!(lookup_project_id(&creds).is_none());
+    }
+
+    #[test]
+    fn handles_empty_access_token() {
+        let creds = make_creds(None, Some("proj-no-token"), vec![]);
+        assert_eq!(lookup_project_id(&creds), Some("proj-no-token".to_string()));
+    }
+
+    #[test]
+    fn psd_projectid_takes_precedence_over_project_id_field() {
+        let creds = make_creds(
+            Some("tok-prec"),
+            Some("fallback"),
+            vec![("projectId", "winner")],
+        );
+        assert_eq!(lookup_project_id(&creds), Some("winner".to_string()));
+    }
+}


### PR DESCRIPTION
Add Gemini CLI executor Bearer auth + Client-Metadata for OAuth mode alongside existing API-key mode. Closes #95.