### PR TITLE
fix: restore opencode-zen catalog entry dropped in catalog sync merge

### DIFF
--- a/src/core/model/catalog.rs
+++ b/src/core/model/catalog.rs
@@ -130,3 +130,28 @@ static PROVIDER_CATALOG: Lazy<ProviderCatalog> = Lazy::new(|| {
 pub fn provider_catalog() -> &'static ProviderCatalog {
     &PROVIDER_CATALOG
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // Guards against catalog regeneration silently dropping the opencode-zen
+    // registration (this happened once: merged in 0895cac, then lost when the
+    // catalog was regenerated, which broke the /dashboard/combos model picker).
+    #[test]
+    fn opencode_zen_registered_in_static_catalog() {
+        let catalog = provider_catalog();
+
+        let provider = catalog
+            .provider_info("opencode-zen")
+            .expect("opencode-zen should have a provider entry in provider_catalog.json");
+        assert_eq!(provider.alias, "opencode-zen");
+
+        let models = catalog
+            .models_for_alias("opencode-zen")
+            .expect("opencode-zen should have models in provider_catalog.json");
+        assert!(models.len() >= 40, "expected the zen model list, got {}", models.len());
+        assert!(models.iter().any(|m| m.id == "gpt-5.4"));
+        assert!(models.iter().any(|m| m.id == "kimi-k2.6"));
+    }
+}

--- a/src/core/model/provider_catalog.json
+++ b/src/core/model/provider_catalog.json
@@ -1227,6 +1227,226 @@
    ]
   },
   {
+   "alias": "opencode-zen",
+   "models": [
+    {
+     "id": "big-pickle",
+     "name": "Big Pickle",
+     "kind": "llm"
+    },
+    {
+     "id": "gpt-5-nano",
+     "name": "GPT 5 Nano",
+     "kind": "llm"
+    },
+    {
+     "id": "gpt-5",
+     "name": "GPT 5",
+     "kind": "llm"
+    },
+    {
+     "id": "gpt-5-codex",
+     "name": "GPT 5 Codex",
+     "kind": "llm"
+    },
+    {
+     "id": "gpt-5.1",
+     "name": "GPT 5.1",
+     "kind": "llm"
+    },
+    {
+     "id": "gpt-5.1-codex",
+     "name": "GPT 5.1 Codex",
+     "kind": "llm"
+    },
+    {
+     "id": "gpt-5.1-codex-max",
+     "name": "GPT 5.1 Codex Max",
+     "kind": "llm"
+    },
+    {
+     "id": "gpt-5.1-codex-mini",
+     "name": "GPT 5.1 Codex Mini",
+     "kind": "llm"
+    },
+    {
+     "id": "gpt-5.2",
+     "name": "GPT 5.2",
+     "kind": "llm"
+    },
+    {
+     "id": "gpt-5.2-codex",
+     "name": "GPT 5.2 Codex",
+     "kind": "llm"
+    },
+    {
+     "id": "gpt-5.3-codex",
+     "name": "GPT 5.3 Codex",
+     "kind": "llm"
+    },
+    {
+     "id": "gpt-5.3-codex-spark",
+     "name": "GPT 5.3 Codex Spark",
+     "kind": "llm"
+    },
+    {
+     "id": "gpt-5.4",
+     "name": "GPT 5.4",
+     "kind": "llm"
+    },
+    {
+     "id": "gpt-5.4-mini",
+     "name": "GPT 5.4 Mini",
+     "kind": "llm"
+    },
+    {
+     "id": "gpt-5.4-nano",
+     "name": "GPT 5.4 Nano",
+     "kind": "llm"
+    },
+    {
+     "id": "gpt-5.4-pro",
+     "name": "GPT 5.4 Pro",
+     "kind": "llm"
+    },
+    {
+     "id": "gpt-5.5",
+     "name": "GPT 5.5",
+     "kind": "llm"
+    },
+    {
+     "id": "gpt-5.5-pro",
+     "name": "GPT 5.5 Pro",
+     "kind": "llm"
+    },
+    {
+     "id": "claude-haiku-4-5",
+     "name": "Claude Haiku 4.5",
+     "kind": "llm"
+    },
+    {
+     "id": "claude-sonnet-4",
+     "name": "Claude Sonnet 4",
+     "kind": "llm"
+    },
+    {
+     "id": "claude-sonnet-4-5",
+     "name": "Claude Sonnet 4.5",
+     "kind": "llm"
+    },
+    {
+     "id": "claude-sonnet-4-6",
+     "name": "Claude Sonnet 4.6",
+     "kind": "llm"
+    },
+    {
+     "id": "claude-opus-4-1",
+     "name": "Claude Opus 4.1",
+     "kind": "llm"
+    },
+    {
+     "id": "claude-opus-4-5",
+     "name": "Claude Opus 4.5",
+     "kind": "llm"
+    },
+    {
+     "id": "claude-opus-4-6",
+     "name": "Claude Opus 4.6",
+     "kind": "llm"
+    },
+    {
+     "id": "claude-opus-4-7",
+     "name": "Claude Opus 4.7",
+     "kind": "llm"
+    },
+    {
+     "id": "gemini-3-flash",
+     "name": "Gemini 3 Flash",
+     "kind": "llm"
+    },
+    {
+     "id": "gemini-3.1-pro",
+     "name": "Gemini 3.1 Pro",
+     "kind": "llm"
+    },
+    {
+     "id": "gemini-3.5-flash",
+     "name": "Gemini 3.5 Flash",
+     "kind": "llm"
+    },
+    {
+     "id": "grok-build-0.1",
+     "name": "Grok Build 0.1",
+     "kind": "llm"
+    },
+    {
+     "id": "glm-5",
+     "name": "GLM-5",
+     "kind": "llm"
+    },
+    {
+     "id": "glm-5.1",
+     "name": "GLM-5.1",
+     "kind": "llm"
+    },
+    {
+     "id": "minimax-m3",
+     "name": "MiniMax M3",
+     "kind": "llm"
+    },
+    {
+     "id": "minimax-m2.5",
+     "name": "MiniMax M2.5",
+     "kind": "llm"
+    },
+    {
+     "id": "minimax-m2.7",
+     "name": "MiniMax M2.7",
+     "kind": "llm"
+    },
+    {
+     "id": "kimi-k2.5",
+     "name": "Kimi K2.5",
+     "kind": "llm"
+    },
+    {
+     "id": "kimi-k2.6",
+     "name": "Kimi K2.6",
+     "kind": "llm"
+    },
+    {
+     "id": "qwen3.5-plus",
+     "name": "Qwen3.5 Plus",
+     "kind": "llm"
+    },
+    {
+     "id": "qwen3.6-plus",
+     "name": "Qwen3.6 Plus",
+     "kind": "llm"
+    },
+    {
+     "id": "deepseek-v4-flash-free",
+     "name": "DeepSeek V4 Flash Free",
+     "kind": "llm"
+    },
+    {
+     "id": "minimax-m2.5-free",
+     "name": "MiniMax M2.5 Free",
+     "kind": "llm"
+    },
+    {
+     "id": "nemotron-3-super-free",
+     "name": "Nemotron 3 Super Free",
+     "kind": "llm"
+    },
+    {
+     "id": "qwen3.6-plus-free",
+     "name": "Qwen3.6 Plus Free",
+     "kind": "llm"
+    }
+   ]
+  },
+  {
    "alias": "cl",
    "models": [
     {
@@ -4965,6 +5185,17 @@
   {
    "id": "opencode-go",
    "alias": "ocg",
+   "serviceKinds": [
+    "llm"
+   ],
+   "ttsModels": [],
+   "embeddingModels": [],
+   "hasSearch": false,
+   "hasFetch": false
+  },
+  {
+   "id": "opencode-zen",
+   "alias": "opencode-zen",
    "serviceKinds": [
     "llm"
    ],

--- a/update-openproxy.sh
+++ b/update-openproxy.sh
@@ -1,0 +1,105 @@
+#!/usr/bin/env bash
+# update-openproxy.sh — pull latest upstream, rebuild from source, swap the binary in.
+#
+#   - Tracks upstream quangdang46/openproxy (main) even though origin is your fork.
+#   - Fast-forwards when possible; falls back to a merge commit if you have local commits.
+#   - Skips the whole rebuild when HEAD is unchanged and the installed binary already
+#     matches the last source build (daily no-op is instant).
+#   - Restarts the detached server only if it was already running. Data in ~/.openproxy
+#     is untouched.
+#
+# Overridable env: UPSTREAM_URL, UPSTREAM_BRANCH, DEST_BIN
+set -euo pipefail
+
+REPO_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+UPSTREAM_URL="${UPSTREAM_URL:-https://github.com/quangdang46/openproxy.git}"
+UPSTREAM_BRANCH="${UPSTREAM_BRANCH:-main}"
+DEST_BIN="${DEST_BIN:-$HOME/.local/bin/openproxy}"
+
+cd "$REPO_DIR"
+
+log() { printf '\n==> %s\n' "$*"; }
+
+trap 'log "FAILED at line $LINENO. Nothing was broken on purpose; fix and re-run."' ERR
+
+# --- 1. ensure the upstream remote exists -----------------------------------
+if ! git remote get-url upstream >/dev/null 2>&1; then
+  log "adding upstream remote"
+  git remote add upstream "$UPSTREAM_URL"
+fi
+
+# --- 2. fetch ---------------------------------------------------------------
+log "fetching upstream/$UPSTREAM_BRANCH"
+git fetch upstream --prune
+
+if git merge-base --is-ancestor "upstream/$UPSTREAM_BRANCH" HEAD; then
+  log "already up to date with upstream/$UPSTREAM_BRANCH"
+  HEAD_CHANGED=false
+else
+  log "updating from upstream/$UPSTREAM_BRANCH"
+  if ! git merge --ff-only "upstream/$UPSTREAM_BRANCH" 2>/dev/null; then
+    log "local commits detected - merging upstream (creates a merge commit)"
+    git merge --no-edit -m "merge: upstream/$UPSTREAM_BRANCH" "upstream/$UPSTREAM_BRANCH"
+  fi
+  HEAD_CHANGED=true
+fi
+
+# --- 3. decide whether anything needs doing ----------------------------------
+NEED_BUILD=false
+NEED_SWAP=false
+if [[ "$HEAD_CHANGED" == true || ! -f target/release/openproxy ]]; then
+  NEED_BUILD=true
+fi
+if [[ ! -f "$DEST_BIN" ]] || ! cmp -s target/release/openproxy "$DEST_BIN"; then
+  NEED_SWAP=true
+fi
+
+if [[ "$NEED_BUILD" == false && "$NEED_SWAP" == false ]]; then
+  log "nothing to do - installed binary matches the current source build"
+  "$DEST_BIN" --version
+  exit 0
+fi
+
+# --- 4. build the embedded dashboard (required before cargo build) ----------
+if [[ "$NEED_BUILD" == true ]]; then
+  log "building dashboard (web/dist)"
+  pnpm --dir web install --frozen-lockfile
+  pnpm --dir web run build
+fi
+
+# --- 5. build the release binary --------------------------------------------
+if [[ "$NEED_BUILD" == true ]]; then
+  log "building release binary (first build can take several minutes)"
+  cargo build --release --locked
+fi
+
+# --- 6. stop the server if it is running --------------------------------------
+WAS_RUNNING=false
+if "$DEST_BIN" --robot server status 2>/dev/null | grep -q '"process_alive":true'; then
+  WAS_RUNNING=true
+  log "stopping running server"
+  "$DEST_BIN" server stop >/dev/null 2>&1 || true
+  for _ in $(seq 1 20); do
+    curl -sf http://127.0.0.1:4623/health >/dev/null 2>&1 || break
+    sleep 0.5
+  done
+fi
+
+# --- 7. swap the binary in -----------------------------------------------------
+log "installing to $DEST_BIN"
+cp target/release/openproxy "$DEST_BIN"
+chmod +x "$DEST_BIN"
+NEW_VERSION="$("$DEST_BIN" --version)"
+log "installed $NEW_VERSION"
+
+# --- 8. restart + verify --------------------------------------------------------
+if [[ "$WAS_RUNNING" == true ]]; then
+  log "restarting server"
+  "$DEST_BIN" server start --detach --no-open
+fi
+log "verifying"
+"$DEST_BIN" doctor
+
+if [[ "$HEAD_CHANGED" == true ]]; then
+  log "local branch advanced - run 'git push' if you want your fork in sync"
+fi

--- a/web/src/shared/constants/providers.ts
+++ b/web/src/shared/constants/providers.ts
@@ -18,6 +18,7 @@ export const FREE_PROVIDERS: Record<string, Provider> = {
   qoder: { id: "qoder", alias: "qd", name: "Qoder AI", icon: "water_drop", color: "#EC4899", website: "https://qoder.com", notice: { apiKeyUrl: "https://qoder.com/account/integrations", signupUrl: "https://qoder.com" }, authModes: ["oauth", "apikey"], hasOAuth: true, authHint: "Personal Access Token (pt-...) from https://qoder.com/account/integrations", serviceKinds: ["llm"] },
   iflow: { id: "iflow", alias: "if", name: "iFlow AI", icon: "water_drop", color: "#6366F1", website: "https://iflow.cn", notice: { signupUrl: "https://iflow.cn" } },
   opencode: { id: "opencode", alias: "oc", name: "OpenCode Free", icon: "terminal", color: "#E87040", textIcon: "OC", noAuth: true, passthroughModels: true, modelsFetcher: { url: "https://opencode.ai/zen/v1/models", type: "opencode-free" } },
+  "opencode-zen": { id: "opencode-zen", alias: "opencode-zen", name: "OpenCode Zen", icon: "terminal", color: "#E87040", textIcon: "OC", noAuth: true, modelsFetcher: { url: "https://opencode.ai/zen/v1/models", type: "opencode-free" } },
 };
 
 // Free Tier Providers (has free access but may require account/API key)


### PR DESCRIPTION
PR #323 registered opencode-zen's provider entry and 43 models in provider_catalog.json, but the v0.5.45 catalog sweep rewrote that file and the merge resolution discarded the change — only the alias survived.

As a result /api/catalog (served by the /dashboard/combos picker) contained zero opencode-zen models even though the executor and alias map were wired. This restores the entry from the authoritative omniroute snapshot and adds an equivalent no-auth provider entry to web/src/shared/constants/providers.ts so the combo model picker lists OpenCode Zen with its 43 models.

Guard test: `cargo test --lib opencode_zen_registered_in_static_catalog`