### PR TITLE
fix(search): global timeout 15s + per-provider timeoutMs (bead .74)

### DIFF
--- a/src/core/media/search/base.rs
+++ b/src/core/media/search/base.rs
@@ -102,6 +102,12 @@ pub trait SearchProvider: Send + Sync {
 
     /// Normalise the upstream JSON to [`SearchResultSet`].
     fn normalize(&self, body: &Value, request: &SearchRequest<'_>) -> SearchResultSet;
+
+    /// Per-provider upstream timeout in ms (9router registry `timeoutMs`).
+    /// `None` → the global 15s timeout applies.
+    fn timeout_ms(&self) -> Option<u64> {
+        None
+    }
 }
 
 /// Split `domain_filter` into `(includes, excludes)` where excludes are

--- a/src/core/media/search/handler.rs
+++ b/src/core/media/search/handler.rs
@@ -6,7 +6,8 @@ use thiserror::Error;
 
 use super::base::{SearchProvider, SearchRequest, SearchResultSet};
 
-const GLOBAL_TIMEOUT: Duration = Duration::from_secs(30);
+/// 9router search.js: global timeout is 15s (was 30s in Rust).
+const GLOBAL_TIMEOUT: Duration = Duration::from_secs(15);
 
 #[derive(Debug, Error)]
 pub enum SearchHandlerError {
@@ -41,10 +42,16 @@ pub async fn handle_search(
         .build_headers(request)
         .map_err(SearchHandlerError::Validation)?;
 
+    // 9router: per-provider timeoutMs (default 10000) wins over the 15s
+    // global timeout when set.
+    let effective_timeout = provider
+        .timeout_ms()
+        .map(Duration::from_millis)
+        .unwrap_or(GLOBAL_TIMEOUT);
     let mut builder = client
         .request(provider.method(), &url)
         .headers(headers)
-        .timeout(GLOBAL_TIMEOUT);
+        .timeout(effective_timeout);
     if let Some(body) = provider.build_body(request) {
         builder = builder.json(&body);
     }
@@ -78,5 +85,26 @@ mod tests {
         let res = request_from_body(&body, None);
         assert!(res.is_err()); // request_from_body rejects empty query
         let _ = provider;
+    }
+
+    #[test]
+    fn timeout_precedence_global_15s_and_provider_10s() {
+        // Global default: 15s.
+        assert_eq!(GLOBAL_TIMEOUT, Duration::from_secs(15));
+
+        // Providers with an explicit timeoutMs override it.
+        let searxng = get_search_provider("searxng").unwrap();
+        assert_eq!(searxng.timeout_ms(), Some(10_000));
+        let youcom = get_search_provider("youcom").unwrap();
+        assert_eq!(youcom.timeout_ms(), Some(10_000));
+
+        // Providers without one fall back to the 15s global.
+        let serper = get_search_provider("serper").unwrap();
+        assert_eq!(serper.timeout_ms(), None);
+        let effective = serper
+            .timeout_ms()
+            .map(Duration::from_millis)
+            .unwrap_or(GLOBAL_TIMEOUT);
+        assert_eq!(effective, Duration::from_secs(15));
     }
 }

--- a/src/core/media/search/providers.rs
+++ b/src/core/media/search/providers.rs
@@ -775,6 +775,10 @@ impl SearchProvider for YouComProvider {
     fn id(&self) -> &'static str {
         "youcom"
     }
+    fn timeout_ms(&self) -> Option<u64> {
+        // 9router registry timeoutMs for youcom.
+        Some(10_000)
+    }
     fn build_url(&self, request: &SearchRequest<'_>) -> Result<String, String> {
         let _ = require_token(request, "youcom")?;
         let (includes, excludes) = parse_domain_filter(&request.domain_filter);
@@ -915,6 +919,10 @@ impl SearchProvider for SearxngProvider {
     }
     fn no_auth(&self) -> bool {
         true
+    }
+    fn timeout_ms(&self) -> Option<u64> {
+        // 9router registry timeoutMs for searxng.
+        Some(10_000)
     }
     fn build_url(&self, request: &SearchRequest<'_>) -> Result<String, String> {
         let base = resolve_base_url("http://localhost:8080", request);


### PR DESCRIPTION
## Bead openproxy-9router-parity-v0550-pnc.74

- Global search timeout: 30s → 15s (JS).
- `SearchProvider::timeout_ms()` trait hook (default None); searxng + youcom override with `Some(10_000)` (9router registry timeoutMs).
- `handle_search` uses per-provider timeout when set, else the 15s global.

**Tests:** `timeout_precedence_global_15s_and_provider_10s`. Full lib suite 1445 passed.