### PR TITLE
fix(translator): max_tokens model ceiling + thinking budget reconciliation (bead .42)

### DIFF
--- a/src/core/translator/request/claude_format.rs
+++ b/src/core/translator/request/claude_format.rs
@@ -152,21 +152,52 @@ pub fn prepare_claude_request(body: &mut Value, provider: &str, api_key: Option<
     }
 
     // ── clamp max_tokens to model-aware ceiling ──
-    if let Some(max_tokens) = obj.get("max_tokens").and_then(Value::as_u64) {
+    let ceiling: u64 = {
         let model_lower = obj
             .get("model")
             .and_then(Value::as_str)
             .unwrap_or("")
             .to_lowercase();
-        let ceiling: u64 = if model_lower.contains("opus") {
-            200_000 // Opus: 200k context
+        if model_lower.contains("opus") {
+            128_000 // Opus: 128k max output (9router capabilities.js parity)
         } else if model_lower.contains("sonnet") {
             128_000
         } else {
             DEFAULT_MAX_TOKENS as u64 // 64_000 (haiku, unknown, non-Claude)
-        };
+        }
+    };
+    if let Some(max_tokens) = obj.get("max_tokens").and_then(Value::as_u64) {
         if max_tokens > ceiling {
             obj.insert("max_tokens".to_string(), json!(ceiling));
+        }
+    }
+
+    // ── thinking budget reconciliation (9router claude.js parity) ──
+    // If the thinking budget is not strictly below max_tokens, Claude 400s —
+    // raise max_tokens to budget + 1024 (capped at the ceiling) and shrink
+    // the budget to max(1024, max_tokens - 1024).
+    if obj
+        .get("thinking")
+        .and_then(|t| t.get("type"))
+        .and_then(Value::as_str)
+        == Some("enabled")
+    {
+        if let (Some(budget_tokens), Some(max_tokens)) = (
+            obj.get("thinking")
+                .and_then(|t| t.get("budget_tokens"))
+                .and_then(Value::as_u64),
+            obj.get("max_tokens").and_then(Value::as_u64),
+        ) {
+            if budget_tokens >= max_tokens {
+                let new_max = (budget_tokens + 1024).min(ceiling);
+                obj.insert("max_tokens".to_string(), json!(new_max));
+                if budget_tokens >= new_max {
+                    obj.get_mut("thinking")
+                        .and_then(Value::as_object_mut)
+                        .and_then(|t| t.get_mut("budget_tokens"))
+                        .map(|v| *v = json!(1024u64.max(new_max - 1024)));
+                }
+            }
         }
     }
 
@@ -658,6 +689,21 @@ mod tests {
         });
         prepare_claude_request(&mut body, "claude", None);
         assert_eq!(body["max_tokens"], DEFAULT_MAX_TOKENS);
+    }
+
+    #[test]
+    fn claude_format_reconciles_budget_after_clamp() {
+        let mut body = json!({
+            "model": "claude-sonnet-4.6",
+            "max_tokens": 128000,
+            "thinking": {"type": "enabled", "budget_tokens": 128000},
+            "messages": [{"role": "user", "content": "hi"}]
+        });
+        prepare_claude_request(&mut body, "claude", None);
+        // budget + 1024 capped at the sonnet ceiling (128000)
+        assert_eq!(body["max_tokens"], 128000);
+        // budget shrunk to max_tokens - 1024
+        assert_eq!(body["thinking"]["budget_tokens"], 126976);
     }
 
     #[test]

--- a/src/core/translator/request/openai_to_claude.rs
+++ b/src/core/translator/request/openai_to_claude.rs
@@ -376,7 +376,38 @@ fn convert_openai_tool_choice(choice: &Value) -> Option<ClaudeToolChoice> {
     }
 }
 
-fn adjust_max_tokens(body: &serde_json::Map<String, Value>) -> u32 {
+/// Model-aware `max_tokens` output ceiling, mirroring 9router
+/// `capabilities.js` `maxOutput` (128000 for claude opus/sonnet >= 4.6,
+/// else 64000).
+fn model_output_ceiling(model: &str) -> u32 {
+    let lower = model.to_lowercase();
+    if lower.contains("claude")
+        && (lower.contains("opus") || lower.contains("sonnet"))
+        && version_at_least_4_6(&lower)
+    {
+        128000
+    } else {
+        64000
+    }
+}
+
+/// Whether the model string carries a version >= 4.6 (e.g. `-4.6`, `-4.8`,
+/// `-5`). `claude-3-5-sonnet` stays below the threshold.
+fn version_at_least_4_6(model: &str) -> bool {
+    let mut rest = model;
+    while let Some(pos) = rest.find(['-', '.']) {
+        rest = &rest[pos + 1..];
+        let major_end = rest.find(['-', '.']).unwrap_or(rest.len());
+        if let Ok(major) = rest[..major_end].parse::<u32>() {
+            if major >= 4 {
+                return true;
+            }
+        }
+    }
+    false
+}
+
+fn adjust_max_tokens(body: &serde_json::Map<String, Value>, ceiling: u32) -> u32 {
     let mut max_tokens = body
         .get("max_tokens")
         .and_then(|v| v.as_u64())
@@ -396,6 +427,11 @@ fn adjust_max_tokens(body: &serde_json::Map<String, Value>) -> u32 {
         }
     }
 
+    // 9router maxTokens.js parity: never exceed the model ceiling.
+    if max_tokens > ceiling {
+        max_tokens = ceiling;
+    }
+
     max_tokens
 }
 
@@ -409,7 +445,8 @@ pub fn openai_to_claude_request(
         return false;
     };
 
-    let max_tokens = adjust_max_tokens(body_obj);
+    let ceiling = model_output_ceiling(model);
+    let max_tokens = adjust_max_tokens(body_obj, ceiling);
 
     let mut result_messages: Vec<ClaudeMessage> = Vec::new();
     let mut system_parts: Vec<String> = Vec::new();
@@ -964,6 +1001,24 @@ mod tests {
             thinking.get("budget_tokens").unwrap().as_u64().unwrap(),
             24576 // 9router LEVEL_TO_BUDGET: high = 24576
         );
+    }
+
+    #[test]
+    fn adjust_max_tokens_clamps_to_model_ceiling() {
+        let mut body: Value = serde_json::from_str(
+            r#"{
+            "model": "gpt-4",
+            "max_tokens": 200000,
+            "messages": [{"role": "user", "content": "Hello"}]
+        }"#,
+        )
+        .unwrap();
+
+        openai_to_claude_request("claude-opus-4.8", &mut body, false, None);
+
+        // 9router capabilities.js parity: claude-opus-4.8 maxOutput = 128000,
+        // so 200000 is clamped down to the model ceiling (not left at 200000).
+        assert_eq!(body.get("max_tokens").unwrap().as_u64().unwrap(), 128000);
     }
 
     #[test]


### PR DESCRIPTION
Per spec P0-A12: adjust_max_tokens ceiling clamp via model_output_ceiling (128000 for claude opus/sonnet >= 4.6), claude_format opus ceiling 200000→128000, JS budget reconciliation after clamp. Guard tests: adjust_max_tokens_clamps_to_model_ceiling, claude_format_reconciles_budget_after_clamp.