### PR TITLE
feat(grok-web): rest endpoint, MODEL_MAP, grokPayload, NDJSON streaming, browser headers (bead .25)

### DIFF
--- a/src/core/executor/grok_web.rs
+++ b/src/core/executor/grok_web.rs
@@ -1,13 +1,251 @@
+//! Grok Web executor — `grok.com/rest` SSO-cookie chat API.
+//!
+//! Port of 9router `open-sse/executors/grok-web.js` (+ `registry/grok-web.js`):
+//! OpenAI chat body → single Grok message string, browser-fingerprint headers
+//! (statsig / traceparent / Sec-Ch-Ua) for Cloudflare, NDJSON response stream →
+//! OpenAI SSE chunks, `reasoning_content` only for thinking models, and
+//! estimated usage (`ceil(len/4)`).
+//!
+//! Distinct from:
+//! - [`super::xai`] → `api.x.ai` (API key / OAuth)
+//! - [`super::grok_cli`] → `cli-chat-proxy.grok.com` Responses API
+//!
+//! Cookie auth: the `sso` cookie is stored in `credentials.api_key` (web-cookie
+//! provider convention, `authType: "cookie"`), with a leading `sso=` prefix
+//! stripped if present.
+
 use std::sync::Arc;
 
+use base64::{engine::general_purpose::STANDARD, Engine as _};
 use hyper::http::uri::InvalidUri;
+use rand::RngCore;
 use reqwest::header::{HeaderMap, HeaderValue, ACCEPT, CONTENT_TYPE, COOKIE};
-use serde_json::Value;
+use serde_json::{json, Value};
+use uuid::Uuid;
 
 use crate::core::proxy::ProxyTarget;
 use crate::types::ProviderConnection;
 
 use super::{ClientPool, TransportKind, UpstreamResponse};
+
+const GROK_CHAT_API: &str = "https://grok.com/rest/app-chat/conversations/new";
+const GROK_USER_AGENT: &str = "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/136.0.0.0 Safari/537.36";
+const GROK_STATSIG_SUFFIX: &str =
+    "e:TypeError: Cannot read properties of null (reading 'children')";
+
+/// Grok web mode mapping (JS MODEL_MAP, lines 9-24).
+struct GrokModelInfo {
+    grok_model: &'static str,
+    model_mode: &'static str,
+    is_thinking: bool,
+}
+
+fn model_map() -> &'static [(&'static str, GrokModelInfo)] {
+    &[
+        (
+            "grok-3",
+            GrokModelInfo {
+                grok_model: "grok-3",
+                model_mode: "MODEL_MODE_GROK_3",
+                is_thinking: false,
+            },
+        ),
+        (
+            "grok-3-mini",
+            GrokModelInfo {
+                grok_model: "grok-3",
+                model_mode: "MODEL_MODE_GROK_3_MINI_THINKING",
+                is_thinking: true,
+            },
+        ),
+        (
+            "grok-3-thinking",
+            GrokModelInfo {
+                grok_model: "grok-3",
+                model_mode: "MODEL_MODE_GROK_3_THINKING",
+                is_thinking: true,
+            },
+        ),
+        (
+            "grok-4",
+            GrokModelInfo {
+                grok_model: "grok-4",
+                model_mode: "MODEL_MODE_GROK_4",
+                is_thinking: false,
+            },
+        ),
+        (
+            "grok-4-mini",
+            GrokModelInfo {
+                grok_model: "grok-4-mini",
+                model_mode: "MODEL_MODE_GROK_4_MINI_THINKING",
+                is_thinking: true,
+            },
+        ),
+        (
+            "grok-4-thinking",
+            GrokModelInfo {
+                grok_model: "grok-4",
+                model_mode: "MODEL_MODE_GROK_4_THINKING",
+                is_thinking: true,
+            },
+        ),
+        (
+            "grok-4-heavy",
+            GrokModelInfo {
+                grok_model: "grok-4",
+                model_mode: "MODEL_MODE_HEAVY",
+                is_thinking: true,
+            },
+        ),
+        (
+            "grok-4.1-mini",
+            GrokModelInfo {
+                grok_model: "grok-4-1-thinking-1129",
+                model_mode: "MODEL_MODE_GROK_4_1_MINI_THINKING",
+                is_thinking: true,
+            },
+        ),
+        (
+            "grok-4.1-fast",
+            GrokModelInfo {
+                grok_model: "grok-4-1-thinking-1129",
+                model_mode: "MODEL_MODE_FAST",
+                is_thinking: false,
+            },
+        ),
+        (
+            "grok-4.1-expert",
+            GrokModelInfo {
+                grok_model: "grok-4-1-thinking-1129",
+                model_mode: "MODEL_MODE_EXPERT",
+                is_thinking: true,
+            },
+        ),
+        (
+            "grok-4.1-thinking",
+            GrokModelInfo {
+                grok_model: "grok-4-1-thinking-1129",
+                model_mode: "MODEL_MODE_GROK_4_1_THINKING",
+                is_thinking: true,
+            },
+        ),
+        (
+            "grok-4.2",
+            GrokModelInfo {
+                grok_model: "grok-420",
+                model_mode: "MODEL_MODE_GROK_420",
+                is_thinking: false,
+            },
+        ),
+        (
+            "grok-4.20",
+            GrokModelInfo {
+                grok_model: "grok-420",
+                model_mode: "MODEL_MODE_GROK_420",
+                is_thinking: false,
+            },
+        ),
+        (
+            "grok-4.20-beta",
+            GrokModelInfo {
+                grok_model: "grok-420",
+                model_mode: "MODEL_MODE_GROK_420",
+                is_thinking: false,
+            },
+        ),
+    ]
+}
+
+/// Random lowercase-alpha string of `length` chars (JS randomString without alphanumeric).
+fn random_alpha(length: usize) -> String {
+    const CHARS: &[u8] = b"abcdefghijklmnopqrstuvwxyz";
+    let mut rng = rand::thread_rng();
+    let mut out = String::with_capacity(length);
+    for _ in 0..length {
+        out.push(CHARS[(rng.next_u32() as usize) % CHARS.len()] as char);
+    }
+    out
+}
+
+/// Random lowercase-alphanumeric string of `length` chars (JS randomString alphanumeric).
+fn random_alnum(length: usize) -> String {
+    const CHARS: &[u8] = b"abcdefghijklmnopqrstuvwxyz0123456789";
+    let mut rng = rand::thread_rng();
+    let mut out = String::with_capacity(length);
+    for _ in 0..length {
+        out.push(CHARS[(rng.next_u32() as usize) % CHARS.len()] as char);
+    }
+    out
+}
+
+/// `x-statsig-id`: base64 of a fake browser TypeError (JS generateStatsigId).
+fn generate_statsig_id() -> String {
+    let msg = format!(
+        "{}['{}']{}",
+        "e:TypeError: Cannot read properties of null (reading 'children",
+        random_alnum(5),
+        ")']"
+    );
+    STANDARD.encode(format!("{}:{}", msg, GROK_STATSIG_SUFFIX))
+}
+
+/// Random hex string of `len_bytes` bytes (JS randomHex).
+fn random_hex(len_bytes: usize) -> String {
+    let mut bytes = vec![0u8; len_bytes];
+    rand::thread_rng().fill_bytes(&mut bytes);
+    bytes.iter().map(|byte| format!("{byte:02x}")).collect()
+}
+
+/// Flatten OpenAI messages to a single Grok message string (JS parseOpenAIMessages).
+///
+/// Every message gets a `role: ` prefix except the last user message, which is
+/// passed raw. System messages DO get role-prefixed (grok-web differs from
+/// perplexity-web here). `developer` role is normalized to `system`.
+fn parse_openai_messages(messages: &[Value]) -> String {
+    let mut extracted: Vec<(String, String)> = Vec::new();
+
+    for message in messages {
+        let role = message
+            .get("role")
+            .and_then(Value::as_str)
+            .unwrap_or("user")
+            .to_string();
+        let role = if role == "developer" {
+            "system".to_string()
+        } else {
+            role
+        };
+
+        let content = match message.get("content") {
+            Some(Value::String(s)) => s.clone(),
+            Some(Value::Array(parts)) => parts
+                .iter()
+                .filter(|part| part.get("type").and_then(Value::as_str) == Some("text"))
+                .filter_map(|part| part.get("text").and_then(Value::as_str))
+                .collect::<Vec<_>>()
+                .join(" "),
+            _ => String::new(),
+        };
+        if content.trim().is_empty() {
+            continue;
+        }
+        extracted.push((role, content));
+    }
+
+    let last_user_idx = extracted.iter().rposition(|(role, _)| role == "user");
+
+    let mut parts = Vec::with_capacity(extracted.len());
+    for (idx, (role, text)) in extracted.into_iter().enumerate() {
+        if Some(idx) == last_user_idx {
+            parts.push(text);
+        } else {
+            parts.push(format!("{role}: {text}"));
+        }
+    }
+
+    parts.join("\n\n")
+}
 
 pub struct GrokWebExecutionRequest {
     pub model: String,
@@ -119,8 +357,28 @@ impl GrokWebExecutor {
         request: GrokWebExecutionRequest,
     ) -> Result<GrokWebExecutorResponse, GrokWebExecutorError> {
         let url = self.build_url();
+
+        // Resolve model → Grok internal model/mode; default to grok-4.1-fast
+        // for unmapped models (JS `modelInfo || MODEL_MAP["grok-4.1-fast"]`).
+        let model_info = model_map()
+            .iter()
+            .find(|(id, _)| *id == request.model)
+            .map(|(_, info)| info)
+            .unwrap_or_else(|| {
+                model_map()
+                    .iter()
+                    .find(|(id, _)| *id == "grok-4.1-fast")
+                    .map(|(_, info)| info)
+                    .expect("grok-4.1-fast is a model map entry")
+            });
+
+        let message = match request.body.get("messages").and_then(Value::as_array) {
+            Some(messages) => parse_openai_messages(messages),
+            None => String::new(),
+        };
+
+        let transformed_body = self.build_payload(model_info, &message);
         let headers = self.build_headers(&request.credentials)?;
-        let transformed_body = self.transform_request(&request.body);
 
         let body_bytes = serde_json::to_vec(&transformed_body)?;
 
@@ -142,28 +400,122 @@ impl GrokWebExecutor {
     }
 
     fn build_url(&self) -> String {
-        "https://grok.com/app-chat/conversations/new".to_string()
+        GROK_CHAT_API.to_string()
     }
 
+    /// grokPayload (JS lines 247-259) — verbatim field set.
+    fn build_payload(&self, model_info: &GrokModelInfo, message: &str) -> Value {
+        json!({
+            "temporary": true,
+            "modelName": model_info.grok_model,
+            "modelMode": model_info.model_mode,
+            "message": message,
+            "fileAttachments": [],
+            "imageAttachments": [],
+            "disableSearch": false,
+            "enableImageGeneration": false,
+            "returnImageBytes": false,
+            "returnRawGrokInXaiRequest": false,
+            "enableImageStreaming": false,
+            "imageGenerationCount": 0,
+            "forceConcise": false,
+            "toolOverrides": {},
+            "enableSideBySide": true,
+            "sendFinalMetadata": true,
+            "isReasoning": false,
+            "disableTextFollowUps": false,
+            "disableMemory": true,
+            "forceSideBySide": false,
+            "isAsyncChat": false,
+            "disableSelfHarmShortCircuit": false,
+            "deviceEnvInfo": {
+                "darkModeEnabled": false,
+                "devicePixelRatio": 2,
+                "screenWidth": 2056,
+                "screenHeight": 1329,
+                "viewportWidth": 2056,
+                "viewportHeight": 1083
+            }
+        })
+    }
+
+    /// Browser-fingerprint headers (JS lines 263-283) — statsig, traceparent,
+    /// Sec-Ch-Ua/Sec-Fetch-*, Chrome 136 UA, and the `sso` cookie.
     fn build_headers(
         &self,
         credentials: &ProviderConnection,
     ) -> Result<HeaderMap, GrokWebExecutorError> {
         let mut headers = HeaderMap::new();
-        headers.insert(CONTENT_TYPE, HeaderValue::from_static("application/json"));
-        headers.insert(ACCEPT, HeaderValue::from_static("application/json"));
 
-        if let Some(sso) = credentials.access_token.as_ref() {
-            let cookie_value = HeaderValue::from_str(&format!("sso={}", sso))
-                .map_err(|_| GrokWebExecutorError::CookieParse("Invalid cookie".to_string()))?;
-            headers.insert(COOKIE, cookie_value);
-        }
+        let sso = credentials
+            .api_key
+            .as_deref()
+            .ok_or_else(|| GrokWebExecutorError::MissingCredentials("grok-web".into()))?
+            .to_string();
+        let token = sso.strip_prefix("sso=").unwrap_or(&sso);
+        let cookie_value = HeaderValue::from_str(&format!("sso={token}"))
+            .map_err(|_| GrokWebExecutorError::CookieParse("Invalid cookie".to_string()))?;
+        headers.insert(COOKIE, cookie_value);
+
+        headers.insert(ACCEPT, HeaderValue::from_static("*/*"));
+        headers.insert(CONTENT_TYPE, HeaderValue::from_static("application/json"));
+        headers.insert(
+            reqwest::header::ACCEPT_ENCODING,
+            HeaderValue::from_static("gzip, deflate, br, zstd"),
+        );
+        headers.insert(
+            reqwest::header::ACCEPT_LANGUAGE,
+            HeaderValue::from_static("en-US,en;q=0.9"),
+        );
+        headers.insert(
+            reqwest::header::ORIGIN,
+            HeaderValue::from_static("https://grok.com"),
+        );
+        headers.insert(
+            reqwest::header::REFERER,
+            HeaderValue::from_static("https://grok.com/"),
+        );
+        headers.insert(
+            reqwest::header::USER_AGENT,
+            HeaderValue::from_static(GROK_USER_AGENT),
+        );
+        headers.insert(
+            "Sec-Ch-Ua",
+            HeaderValue::from_static(
+                r#""Google Chrome";v="136", "Chromium";v="136", "Not(A:Brand";v="24""#,
+            ),
+        );
+        headers.insert("Sec-Ch-Ua-Mobile", HeaderValue::from_static("?0"));
+        headers.insert("Sec-Ch-Ua-Platform", HeaderValue::from_static(r#""macOS""#));
+        headers.insert("Sec-Fetch-Dest", HeaderValue::from_static("empty"));
+        headers.insert("Sec-Fetch-Mode", HeaderValue::from_static("cors"));
+        headers.insert("Sec-Fetch-Site", HeaderValue::from_static("same-origin"));
+        headers.insert(
+            "Baggage",
+            HeaderValue::from_static(
+                "sentry-environment=production,sentry-release=d6add6fb0460641fd482d767a335ef72b9b6abb8,sentry-public_key=b311e0f2690c81f25e2c4cf6d4f7ce1c",
+            ),
+        );
+        headers.insert(
+            "x-statsig-id",
+            HeaderValue::from_str(&generate_statsig_id()).map_err(|_| {
+                GrokWebExecutorError::InvalidCredentials("Invalid statsig id".to_string())
+            })?,
+        );
+        headers.insert(
+            "x-xai-request-id",
+            HeaderValue::from_str(&Uuid::new_v4().to_string()).map_err(|_| {
+                GrokWebExecutorError::InvalidCredentials("Invalid request id".to_string())
+            })?,
+        );
+        headers.insert(
+            "traceparent",
+            HeaderValue::from_str(&format!("00-{}-{}-00", random_hex(16), random_hex(8))).map_err(
+                |_| GrokWebExecutorError::InvalidCredentials("Invalid traceparent".to_string()),
+            )?,
+        );
 
         Ok(headers)
-    }
-
-    fn transform_request(&self, body: &Value) -> Value {
-        body.clone()
     }
 }
 
@@ -398,7 +750,7 @@ mod tests {
     fn test_grok_build_url() {
         let executor = GrokWebExecutor::new(Arc::new(ClientPool::default()));
         let url = executor.build_url();
-        assert!(url.contains("grok.com"));
+        assert_eq!(url, "https://grok.com/rest/app-chat/conversations/new");
     }
 
     #[test]
@@ -406,6 +758,139 @@ mod tests {
         let executor = PerplexityWebExecutor::new(Arc::new(ClientPool::default()));
         let url = executor.build_url();
         assert!(url.contains("perplexity.ai"));
+    }
+
+    #[test]
+    fn test_grok_web_payload_shape() {
+        let executor = GrokWebExecutor::new(Arc::new(ClientPool::default()));
+        let body = serde_json::json!({
+            "messages": [
+                {"role": "system", "content": "S"},
+                {"role": "user", "content": "U"}
+            ]
+        });
+        let model_info = model_map()
+            .iter()
+            .find(|(id, _)| *id == "grok-4.2")
+            .map(|(_, info)| info)
+            .unwrap();
+        let message =
+            parse_openai_messages(body.get("messages").and_then(Value::as_array).unwrap());
+        let transformed = executor.build_payload(model_info, &message);
+        assert_eq!(transformed["modelName"], "grok-420");
+        assert_eq!(transformed["modelMode"], "MODEL_MODE_GROK_420");
+        assert_eq!(transformed["message"], "system: S\n\nU");
+        assert_eq!(transformed["temporary"], true);
+    }
+
+    #[test]
+    fn test_parse_openai_messages_last_user_raw() {
+        let messages = serde_json::json!([
+            {"role": "system", "content": "Be helpful"},
+            {"role": "user", "content": "First question"},
+            {"role": "assistant", "content": "First answer"},
+            {"role": "user", "content": "Follow up"}
+        ]);
+        let parsed = parse_openai_messages(messages.as_array().unwrap());
+        assert_eq!(
+            parsed,
+            "system: Be helpful\n\nuser: First question\n\nassistant: First answer\n\nFollow up"
+        );
+    }
+
+    #[test]
+    fn test_parse_openai_messages_skips_empty() {
+        let messages = serde_json::json!([
+            {"role": "system", "content": " "},
+            {"role": "user", "content": "Hello"}
+        ]);
+        let parsed = parse_openai_messages(messages.as_array().unwrap());
+        assert_eq!(parsed, "Hello");
+    }
+
+    #[test]
+    fn test_parse_openai_messages_content_array() {
+        let messages = serde_json::json!([
+            {"role": "user", "content": [
+                {"type": "text", "text": "Hello"},
+                {"type": "image_url", "image_url": {"url": "data:..."}},
+                {"type": "text", "text": " world"}
+            ]}
+        ]);
+        let parsed = parse_openai_messages(messages.as_array().unwrap());
+        assert_eq!(parsed, "Hello  world");
+    }
+
+    #[test]
+    fn test_parse_openai_messages_developer_is_system() {
+        let messages = serde_json::json!([
+            {"role": "developer", "content": "Instructions"},
+            {"role": "user", "content": "Hi"}
+        ]);
+        let parsed = parse_openai_messages(messages.as_array().unwrap());
+        assert_eq!(parsed, "system: Instructions\n\nHi");
+    }
+
+    #[test]
+    fn test_generate_statsig_id_is_valid_base64() {
+        let statsig = generate_statsig_id();
+        // Must be valid base64 and decode to an e:TypeError string.
+        let decoded = STANDARD.decode(&statsig).expect("valid base64");
+        assert!(String::from_utf8(decoded)
+            .unwrap()
+            .starts_with("e:TypeError:"));
+    }
+
+    #[test]
+    fn test_grok_headers_cookie_prefix_stripped() {
+        use std::collections::BTreeMap;
+        let executor = GrokWebExecutor::new(Arc::new(ClientPool::default()));
+        let credentials = ProviderConnection {
+            id: "test".to_string(),
+            provider: "grok-web".to_string(),
+            auth_type: "cookie".to_string(),
+            name: None,
+            priority: None,
+            is_active: Some(true),
+            created_at: None,
+            updated_at: None,
+            display_name: None,
+            email: None,
+            global_priority: None,
+            default_model: None,
+            access_token: None,
+            refresh_token: None,
+            expires_at: None,
+            token_type: None,
+            scope: None,
+            id_token: None,
+            project_id: None,
+            api_key: Some("sso=my-token".to_string()),
+            test_status: None,
+            last_tested: None,
+            last_error: None,
+            last_error_at: None,
+            rate_limited_until: None,
+            expires_in: None,
+            error_code: None,
+            consecutive_use_count: None,
+            backoff_level: None,
+            consecutive_errors: None,
+            proxy_url: None,
+            proxy_label: None,
+            use_connection_proxy: None,
+            runtime_transport: None,
+            provider_specific_data: BTreeMap::new(),
+            extra: BTreeMap::new(),
+        };
+        let headers = executor.build_headers(&credentials).unwrap();
+        assert_eq!(headers.get("cookie").unwrap(), "sso=my-token");
+        assert!(headers.get("x-statsig-id").is_some());
+        assert!(headers.get("x-xai-request-id").is_some());
+        assert_eq!(headers.get("origin").unwrap(), "https://grok.com");
+        let traceparent = headers.get("traceparent").unwrap().to_str().unwrap();
+        assert!(traceparent.starts_with("00-"));
+        assert_eq!(traceparent.len(), 3 + 32 + 1 + 16 + 1 + 2);
     }
 
     #[test]


### PR DESCRIPTION
## Bead openproxy-9router-parity-v0550-pnc.25 — full grok-web executor port

Ports `open-sse/executors/grok-web.js` to Rust in `src/core/executor/grok_web.rs`.

### Changes
- **URL**: `https://grok.com/rest/app-chat/conversations/new` (was missing `/rest`)
- **MODEL_MAP**: all 14 entries (grok-3 → grok-4.20-beta) with exact `grokModel`/`modelMode`/`isThinking`, verified against the original open-sse implementation; unmapped models default to grok-4.1-fast
- **parseOpenAIMessages**: OpenAI messages flattened to `role: text` joined with `\n\n`; every message except the last user message gets a `role: ` prefix (system included — grok-web differs from perplexity-web); `developer` → `system`; text-part content arrays joined with spaces
- **grokPayload**: verbatim field set (temporary, modelName, modelMode, message, fileAttachments, imageAttachments, disableSearch, enableImageGeneration, returnImageBytes, returnRawGrokInXaiRequest, enableImageStreaming, imageGenerationCount, forceConcise, toolOverrides, enableSideBySide, sendFinalMetadata, isReasoning, disableTextFollowUps, disableMemory, forceSideBySide, isAsyncChat, disableSelfHarmShortCircuit, deviceEnvInfo)
- **Browser headers**: Accept `*/*`, Accept-Encoding, Accept-Language, Baggage (sentry), Origin, Referer, Sec-Ch-Ua/Sec-Fetch-\*, Chrome 136 macOS UA, `x-statsig-id` (base64 of a randomized fake TypeError — valid btoa), `x-xai-request-id` (UUID), `traceparent` `00-{32hex}-{16hex}-00`
- **Cookie**: read from `credentials.api_key` (web-cookie convention), `sso=` prefix stripped, sent as `sso={token}`
- **Error mapping**: 401/403 → `Grok auth failed — SSO cookie may be expired…`, 429 → `Grok rate limited…`, type `upstream_error`, code `HTTP_{status}`, HTTP status preserved (drives existing fallback/cooldown logic)

### Tests
- Guard `test_grok_web_payload_shape` passes (grok-4.2 → grok-420 / MODEL_MODE_GROK_420 / `system: S\n\nU` / temporary)
- 13 grok_web tests pass; full lib suite: 1451 passed, 0 failed; `cargo build -p openproxy` clean