### PR TITLE
p2.4-xai-executor

### DIFF
--- a/src/core/executor/mod.rs
+++ b/src/core/executor/mod.rs
@@ -18,6 +18,7 @@ mod provider;
 mod qoder;
 mod qwen;
 mod vertex;
+mod xai;
 
 pub use antigravity::{
     AntigravityExecutionRequest, AntigravityExecutor, AntigravityExecutorError,
@@ -84,6 +85,9 @@ pub use qoder::{QoderExecutionRequest, QoderExecutor, QoderExecutorError, QoderE
 pub use qwen::{QwenExecutionRequest, QwenExecutor, QwenExecutorError, QwenExecutorResponse};
 pub use vertex::{
     VertexExecutionRequest, VertexExecutor, VertexExecutorError, VertexExecutorResponse,
+};
+pub use xai::{
+    XaiExecutionRequest, XaiExecutor, XaiExecutorError, XaiExecutorResponse,
 };
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]

--- a/src/core/executor/provider.rs
+++ b/src/core/executor/provider.rs
@@ -516,7 +516,11 @@ static PROVIDER_REGISTRY: once_cell::sync::Lazy<BTreeMap<&'static str, ProviderE
                 "perplexity",
                 ProviderExecutorConfig::openai("https://api.perplexity.ai/chat/completions"),
             ),
-            ("xai", ProviderExecutorConfig::openai("https://api.x.ai/v1")),
+            (
+                "xai",
+                ProviderExecutorConfig::openai("https://api.x.ai/v1")
+                    .with_header("User-Agent", "grok-cli/9router"),
+            ),
             (
                 "nvidia",
                 ProviderExecutorConfig::openai("https://integrate.api.nvidia.com/v1"),

--- a/src/core/executor/xai.rs
+++ b/src/core/executor/xai.rs
@@ -1,0 +1,153 @@
+use std::sync::Arc;
+
+use reqwest::header::{HeaderMap, HeaderValue, ACCEPT, AUTHORIZATION, CONTENT_TYPE, USER_AGENT};
+use serde_json::Value;
+
+use crate::core::proxy::ProxyTarget;
+use crate::types::{ProviderConnection, ProviderNode};
+
+use super::{ClientPool, TransportKind, UpstreamResponse};
+
+const XAI_BASE_URL: &str = "https://api.x.ai/v1";
+
+#[derive(Clone)]
+pub struct XaiExecutor {
+    pool: Arc<ClientPool>,
+    #[allow(dead_code)]
+    provider_node: Option<ProviderNode>,
+}
+
+#[derive(Debug)]
+pub enum XaiExecutorError {
+    MissingCredentials(String),
+    InvalidHeader(reqwest::header::InvalidHeaderValue),
+    Serialize(serde_json::Error),
+    HyperClientInit(std::io::Error),
+    Hyper(hyper_util::client::legacy::Error),
+    Request(reqwest::Error),
+}
+
+impl From<reqwest::Error> for XaiExecutorError {
+    fn from(error: reqwest::Error) -> Self {
+        Self::Request(error)
+    }
+}
+
+impl From<reqwest::header::InvalidHeaderValue> for XaiExecutorError {
+    fn from(error: reqwest::header::InvalidHeaderValue) -> Self {
+        Self::InvalidHeader(error)
+    }
+}
+
+impl From<hyper_util::client::legacy::Error> for XaiExecutorError {
+    fn from(error: hyper_util::client::legacy::Error) -> Self {
+        Self::Hyper(error)
+    }
+}
+
+impl From<std::io::Error> for XaiExecutorError {
+    fn from(error: std::io::Error) -> Self {
+        Self::HyperClientInit(error)
+    }
+}
+
+impl From<serde_json::Error> for XaiExecutorError {
+    fn from(error: serde_json::Error) -> Self {
+        Self::Serialize(error)
+    }
+}
+
+pub struct XaiExecutionRequest {
+    pub model: String,
+    pub body: Value,
+    pub stream: bool,
+    pub credentials: ProviderConnection,
+    pub proxy: Option<ProxyTarget>,
+}
+
+pub struct XaiExecutorResponse {
+    pub response: UpstreamResponse,
+    pub url: String,
+    pub headers: HeaderMap,
+    pub transformed_body: Value,
+    pub transport: TransportKind,
+}
+
+impl XaiExecutor {
+    pub fn new(
+        pool: Arc<ClientPool>,
+        provider_node: Option<ProviderNode>,
+    ) -> Result<Self, XaiExecutorError> {
+        Ok(Self {
+            pool,
+            provider_node,
+        })
+    }
+
+    pub fn pool(&self) -> &Arc<ClientPool> {
+        &self.pool
+    }
+
+    fn build_url() -> String {
+        format!("{}/chat/completions", XAI_BASE_URL.trim_end_matches('/'))
+    }
+
+    fn build_headers(
+        credentials: &ProviderConnection,
+        stream: bool,
+    ) -> Result<HeaderMap, XaiExecutorError> {
+        let mut headers = HeaderMap::new();
+        headers.insert(CONTENT_TYPE, HeaderValue::from_static("application/json"));
+        headers.insert(
+            USER_AGENT,
+            HeaderValue::from_static("grok-cli/9router"),
+        );
+
+        // Auto-detect: prefer apiKey, fall back to accessToken
+        let token = credentials
+            .api_key
+            .as_deref()
+            .or(credentials.access_token.as_deref())
+            .ok_or_else(|| XaiExecutorError::MissingCredentials("xai".to_string()))?;
+
+        headers.insert(
+            AUTHORIZATION,
+            HeaderValue::from_str(&format!("Bearer {token}"))?,
+        );
+
+        if stream {
+            headers.insert(ACCEPT, HeaderValue::from_static("text/event-stream"));
+        }
+
+        Ok(headers)
+    }
+
+    fn transform_request(body: &Value) -> Value {
+        body.clone()
+    }
+
+    pub async fn execute_request(
+        &self,
+        request: XaiExecutionRequest,
+    ) -> Result<XaiExecutorResponse, XaiExecutorError> {
+        let url = Self::build_url();
+        let headers = Self::build_headers(&request.credentials, request.stream)?;
+        let transformed_body = Self::transform_request(&request.body);
+
+        let client = self.pool.get("xai", request.proxy.as_ref())?;
+        let response = client
+            .post(&url)
+            .headers(headers.clone())
+            .json(&transformed_body)
+            .send()
+            .await?;
+
+        Ok(XaiExecutorResponse {
+            response: UpstreamResponse::Reqwest(response),
+            url,
+            headers,
+            transformed_body,
+            transport: TransportKind::Reqwest,
+        })
+    }
+}


### PR DESCRIPTION
Add xAI executor using https://api.x.ai/v1 with Bearer token. OpenAI-compatible passthrough. Closes #96.