### PR TITLE
fix(models): register opencode-zen catalog so models appear in /v1/models and combos

### DIFF
--- a/src/core/model/provider_catalog.json
+++ b/src/core/model/provider_catalog.json
@@ -3698,6 +3698,226 @@
           "kind": "llm"
         }
       ]
+    },
+    {
+      "alias": "opencode-zen",
+      "models": [
+        {
+          "id": "big-pickle",
+          "name": "Big Pickle",
+          "kind": "llm"
+        },
+        {
+          "id": "gpt-5-nano",
+          "name": "GPT 5 Nano",
+          "kind": "llm"
+        },
+        {
+          "id": "gpt-5",
+          "name": "GPT 5",
+          "kind": "llm"
+        },
+        {
+          "id": "gpt-5-codex",
+          "name": "GPT 5 Codex",
+          "kind": "llm"
+        },
+        {
+          "id": "gpt-5.1",
+          "name": "GPT 5.1",
+          "kind": "llm"
+        },
+        {
+          "id": "gpt-5.1-codex",
+          "name": "GPT 5.1 Codex",
+          "kind": "llm"
+        },
+        {
+          "id": "gpt-5.1-codex-max",
+          "name": "GPT 5.1 Codex Max",
+          "kind": "llm"
+        },
+        {
+          "id": "gpt-5.1-codex-mini",
+          "name": "GPT 5.1 Codex Mini",
+          "kind": "llm"
+        },
+        {
+          "id": "gpt-5.2",
+          "name": "GPT 5.2",
+          "kind": "llm"
+        },
+        {
+          "id": "gpt-5.2-codex",
+          "name": "GPT 5.2 Codex",
+          "kind": "llm"
+        },
+        {
+          "id": "gpt-5.3-codex",
+          "name": "GPT 5.3 Codex",
+          "kind": "llm"
+        },
+        {
+          "id": "gpt-5.3-codex-spark",
+          "name": "GPT 5.3 Codex Spark",
+          "kind": "llm"
+        },
+        {
+          "id": "gpt-5.4",
+          "name": "GPT 5.4",
+          "kind": "llm"
+        },
+        {
+          "id": "gpt-5.4-mini",
+          "name": "GPT 5.4 Mini",
+          "kind": "llm"
+        },
+        {
+          "id": "gpt-5.4-nano",
+          "name": "GPT 5.4 Nano",
+          "kind": "llm"
+        },
+        {
+          "id": "gpt-5.4-pro",
+          "name": "GPT 5.4 Pro",
+          "kind": "llm"
+        },
+        {
+          "id": "gpt-5.5",
+          "name": "GPT 5.5",
+          "kind": "llm"
+        },
+        {
+          "id": "gpt-5.5-pro",
+          "name": "GPT 5.5 Pro",
+          "kind": "llm"
+        },
+        {
+          "id": "claude-haiku-4-5",
+          "name": "Claude Haiku 4.5",
+          "kind": "llm"
+        },
+        {
+          "id": "claude-sonnet-4",
+          "name": "Claude Sonnet 4",
+          "kind": "llm"
+        },
+        {
+          "id": "claude-sonnet-4-5",
+          "name": "Claude Sonnet 4.5",
+          "kind": "llm"
+        },
+        {
+          "id": "claude-sonnet-4-6",
+          "name": "Claude Sonnet 4.6",
+          "kind": "llm"
+        },
+        {
+          "id": "claude-opus-4-1",
+          "name": "Claude Opus 4.1",
+          "kind": "llm"
+        },
+        {
+          "id": "claude-opus-4-5",
+          "name": "Claude Opus 4.5",
+          "kind": "llm"
+        },
+        {
+          "id": "claude-opus-4-6",
+          "name": "Claude Opus 4.6",
+          "kind": "llm"
+        },
+        {
+          "id": "claude-opus-4-7",
+          "name": "Claude Opus 4.7",
+          "kind": "llm"
+        },
+        {
+          "id": "gemini-3-flash",
+          "name": "Gemini 3 Flash",
+          "kind": "llm"
+        },
+        {
+          "id": "gemini-3.1-pro",
+          "name": "Gemini 3.1 Pro",
+          "kind": "llm"
+        },
+        {
+          "id": "gemini-3.5-flash",
+          "name": "Gemini 3.5 Flash",
+          "kind": "llm"
+        },
+        {
+          "id": "grok-build-0.1",
+          "name": "Grok Build 0.1",
+          "kind": "llm"
+        },
+        {
+          "id": "glm-5",
+          "name": "GLM-5",
+          "kind": "llm"
+        },
+        {
+          "id": "glm-5.1",
+          "name": "GLM-5.1",
+          "kind": "llm"
+        },
+        {
+          "id": "minimax-m3",
+          "name": "MiniMax M3",
+          "kind": "llm"
+        },
+        {
+          "id": "minimax-m2.5",
+          "name": "MiniMax M2.5",
+          "kind": "llm"
+        },
+        {
+          "id": "minimax-m2.7",
+          "name": "MiniMax M2.7",
+          "kind": "llm"
+        },
+        {
+          "id": "kimi-k2.5",
+          "name": "Kimi K2.5",
+          "kind": "llm"
+        },
+        {
+          "id": "kimi-k2.6",
+          "name": "Kimi K2.6",
+          "kind": "llm"
+        },
+        {
+          "id": "qwen3.5-plus",
+          "name": "Qwen3.5 Plus",
+          "kind": "llm"
+        },
+        {
+          "id": "qwen3.6-plus",
+          "name": "Qwen3.6 Plus",
+          "kind": "llm"
+        },
+        {
+          "id": "deepseek-v4-flash-free",
+          "name": "DeepSeek V4 Flash Free",
+          "kind": "llm"
+        },
+        {
+          "id": "minimax-m2.5-free",
+          "name": "MiniMax M2.5 Free",
+          "kind": "llm"
+        },
+        {
+          "id": "nemotron-3-super-free",
+          "name": "Nemotron 3 Super Free",
+          "kind": "llm"
+        },
+        {
+          "id": "qwen3.6-plus-free",
+          "name": "Qwen3.6 Plus Free",
+          "kind": "llm"
+        }
+      ]
     }
   ],
   "providers": [
@@ -4860,6 +5080,17 @@
     {
       "id": "mimo-free",
       "alias": "mmf",
+      "serviceKinds": [
+        "llm"
+      ],
+      "ttsModels": [],
+      "embeddingModels": [],
+      "hasSearch": false,
+      "hasFetch": false
+    },
+    {
+      "id": "opencode-zen",
+      "alias": "opencode-zen",
       "serviceKinds": [
         "llm"
       ],

--- a/src/server/api/provider_models.rs
+++ b/src/server/api/provider_models.rs
@@ -104,6 +104,101 @@ pub(super) async fn fetch_compatible_model_ids(connection: &ProviderConnection) 
     )
 }
 
+/// Generic dynamic-discovery fallback used by `/v1/models`.
+///
+/// For compatible providers this keeps the exact `fetch_compatible_model_ids`
+/// behavior. For built-in providers it runs the same discovery the dashboard
+/// uses (`fetch_provider_models_response`), so a provider whose static catalog
+/// entry is missing/empty is still exposed through `/v1/models` instead of
+/// silently disappearing. Providers without a discovery fetcher return
+/// immediately with no network traffic.
+pub(super) async fn fetch_discovered_model_ids(
+    state: &AppState,
+    connection: &ProviderConnection,
+) -> Vec<String> {
+    if is_openai_compatible_provider(&connection.provider)
+        || is_anthropic_compatible_provider(&connection.provider)
+    {
+        return fetch_compatible_model_ids(connection).await;
+    }
+
+    let models = fetch_provider_models_response(state, connection)
+        .await
+        .ok()
+        .map(|payload| payload.models)
+        .unwrap_or_default();
+
+    dedupe_model_ids(
+        models
+            .into_iter()
+            .map(|model| model.id.trim().to_string())
+            .filter(|id| !id.is_empty())
+            .collect(),
+    )
+}
+
+/// Whether the server has a models-listing fetcher for this provider.
+///
+/// Mirrors the match arms in `fetch_provider_models_response`. Used by
+/// `/v1/models` to decide whether a catalog-less connection can fall back to
+/// live discovery without issuing doomed network requests.
+pub(super) fn supports_models_discovery(provider: &str) -> bool {
+    is_openai_compatible_provider(provider)
+        || is_anthropic_compatible_provider(provider)
+        || matches!(
+            provider,
+            "kiro"
+                | "gemini-cli"
+                | "ollama-local"
+                | "claude"
+                | "anthropic"
+                | "gemini"
+                | "qwen"
+                | "codex"
+                | "antigravity"
+                | "github"
+                | "qoder"
+                | "openai"
+                | "openrouter"
+                | "opencode-zen"
+                | "alicode"
+                | "alicode-intl"
+                | "volcengine-ark"
+                | "byteplus"
+                | "deepseek"
+                | "groq"
+                | "xai"
+                | "mistral"
+                | "perplexity"
+                | "together"
+                | "fireworks"
+                | "cerebras"
+                | "cohere"
+                | "nebius"
+                | "siliconflow"
+                | "hyperbolic"
+                | "ollama"
+                | "nanobanana"
+                | "chutes"
+                | "nvidia"
+                | "assemblyai"
+                | "xiaomi-mimo"
+                | "xiaomi-tokenplan"
+                | "aimlapi"
+                | "modal"
+                | "reka"
+                | "kluster"
+                | "morph"
+                | "longcat"
+                | "scaleway"
+                | "sambanova"
+                | "nscale"
+                | "baseten"
+                | "nous-research"
+                | "glhf"
+        )
+}
+
 pub(super) async fn fetch_models_for_connection(
     state: &AppState,
     connection: &ProviderConnection,
@@ -225,6 +320,13 @@ async fn fetch_provider_models_response(
         }
         "openrouter" => {
             fetch_first_party_openai_style_models(connection, "https://openrouter.ai/api/v1/models")
+                .await
+        }
+        "opencode-zen" => {
+            // OpenCode Zen exposes an OpenAI-compatible models listing. Same
+            // endpoint the dashboard's modelsFetcher uses for the `opencode`
+            // free provider (https://opencode.ai/zen/v1/models).
+            fetch_first_party_openai_style_models(connection, "https://opencode.ai/zen/v1/models")
                 .await
         }
         "alicode" => {
@@ -1380,6 +1482,17 @@ mod tests {
             normalize_anthropic_models_base_url("https://example.com/v1/messages/"),
             "https://example.com/v1/models"
         );
+    }
+
+    #[test]
+    fn supports_models_discovery_covers_builtin_and_compatible_providers() {
+        assert!(supports_models_discovery("opencode-zen"));
+        assert!(supports_models_discovery("nvidia"));
+        assert!(supports_models_discovery("openrouter"));
+        assert!(supports_models_discovery("ollama-local"));
+        assert!(supports_models_discovery("openai-compatible-chat"));
+        assert!(supports_models_discovery("anthropic-compatible-chat"));
+        assert!(!supports_models_discovery("totally-unknown-provider"));
     }
 
     #[test]

--- a/src/server/api/v1_models.rs
+++ b/src/server/api/v1_models.rs
@@ -20,8 +20,6 @@ use crate::server::state::AppState;
 use crate::types::{AppDb, ModelAliasTarget, ProviderConnection};
 
 const LLM_KIND: &str = "llm";
-const OPENAI_COMPATIBLE_PREFIX: &str = "openai-compatible-";
-const ANTHROPIC_COMPATIBLE_PREFIX: &str = "anthropic-compatible-";
 
 static UPSTREAM_CONNECTION_RE: Lazy<Regex> =
     Lazy::new(|| Regex::new(r"[-_][0-9a-f]{8,}$").expect("valid upstream connection regex"));
@@ -86,7 +84,7 @@ async fn list_models_for_kinds(
         }
     }
 
-    let data = build_models_list(&snapshot, kind_filter).await;
+    let data = build_models_list(&state, &snapshot, kind_filter).await;
 
     with_cors_response(
         Json(ModelListResponse {
@@ -97,7 +95,11 @@ async fn list_models_for_kinds(
     )
 }
 
-async fn build_models_list(snapshot: &AppDb, kind_filter: &[&str]) -> Vec<ModelCard> {
+async fn build_models_list(
+    state: &AppState,
+    snapshot: &AppDb,
+    kind_filter: &[&str],
+) -> Vec<ModelCard> {
     let catalog = provider_catalog();
     let alias_to_provider_id = catalog.alias_to_provider_id();
     let created = SystemTime::now()
@@ -208,12 +210,12 @@ async fn build_models_list(snapshot: &AppDb, kind_filter: &[&str]) -> Vec<ModelC
                     .collect::<Vec<_>>();
             }
 
-            if is_compatible_provider(provider_id)
-                && raw_model_ids.is_empty()
+            if raw_model_ids.is_empty()
                 && !UPSTREAM_CONNECTION_RE.is_match(provider_id)
+                && super::provider_models::supports_models_discovery(provider_id)
             {
                 raw_model_ids =
-                    super::provider_models::fetch_compatible_model_ids(connection).await;
+                    super::provider_models::fetch_discovered_model_ids(state, connection).await;
             }
 
             let prefixes = [output_alias.as_str(), static_alias, provider_id];
@@ -432,11 +434,6 @@ fn enabled_model_ids(connection: &ProviderConnection) -> (Vec<String>, bool) {
         .unwrap_or_default();
 
     (models, had_enabled_models)
-}
-
-fn is_compatible_provider(provider_id: &str) -> bool {
-    provider_id.starts_with(OPENAI_COMPATIBLE_PREFIX)
-        || provider_id.starts_with(ANTHROPIC_COMPATIBLE_PREFIX)
 }
 
 fn strip_provider_prefix(model_id: &str, prefixes: &[&str]) -> Option<String> {
@@ -685,8 +682,16 @@ pub async fn models_info(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::server::state::AppState;
     use crate::types::{CustomModel, ProviderConnection};
     use std::collections::BTreeMap;
+    use std::sync::Arc;
+
+    async fn test_state() -> AppState {
+        let dir = tempfile::tempdir().unwrap();
+        let db = crate::db::Db::load_from(dir.path()).await.unwrap();
+        AppState::new(Arc::new(db))
+    }
 
     #[tokio::test]
     async fn custom_models_appear_without_connections() {
@@ -703,7 +708,7 @@ mod tests {
             ..Default::default()
         };
 
-        let models = build_models_list(&snapshot, &[LLM_KIND]).await;
+        let models = build_models_list(&test_state().await, &snapshot, &[LLM_KIND]).await;
         assert!(models.iter().any(|m| m.id == "tr/MiniMax-M3"),
             "custom model with provider_alias 'tr' should appear in /v1/models even without connections");
     }
@@ -733,7 +738,7 @@ mod tests {
             ..Default::default()
         };
 
-        let models = build_models_list(&snapshot, &[LLM_KIND]).await;
+        let models = build_models_list(&test_state().await, &snapshot, &[LLM_KIND]).await;
         assert!(models.iter().any(|m| m.id == "tr/MiniMax-M3"),
             "custom model 'tr/MiniMax-M3' should appear even when it doesn't match any connection's prefix");
     }
@@ -763,7 +768,7 @@ mod tests {
             ..Default::default()
         };
 
-        let models = build_models_list(&snapshot, &[LLM_KIND]).await;
+        let models = build_models_list(&test_state().await, &snapshot, &[LLM_KIND]).await;
         let count = models.iter().filter(|m| m.id == "ocg/gpt-4o").count();
         assert_eq!(count, 1,
             "custom model 'ocg/gpt-4o' should appear exactly once even if matched by connection AND fallback");
@@ -792,7 +797,7 @@ mod tests {
             ..Default::default()
         };
 
-        let models = build_models_list(&snapshot, &[LLM_KIND]).await;
+        let models = build_models_list(&test_state().await, &snapshot, &[LLM_KIND]).await;
         assert!(
             models.iter().any(|m| m.id == "tr/MiniMax-M3"),
             "llm-type custom model should appear in LLM list"
@@ -800,6 +805,71 @@ mod tests {
         assert!(
             !models.iter().any(|m| m.id == "tr/flux-pro"),
             "image-type custom model should NOT appear in LLM list"
+        );
+    }
+
+    #[tokio::test]
+    async fn opencode_zen_models_appear_in_models_list() {
+        // Regression: opencode-zen was registered in the executor/CLI/alias
+        // maps but its provider entry + models were missing from the static
+        // catalog, so /v1/models exposed nothing for it.
+        let snapshot = AppDb {
+            provider_connections: vec![ProviderConnection {
+                id: "conn-zen".into(),
+                provider: "opencode-zen".into(),
+                auth_type: "apikey".into(),
+                ..Default::default()
+            }],
+            ..Default::default()
+        };
+
+        let models = build_models_list(&test_state().await, &snapshot, &[LLM_KIND]).await;
+        assert!(
+            models.iter().any(|m| m.id == "opencode-zen/gpt-5.4"),
+            "catalog-registered opencode-zen model should appear in /v1/models"
+        );
+        assert!(
+            models.iter().any(|m| m.id == "opencode-zen/kimi-k2.6"),
+            "catalog-registered opencode-zen model should appear in /v1/models"
+        );
+    }
+
+    #[tokio::test]
+    async fn catalog_less_builtin_provider_falls_back_to_dynamic_discovery() {
+        // Generic path: a built-in provider with NO static catalog models but
+        // with a server-side discovery fetcher must still surface its models
+        // through /v1/models (same discovery the dashboard uses).
+        let server = wiremock::MockServer::start().await;
+        wiremock::Mock::given(wiremock::matchers::method("GET"))
+            .and(wiremock::matchers::path("/api/tags"))
+            .respond_with(wiremock::ResponseTemplate::new(200).set_body_json(json!({
+                "models": [
+                    { "id": "local-llama-3.1" },
+                    { "id": "local-qwen-2.5" }
+                ]
+            })))
+            .mount(&server)
+            .await;
+
+        let snapshot = AppDb {
+            provider_connections: vec![ProviderConnection {
+                id: "conn-ollama-local".into(),
+                provider: "ollama-local".into(),
+                auth_type: "apikey".into(),
+                provider_specific_data: BTreeMap::from([("baseUrl".into(), json!(server.uri()))]),
+                ..Default::default()
+            }],
+            ..Default::default()
+        };
+
+        let models = build_models_list(&test_state().await, &snapshot, &[LLM_KIND]).await;
+        assert!(
+            models.iter().any(|m| m.id == "ollama-local/local-llama-3.1"),
+            "dynamically discovered models of a catalog-less built-in provider should appear in /v1/models"
+        );
+        assert!(
+            models.iter().any(|m| m.id == "ollama-local/local-qwen-2.5"),
+            "dynamically discovered models of a catalog-less built-in provider should appear in /v1/models"
         );
     }
 }


### PR DESCRIPTION
## Problem

OpenCode Zen (`opencode-zen`) is configured and works as a provider, its model catalog is discovered in the dashboard, and individual models test successfully — but **no Zen models appear in `GET /v1/models`** and they are **not selectable in Combos**.

```bash
curl -s http://127.0.0.1:4623/v1/models -H "Authorization: Bearer $KEY" | jq -r '.data[].id' | grep -i opencode
# (nothing)
```

## Root cause

`opencode-zen` is **half-registered**:

- Present in `providerIdToAlias` (catalog), the executor `PROVIDER_REGISTRY`, `get_api_key_providers` (CLI), and `ALIAS_TO_PROVIDER_ID`.
- **Missing** from the catalog's `providers` array and `providerModels` map — the provider entry and its 43 models were dropped when `provider_catalog.json` was generated. The authoritative source snapshot `src/core/model/sources/omniroute.json` still contains the full entry.

`/v1/models` (`build_models_list`) and the Combo model selector (`ModelSelectModal`) both derive model ids from that static catalog:

- `catalog.models_for_alias("opencode-zen")` → `None` → empty
- no `enabledModels` stored → empty
- live discovery only fired for `openai-compatible-*` / `anthropic-compatible-*` prefixes → skipped

Result: zero entries, while working providers (NVIDIA, OpenRouter, `opencode`, `opencode-go`) all have `providerModels` entries with exactly the ids seen in `/v1/models`.

## Fix

1. **Restore the catalog registration** for `opencode-zen` (`providers` + `providerModels`, 43 models), sourced from the repo's own `omniroute.json` snapshot — the same source the catalog was generated from, not hand-authored data. This makes Zen appear in both `/v1/models` and Combo selection, matching every other provider.

2. **Generic `/v1/models` fallback** (`v1_models.rs` + `provider_models.rs`): when a connection has no static catalog models and no `enabledModels`, fall back to the same server-side discovery the dashboard uses (`fetch_provider_models_response`) for **any** provider with a models fetcher — not just compatible prefixes. Gated by an explicit `supports_models_discovery` allowlist so no surprise network calls are issued.

3. **`opencode-zen` discovery arm** in `fetch_provider_models_response` → `https://opencode.ai/zen/v1/models` (the same endpoint the dashboard's existing `modelsFetcher` uses for the `opencode` free provider). The existing discovery mechanism is preserved, not replaced.

## Tests

- `v1_models::opencode_zen_models_appear_in_models_list` — active `opencode-zen` connection yields `opencode-zen/<model>` entries.
- `v1_models::catalog_less_builtin_provider_falls_back_to_dynamic_discovery` — a catalog-less built-in provider with a fetcher (`ollama-local` via wiremock) still surfaces models through `/v1/models`.
- `provider_models::supports_models_discovery_covers_builtin_and_compatible_providers`.

Verification: `cargo build --no-default-features` passes; the new tests pass; full lib suite is 1346 passed / 3 failed, and all 3 failures reproduce on `main` without this change (pre-existing upstream defects: `grok_build_settings` regex look-around and a `combo::shadow` test). End-to-end on an isolated instance, `/v1/models` now returns all 43 `opencode-zen/*` models and `/api/catalog` (the Combo source) includes the provider.

## Notes

- The provider itself behaves exactly as before — this only restores catalog registration and generalizes the existing discovery fallback.
- Upstream `main` has unrelated pre-existing breakage (web build `patchSettings` import, test E0063 in `admin_items.rs`); this PR does not touch either.
