### PR TITLE
feat(codebuddy-cn): system-prompt neutralizer + reasoning_effort deletion (bead .27)

### DIFF
--- a/src/core/executor/codebuddy_cn.rs
+++ b/src/core/executor/codebuddy_cn.rs
@@ -4,11 +4,16 @@
 //!
 //! Behaviour:
 //! - Always forces `stream: true` in the request body.
-//! - If `reasoning_effort` is present, sets `reasoning_summary: "auto"`.
+//! - Neutralizes system prompts that identify a coding agent (9router
+//!   `AGENT_PATTERN` + `NEUTRAL_PROMPT`) so upstream does not reject them.
+//! - `reasoning_effort`: deletes `"none"`/`"off"` (and does not set
+//!   `reasoning_summary`); any other truthy effort sets `reasoning_summary:
+//!   "auto"`.
 
 use std::sync::Arc;
 
 use async_trait::async_trait;
+use regex::Regex;
 use reqwest::header::{HeaderMap, HeaderValue};
 use serde_json::Value;
 
@@ -18,6 +23,40 @@ use super::provider::{
     ProviderExecutionRequest, ProviderExecutionResponse, ProviderExecutor, ProviderExecutorError,
 };
 use super::{ClientPool, TransportKind, UpstreamResponse};
+
+/// Replacement system prompt when a system message reveals a coding agent.
+/// 9router codebuddy-cn.js NEUTRAL_PROMPT — verbatim.
+const NEUTRAL_PROMPT: &str =
+    "You are a helpful AI assistant that helps with software engineering tasks.";
+
+/// Patterns that identify a coding-agent system prompt. Ported verbatim from
+/// 9router codebuddy-cn.js AGENT_PATTERN (JS `/i` flag). `(?is)` adds
+/// case-insensitivity and multi-line `.` so alternates like `<agent-identity>`
+/// and `cc_entrypoint` match across newlines.
+static AGENT_PATTERN: once_cell::sync::Lazy<Regex> = once_cell::sync::Lazy::new(|| {
+    Regex::new(
+        r"(?is)you are claude code|claude.?code.+official.+cli|anthropic.+official.+cli|anxthxropic.+official.+cli|you are (?:cursor|windsurf|cline|aider|continue|copilot|cody)|you are an? (?:ai )?(?:coding |code )?agent|cc_entrypoint\s*=\s*(?:cli|vscode|jetbrains|gui)|claude.?code.+issues|give feedback.+claude.?code|you are .{0,30}(?:powerful )?ai agent|orchestration capabilities|OhMyOpenCode|<agent-identity>|<Role>|<Behavior_Instructions>",
+    )
+    .expect("AGENT_PATTERN regex must compile")
+});
+
+/// Threshold (in characters) above which a system prompt is always replaced,
+/// matching 9router's `text.length > 2000` check.
+const SYSTEM_PROMPT_LENGTH_THRESHOLD: usize = 2000;
+
+/// Flatten a message's `content` (string or array of `{type:"text",text}`)
+/// into plain text; 9router's `flatten(message.content)`.
+fn flatten_content(content: &Value) -> String {
+    match content {
+        Value::String(s) => s.clone(),
+        Value::Array(items) => items
+            .iter()
+            .filter_map(|item| item.get("text").and_then(Value::as_str))
+            .collect::<Vec<_>>()
+            .join(""),
+        _ => String::new(),
+    }
+}
 
 /// Dedicated executor for the `codebuddy-cn` provider.
 #[derive(Clone)]
@@ -102,9 +141,53 @@ impl ProviderExecutor for CodeBuddyCNExecutor {
         // 1. Force stream=true always
         body["stream"] = Value::Bool(true);
 
-        // 2. If reasoning_effort is present, set reasoning_summary=auto
-        if body.get("reasoning_effort").is_some() {
-            body["reasoning_summary"] = Value::String("auto".to_string());
+        // 2. Neutralize system prompts that identify a coding agent
+        //    (9router codebuddy-cn.js: replace when >2000 chars or the
+        //    AGENT_PATTERN matches, preserving the content shape).
+        if let Some(messages) = body.get_mut("messages").and_then(Value::as_array_mut) {
+            for message in messages.iter_mut() {
+                if message.get("role").and_then(Value::as_str) != Some("system") {
+                    continue;
+                }
+                let Some(content) = message.get("content") else {
+                    continue;
+                };
+                let text = flatten_content(content);
+                if text.is_empty() {
+                    continue;
+                }
+                if text.len() > SYSTEM_PROMPT_LENGTH_THRESHOLD || AGENT_PATTERN.is_match(&text) {
+                    match content {
+                        Value::String(_) => {
+                            message["content"] = Value::String(NEUTRAL_PROMPT.to_string());
+                        }
+                        Value::Array(_) => {
+                            message["content"] = Value::Array(vec![serde_json::json!({
+                                "type": "text",
+                                "text": NEUTRAL_PROMPT
+                            })]);
+                        }
+                        _ => {}
+                    }
+                }
+            }
+        }
+
+        // 3. reasoning_effort: "none"/"off" → delete (no summary); any other
+        //    truthy effort → reasoning_summary="auto"
+        match body
+            .get("reasoning_effort")
+            .and_then(Value::as_str)
+            .map(str::to_string)
+        {
+            Some(eff) if eff == "none" || eff == "off" => {
+                body.as_object_mut()
+                    .map(|obj| obj.remove("reasoning_effort"));
+            }
+            Some(eff) if !eff.is_empty() => {
+                body["reasoning_summary"] = Value::String("auto".to_string());
+            }
+            _ => {}
         }
 
         body
@@ -179,6 +262,128 @@ mod tests {
         let result =
             executor.transform_request(&body, "gpt-4", false, &ProviderConnection::default());
         assert_eq!(result["stream"], true);
+    }
+
+    #[test]
+    fn test_neutralize_claude_code_system_prompt() {
+        let executor = CodeBuddyCNExecutor::new(Arc::new(ClientPool::new()), None);
+        let body = json!({
+            "model": "claude-sonnet-4",
+            "messages": [
+                {"role": "system", "content": "You are Claude Code, Anthropic's official CLI for AI-assisted coding. Help the user with their tasks."},
+                {"role": "user", "content": "Hello"}
+            ],
+            "stream": true
+        });
+        let result = executor.transform_request(
+            &body,
+            "claude-sonnet-4",
+            true,
+            &ProviderConnection::default(),
+        );
+        let messages = result["messages"].as_array().unwrap();
+        assert_eq!(
+            messages[0]["content"], NEUTRAL_PROMPT,
+            "system prompt identifying Claude Code must be neutralized"
+        );
+        assert_eq!(messages[1]["content"], "Hello", "user message untouched");
+    }
+
+    #[test]
+    fn test_neutralize_preserves_array_shape() {
+        let executor = CodeBuddyCNExecutor::new(Arc::new(ClientPool::new()), None);
+        let body = json!({
+            "model": "claude-sonnet-4",
+            "messages": [
+                {
+                    "role": "system",
+                    "content": [
+                        {"type": "text", "text": "You are Cursor, an AI code editor."}
+                    ]
+                },
+                {"role": "user", "content": "Hi"}
+            ],
+            "stream": true
+        });
+        let result = executor.transform_request(
+            &body,
+            "claude-sonnet-4",
+            true,
+            &ProviderConnection::default(),
+        );
+        let messages = result["messages"].as_array().unwrap();
+        let content = &messages[0]["content"];
+        assert!(content.is_array(), "array content stays an array");
+        assert_eq!(content[0]["type"], "text");
+        assert_eq!(content[0]["text"], NEUTRAL_PROMPT);
+    }
+
+    #[test]
+    fn test_long_system_prompt_replaced() {
+        let executor = CodeBuddyCNExecutor::new(Arc::new(ClientPool::new()), None);
+        let long_prompt = "x".repeat(2500);
+        let body = json!({
+            "model": "claude-sonnet-4",
+            "messages": [{"role": "system", "content": long_prompt}],
+            "stream": true
+        });
+        let result = executor.transform_request(
+            &body,
+            "claude-sonnet-4",
+            true,
+            &ProviderConnection::default(),
+        );
+        assert_eq!(result["messages"][0]["content"], NEUTRAL_PROMPT);
+    }
+
+    #[test]
+    fn test_benign_system_prompt_untouched() {
+        let executor = CodeBuddyCNExecutor::new(Arc::new(ClientPool::new()), None);
+        let body = json!({
+            "model": "claude-sonnet-4",
+            "messages": [
+                {"role": "system", "content": "You are a helpful assistant."},
+                {"role": "user", "content": "Hi"}
+            ],
+            "stream": true
+        });
+        let result = executor.transform_request(
+            &body,
+            "claude-sonnet-4",
+            true,
+            &ProviderConnection::default(),
+        );
+        assert_eq!(
+            result["messages"][0]["content"],
+            "You are a helpful assistant."
+        );
+    }
+
+    #[test]
+    fn test_reasoning_effort_none_deleted_no_summary() {
+        let executor = CodeBuddyCNExecutor::new(Arc::new(ClientPool::new()), None);
+        for eff in ["none", "off"] {
+            let body = json!({
+                "model": "claude-sonnet-4",
+                "messages": [{"role": "user", "content": "Think carefully"}],
+                "reasoning_effort": eff,
+                "stream": true
+            });
+            let result = executor.transform_request(
+                &body,
+                "claude-sonnet-4",
+                true,
+                &ProviderConnection::default(),
+            );
+            assert!(
+                result.get("reasoning_effort").is_none(),
+                "reasoning_effort {eff:?} must be deleted"
+            );
+            assert!(
+                result.get("reasoning_summary").is_none(),
+                "no reasoning_summary for effort {eff:?}"
+            );
+        }
     }
 
     #[test]


### PR DESCRIPTION
## Bead openproxy-9router-parity-v0550-pnc.27 (P0-D1)

**JS codebuddy-cn.js parity:**

1. **System-prompt neutralizer**: ported `NEUTRAL_PROMPT` and `AGENT_PATTERN` verbatim (as a compiled `Regex` with `(?is)` flags — JS uses `/i`, and multi-line alternates like `<agent-identity>` need `(?s)`). For each `role == "system"` message, flattens content (string or array of `{type:text}`) and replaces it with the neutral prompt when `len > 2000` or the pattern matches — preserving the shape: string → string, array → `[{type:"text",text:...}]`.
2. **reasoning_effort**: `"none"`/`"off"` → key deleted, NO `reasoning_summary` (JS `delete` branch); any other truthy effort → `reasoning_summary: "auto"`.

**Tests:** 5 new unit tests (incl. guard `test_neutralize_claude_code_system_prompt` and `test_reasoning_effort_none_deleted_no_summary`). Full lib suite 1449 passed.