### PR TITLE
fix(kiro): max_thinking_length budget + additionalModelRequestFields (bead .45)

### DIFF
--- a/src/core/config/kiro_constants.rs
+++ b/src/core/config/kiro_constants.rs
@@ -125,6 +125,227 @@ pub fn build_thinking_system_prefix(budget: Option<u32>) -> String {
     )
 }
 
+/// Map an effort level string to a thinking budget, mirroring the
+/// `effortToBudget` LEVEL_TO_BUDGET table in 9router's thinking.js. Unknown
+/// levels fall back to the default budget (JS: `?? KIRO_THINKING_BUDGET_DEFAULT`).
+pub fn effort_to_kiro_budget(level: &str) -> Option<u32> {
+    match level.to_lowercase().as_str() {
+        "minimal" => Some(512),
+        "low" => Some(1024),
+        "medium" => Some(8192),
+        "high" => Some(24576),
+        "xhigh" => Some(32768),
+        "max" => Some(128_000),
+        // "auto" and any other unknown level: JS treats it as a fallback to
+        // KIRO_THINKING_BUDGET_DEFAULT (16000).
+        _ => Some(KIRO_THINKING_BUDGET_DEFAULT),
+    }
+}
+
+/// Resolve the Kiro thinking budget for an inbound request, mirroring
+/// `resolveKiroThinkingBudget` in 9router's kiroConstants.js.
+///
+/// Resolution order (first match wins):
+///   1. `body.output_config.effort` (Claude-flavored native effort field)
+///   2. `body.thinking` block — `disabled` → None; `enabled`/`adaptive` with
+///      `budget_tokens` → that budget
+///   3. `body.reasoning_effort` / `body.reasoning.effort` — `none`/`off`/
+///      `disabled` → None; otherwise effortToBudget(level)
+///   4. `anthropic-beta` header containing `interleaved-thinking` → 16000
+///   5. messages/system containing a `<thinking_mode>` tag → 16000
+///   6. model id containing `thinking` or `-reason` → 16000
+///   7. else None
+pub fn resolve_kiro_thinking_budget(
+    body: &Value,
+    headers: Option<&dyn HeaderLookup>,
+    model: &str,
+) -> Option<u32> {
+    // 1. output_config.effort (native Claude effort field).
+    if let Some(effort) = body
+        .get("output_config")
+        .and_then(|o| o.get("effort"))
+        .and_then(|v| v.as_str())
+    {
+        return effort_to_kiro_budget(effort);
+    }
+
+    // 2. thinking block.
+    if let Some(thinking) = body.get("thinking") {
+        let t = thinking.get("type").and_then(|v| v.as_str());
+        match t {
+            Some("disabled") => return None,
+            Some("enabled" | "adaptive") => {
+                let budget = thinking
+                    .get("budget_tokens")
+                    .and_then(|v| v.as_f64())
+                    .filter(|b| b.is_finite() && *b > 0.0);
+                if let Some(b) = budget {
+                    return Some(b as u32);
+                }
+                // enabled without a positive budget still counts as thinking;
+                // JS falls through to the default-budget fallbacks below.
+            }
+            _ => {}
+        }
+    }
+
+    // 3. reasoning effort fields.
+    let effort = body
+        .get("reasoning_effort")
+        .and_then(|v| v.as_str())
+        .or_else(|| {
+            body.get("reasoning")
+                .and_then(|r| r.get("effort"))
+                .and_then(|v| v.as_str())
+        });
+    if let Some(level) = effort {
+        let lowered = level.to_lowercase();
+        if matches!(lowered.as_str(), "none" | "off" | "disabled") {
+            return None;
+        }
+        return effort_to_kiro_budget(&lowered);
+    }
+
+    // 4. anthropic-beta header.
+    if let Some(h) = headers {
+        if let Some(beta) = h.get("anthropic-beta") {
+            if beta.to_lowercase().contains("interleaved-thinking") {
+                return Some(KIRO_THINKING_BUDGET_DEFAULT);
+            }
+        }
+    }
+
+    // 5. thinking-mode tag in messages/system.
+    if contains_thinking_mode_tag(body) {
+        return Some(KIRO_THINKING_BUDGET_DEFAULT);
+    }
+
+    // 6. model id hint.
+    let m = model.to_lowercase();
+    if m.contains("thinking") || m.contains("-reason") {
+        return Some(KIRO_THINKING_BUDGET_DEFAULT);
+    }
+
+    None
+}
+
+/// Decide which native-effort request field a model speaks, mirroring
+/// `resolveKiroEffortPath` in 9router's kiroConstants.js:
+///   - `"reasoning"` for GPT-5.6-family models (id contains `gpt`, `5` and
+///     `6` tokens)
+///   - `"output_config"` for Claude models newer than 4.5 (major > 4, or
+///     major 4 with minor > 5)
+///   - `None` otherwise
+pub fn resolve_kiro_effort_path(model: &str) -> Option<&'static str> {
+    let lower = model.to_lowercase();
+    let tokens: Vec<&str> = lower
+        .split(|c: char| !c.is_ascii_alphanumeric())
+        .filter(|t| !t.is_empty())
+        .collect();
+
+    // GPT-5.6 family: "gpt" plus a "5" and a "6" version token.
+    if tokens.iter().any(|t| *t == "gpt")
+        && tokens.iter().any(|t| *t == "5")
+        && tokens.iter().any(|t| *t == "6")
+    {
+        return Some("reasoning");
+    }
+
+    // Claude: parse the first numeric version run (`N` or `N.M`) after the
+    // `claude` token — e.g. `4.6` in `claude-sonnet-4.6`, `4` in
+    // `claude-opus-4-20250514`.
+    if lower.contains("claude") {
+        let rest = &lower[lower.find("claude").unwrap() + "claude".len()..];
+        let version = rest
+            .split(|c: char| !c.is_ascii_digit() && c != '.')
+            .find(|tok| !tok.is_empty() && tok.chars().any(|c| c.is_ascii_digit()));
+        if let Some(v) = version {
+            let mut parts = v.split('.');
+            let major: u32 = parts.next().and_then(|p| p.parse().ok()).unwrap_or(0);
+            let minor: Option<u32> = parts.next().and_then(|p| p.parse().ok());
+            let is_newer = major > 4 || (major == 4 && minor.is_some_and(|m| m > 5));
+            if is_newer {
+                return Some("output_config");
+            }
+        }
+    }
+
+    None
+}
+
+/// Extract the native effort level a model should receive on the wire,
+/// mirroring the JS extractors in kiroConstants.js. Only known effort
+/// levels are accepted (unknown ones like `auto`/`minimal`/`ultra` yield
+/// `None`); for Claude (`output_config`) the `xhigh`/`max` levels fold
+/// down to `high`, and for GPT (`reasoning`) `max` maps to `xhigh`.
+/// Returns `None` when the body carries no usable effort value.
+pub fn extract_kiro_effort_level(body: &Value, path: &str) -> Option<String> {
+    let effort = body
+        .get("reasoning_effort")
+        .and_then(|v| v.as_str())
+        .or_else(|| {
+            body.get("reasoning")
+                .and_then(|r| r.get("effort"))
+                .and_then(|v| v.as_str())
+        })
+        .or_else(|| {
+            body.get("output_config")
+                .and_then(|o| o.get("effort"))
+                .and_then(|v| v.as_str())
+        })
+        .map(str::to_lowercase)?;
+
+    match path {
+        "output_config" => match effort.as_str() {
+            "low" | "medium" | "high" => Some(effort),
+            "xhigh" | "max" => Some("high".to_string()),
+            _ => None,
+        },
+        "reasoning" => match effort.as_str() {
+            "low" | "medium" | "high" | "xhigh" => Some(effort),
+            "max" => Some("xhigh".to_string()),
+            _ => None,
+        },
+        _ => None,
+    }
+}
+
+/// Whether a model uses Kiro's native GPT effort field, in which case the
+/// legacy `<thinking_mode>` prompt-tag prefix must be suppressed. Mirrors
+/// `usesKiroNativeGptEffort` in 9router: only true for GPT-5.6 models
+/// carrying a supported effort value (none/off/disabled/unknown are not
+/// native).
+pub fn uses_kiro_native_gpt_effort(model: &str, body: &Value) -> bool {
+    resolve_kiro_effort_path(model) == Some("reasoning")
+        && extract_kiro_effort_level(body, "reasoning").is_some()
+}
+
+/// Build `additionalModelRequestFields` for a Kiro request, mirroring
+/// `buildKiroAdditionalModelRequestFieldsForModel` in 9router's
+/// kiroConstants.js:
+///   - Claude models (`output_config` path) →
+///     `{ thinking: { type: "adaptive", display: "summarized" }, output_config: { effort } }`
+///   - GPT-5.6 models (`reasoning` path) → `{ reasoning: { effort } }`
+///   - otherwise `None`
+pub fn build_kiro_additional_model_request_fields_for_model(
+    body: &Value,
+    model: &str,
+) -> Option<Value> {
+    let path = resolve_kiro_effort_path(model)?;
+    let effort = extract_kiro_effort_level(body, path)?;
+
+    match path {
+        "output_config" => Some(serde_json::json!({
+            "thinking": { "type": "adaptive", "display": "summarized" },
+            "output_config": { "effort": effort }
+        })),
+        "reasoning" => Some(serde_json::json!({
+            "reasoning": { "effort": effort }
+        })),
+        _ => None,
+    }
+}
+
 /// Detect whether an inbound request is asking for reasoning / thinking
 /// output. Mirrors `isThinkingEnabled` in 9router.
 ///
@@ -359,5 +580,234 @@ mod tests {
         assert!(is_thinking_enabled(None, None, Some("kimi-k2-thinking")));
         assert!(is_thinking_enabled(None, None, Some("o3-reason")));
         assert!(!is_thinking_enabled(None, None, Some("gpt-4o")));
+    }
+
+    #[test]
+    fn resolve_kiro_thinking_budget_effort_levels() {
+        // low → 1024
+        let body = json!({"reasoning_effort": "low"});
+        assert_eq!(
+            resolve_kiro_thinking_budget(&body, None, "gpt-4o"),
+            Some(1024)
+        );
+        // medium → 8192
+        let body = json!({"reasoning_effort": "medium"});
+        assert_eq!(
+            resolve_kiro_thinking_budget(&body, None, "gpt-4o"),
+            Some(8192)
+        );
+        // high → 24576
+        let body = json!({"reasoning": {"effort": "high"}});
+        assert_eq!(
+            resolve_kiro_thinking_budget(&body, None, "gpt-4o"),
+            Some(24576)
+        );
+        // xhigh → 32768
+        let body = json!({"reasoning_effort": "xhigh"});
+        assert_eq!(
+            resolve_kiro_thinking_budget(&body, None, "gpt-4o"),
+            Some(32768)
+        );
+        // max → 128000
+        let body = json!({"reasoning_effort": "max"});
+        assert_eq!(
+            resolve_kiro_thinking_budget(&body, None, "gpt-4o"),
+            Some(128_000)
+        );
+        // minimal → 512
+        let body = json!({"reasoning_effort": "minimal"});
+        assert_eq!(
+            resolve_kiro_thinking_budget(&body, None, "gpt-4o"),
+            Some(512)
+        );
+        // auto → default 16000
+        let body = json!({"reasoning_effort": "auto"});
+        assert_eq!(
+            resolve_kiro_thinking_budget(&body, None, "gpt-4o"),
+            Some(16_000)
+        );
+        // unknown level → default 16000 (JS `?? KIRO_THINKING_BUDGET_DEFAULT`)
+        let body = json!({"reasoning_effort": "ultra"});
+        assert_eq!(
+            resolve_kiro_thinking_budget(&body, None, "gpt-4o"),
+            Some(16_000)
+        );
+    }
+
+    #[test]
+    fn resolve_kiro_thinking_budget_none_off_disabled() {
+        let body = json!({"reasoning_effort": "none"});
+        assert_eq!(resolve_kiro_thinking_budget(&body, None, "gpt-4o"), None);
+        let body = json!({"reasoning_effort": "off"});
+        assert_eq!(resolve_kiro_thinking_budget(&body, None, "gpt-4o"), None);
+        let body = json!({"reasoning": {"effort": "disabled"}});
+        assert_eq!(resolve_kiro_thinking_budget(&body, None, "gpt-4o"), None);
+        let body = json!({"reasoning": {"effort": "none"}});
+        assert_eq!(resolve_kiro_thinking_budget(&body, None, "gpt-4o"), None);
+        // No effort at all → None.
+        let body = json!({"messages": [{"role": "user", "content": "hi"}]});
+        assert_eq!(resolve_kiro_thinking_budget(&body, None, "gpt-4o"), None);
+    }
+
+    #[test]
+    fn resolve_kiro_thinking_budget_thinking_block() {
+        let body = json!({"thinking": {"type": "disabled"}});
+        assert_eq!(resolve_kiro_thinking_budget(&body, None, "gpt-4o"), None);
+        let body = json!({"thinking": {"type": "enabled", "budget_tokens": 8000}});
+        assert_eq!(
+            resolve_kiro_thinking_budget(&body, None, "gpt-4o"),
+            Some(8000)
+        );
+        let body = json!({"thinking": {"type": "adaptive", "budget_tokens": 4096}});
+        assert_eq!(
+            resolve_kiro_thinking_budget(&body, None, "gpt-4o"),
+            Some(4096)
+        );
+        // enabled without a budget falls through to the default fallbacks.
+        let body = json!({"thinking": {"type": "enabled"}});
+        assert_eq!(resolve_kiro_thinking_budget(&body, None, "gpt-4o"), None);
+    }
+
+    #[test]
+    fn resolve_kiro_thinking_budget_output_config_effort() {
+        let body = json!({"output_config": {"effort": "low"}});
+        assert_eq!(
+            resolve_kiro_thinking_budget(&body, None, "gpt-4o"),
+            Some(1024)
+        );
+        let body = json!({"output_config": {"effort": "disabled"}});
+        assert_eq!(
+            resolve_kiro_thinking_budget(&body, None, "gpt-4o"),
+            Some(16_000)
+        );
+    }
+
+    #[test]
+    fn resolve_kiro_thinking_budget_header_tag_model() {
+        // anthropic-beta header.
+        let mut h = std::collections::BTreeMap::new();
+        h.insert(
+            "Anthropic-Beta".to_string(),
+            "interleaved-thinking-2024".to_string(),
+        );
+        let body = json!({});
+        assert_eq!(
+            resolve_kiro_thinking_budget(&body, Some(&h), "gpt-4o"),
+            Some(16_000)
+        );
+
+        // thinking-mode tag in messages.
+        let body = json!({
+            "messages": [
+                {"role": "system", "content": "do stuff <thinking_mode>enabled</thinking_mode>"}
+            ]
+        });
+        assert_eq!(
+            resolve_kiro_thinking_budget(&body, None, "gpt-4o"),
+            Some(16_000)
+        );
+
+        // Model-name hints.
+        let body = json!({});
+        assert_eq!(
+            resolve_kiro_thinking_budget(&body, None, "kimi-k2-thinking"),
+            Some(16_000)
+        );
+        assert_eq!(
+            resolve_kiro_thinking_budget(&body, None, "o3-reason"),
+            Some(16_000)
+        );
+        assert_eq!(resolve_kiro_thinking_budget(&body, None, "gpt-4o"), None);
+    }
+
+    #[test]
+    fn resolve_kiro_effort_path_detects_gpt56_and_claude46() {
+        assert_eq!(resolve_kiro_effort_path("gpt-5.6-sol"), Some("reasoning"));
+        assert_eq!(resolve_kiro_effort_path("gpt-5.6"), Some("reasoning"));
+        assert_eq!(resolve_kiro_effort_path("gpt-4o"), None);
+        assert_eq!(resolve_kiro_effort_path("gpt-5"), None);
+
+        assert_eq!(
+            resolve_kiro_effort_path("claude-sonnet-4.6"),
+            Some("output_config")
+        );
+        assert_eq!(
+            resolve_kiro_effort_path("claude-opus-4.6"),
+            Some("output_config")
+        );
+        assert_eq!(resolve_kiro_effort_path("claude-3-7-sonnet"), None);
+        assert_eq!(resolve_kiro_effort_path("claude-sonnet-4.5"), None);
+        assert_eq!(resolve_kiro_effort_path("claude-opus-4"), None);
+        // 4.6 after a 4 token: `claude-4-4.6` edge, first version run is 4.
+        assert_eq!(resolve_kiro_effort_path("claude-4-4.6"), None);
+    }
+
+    #[test]
+    fn build_kiro_additional_model_request_fields_claude() {
+        let body = json!({"reasoning_effort": "low"});
+        assert_eq!(
+            build_kiro_additional_model_request_fields_for_model(&body, "claude-sonnet-4.6"),
+            Some(json!({
+                "thinking": {"type": "adaptive", "display": "summarized"},
+                "output_config": {"effort": "low"}
+            }))
+        );
+        // xhigh/max fold down to high for Claude.
+        let body = json!({"reasoning_effort": "xhigh"});
+        let fields =
+            build_kiro_additional_model_request_fields_for_model(&body, "claude-sonnet-4.6")
+                .unwrap();
+        assert_eq!(fields["output_config"]["effort"], "high");
+        // Unsupported effort → no fields.
+        let body = json!({"reasoning_effort": "auto"});
+        assert_eq!(
+            build_kiro_additional_model_request_fields_for_model(&body, "claude-sonnet-4.6"),
+            None
+        );
+        // none → no fields.
+        let body = json!({"reasoning_effort": "none"});
+        assert_eq!(
+            build_kiro_additional_model_request_fields_for_model(&body, "claude-sonnet-4.6"),
+            None
+        );
+        // Old claude → no fields even with effort.
+        let body = json!({"reasoning_effort": "low"});
+        assert_eq!(
+            build_kiro_additional_model_request_fields_for_model(&body, "claude-sonnet-4.5"),
+            None
+        );
+    }
+
+    #[test]
+    fn build_kiro_additional_model_request_fields_gpt() {
+        let body = json!({"reasoning": {"effort": "high"}});
+        assert_eq!(
+            build_kiro_additional_model_request_fields_for_model(&body, "gpt-5.6-sol"),
+            Some(json!({"reasoning": {"effort": "high"}}))
+        );
+        // max → xhigh for GPT.
+        let body = json!({"reasoning": {"effort": "max"}});
+        let fields =
+            build_kiro_additional_model_request_fields_for_model(&body, "gpt-5.6-sol").unwrap();
+        assert_eq!(fields["reasoning"]["effort"], "xhigh");
+        // none → no fields.
+        let body = json!({"reasoning": {"effort": "none"}});
+        assert_eq!(
+            build_kiro_additional_model_request_fields_for_model(&body, "gpt-5.6-sol"),
+            None
+        );
+    }
+
+    #[test]
+    fn uses_kiro_native_gpt_effort_guards() {
+        let body = json!({"reasoning": {"effort": "high"}});
+        assert!(uses_kiro_native_gpt_effort("gpt-5.6-sol", &body));
+        let body = json!({"reasoning": {"effort": "none"}});
+        assert!(!uses_kiro_native_gpt_effort("gpt-5.6-sol", &body));
+        let body = json!({"reasoning_effort": "auto"});
+        assert!(!uses_kiro_native_gpt_effort("gpt-5.6-sol", &body));
+        // Non-GPT models never native.
+        let body = json!({"reasoning_effort": "high"});
+        assert!(!uses_kiro_native_gpt_effort("claude-sonnet-4.6", &body));
     }
 }

--- a/src/core/translator/request/claude_to_kiro.rs
+++ b/src/core/translator/request/claude_to_kiro.rs
@@ -6,6 +6,10 @@
 //! The Kiro format is the same target as `openai_to_kiro_request` produces,
 //! so this implementation mirrors that approach but reads Claude-format input.
 
+use crate::core::config::kiro_constants::{
+    build_kiro_additional_model_request_fields_for_model, build_thinking_system_prefix,
+    resolve_kiro_thinking_budget, uses_kiro_native_gpt_effort, HeaderLookup,
+};
 use crate::core::translator::concerns::kiro_conversation::{
     canonicalize_kiro_conversation, normalize_kiro_tool_specs,
 };
@@ -186,7 +190,8 @@ pub fn claude_to_kiro_request(
                             if let Some(tool_use_id) = c.get("tool_use_id").and_then(|v| v.as_str())
                             {
                                 // 9router claude-to-kiro.js:110 — status reflects is_error.
-                                let is_err = c.get("is_error").and_then(Value::as_bool).unwrap_or(false);
+                                let is_err =
+                                    c.get("is_error").and_then(Value::as_bool).unwrap_or(false);
                                 pending_tool_results.push(serde_json::json!({
                                     "toolUseId": tool_use_id,
                                     "status": if is_err { "error" } else { "success" },
@@ -386,17 +391,6 @@ pub fn claude_to_kiro_request(
         }
     }
 
-    // Check for thinking/reasoning_effort
-    let thinking_enabled = body.get("reasoning_effort").is_some()
-        || body
-            .get("thinking")
-            .and_then(|t| t.get("type"))
-            .and_then(|v| v.as_str())
-            == Some("enabled");
-    if thinking_enabled {
-        system_prompt_parts.push("<thinking_mode>enabled</thinking_mode>".to_string());
-    }
-
     // Check for -agentic suffix
     let is_agentic = model.ends_with("-agentic");
     if is_agentic {
@@ -411,6 +405,19 @@ pub fn claude_to_kiro_request(
         model
     };
 
+    // Resolve the Kiro thinking budget (9router resolveKiroThinkingBudget) and
+    // push the legacy `<thinking_mode>`/`<max_thinking_length>` prefix when a
+    // budget exists and the model does not use native GPT effort fields.
+    let raw_headers = crate::core::utils::session_manager::credentials_raw_headers(credentials);
+    let headers_lookup = raw_headers.as_ref().map(|h| h as &dyn HeaderLookup);
+    let thinking_budget = resolve_kiro_thinking_budget(body, headers_lookup, upstream_model);
+    let uses_native_gpt_effort = uses_kiro_native_gpt_effort(upstream_model, body);
+    if let Some(budget) = thinking_budget {
+        if !uses_native_gpt_effort {
+            system_prompt_parts.push(build_thinking_system_prefix(Some(budget)));
+        }
+    }
+
     let system_prompt = system_prompt_parts.join("\n\n");
     let timestamp = chrono::Utc::now().to_rfc3339();
     let current_time_context = format!("[Context: Current time is {timestamp}]");
@@ -424,7 +431,6 @@ pub fn claude_to_kiro_request(
     // Resolve conversation-stable session identity (client header / body field,
     // or ephemeral one-shot for Kiro when no client id is present).
     let connection_id = crate::core::utils::session_manager::credentials_connection_id(credentials);
-    let raw_headers = crate::core::utils::session_manager::credentials_raw_headers(credentials);
     let session_identity = crate::core::utils::session_manager::resolve_session_identity(
         raw_headers.as_ref(),
         // Body still has original Claude shape here (we replace *body later).
@@ -508,6 +514,12 @@ pub fn claude_to_kiro_request(
 
     if !system_prompt.is_empty() {
         payload["systemPrompt"] = Value::String(system_prompt);
+    }
+
+    // Native effort fields for supported models (9router
+    // buildKiroAdditionalModelRequestFieldsForModel).
+    if let Some(amrf) = build_kiro_additional_model_request_fields_for_model(body, upstream_model) {
+        payload["additionalModelRequestFields"] = amrf;
     }
 
     // Add profileArn if present

--- a/src/core/translator/request/openai_to_kiro.rs
+++ b/src/core/translator/request/openai_to_kiro.rs
@@ -2,6 +2,10 @@
 //!
 //! Converts OpenAI Chat Completions to Kiro/AWS CodeWhisperer format.
 
+use crate::core::config::kiro_constants::{
+    build_kiro_additional_model_request_fields_for_model, build_thinking_system_prefix,
+    resolve_kiro_thinking_budget, uses_kiro_native_gpt_effort, HeaderLookup,
+};
 use crate::core::translator::concerns::kiro_conversation::{
     canonicalize_kiro_conversation, normalize_kiro_tool_specs,
 };
@@ -190,7 +194,8 @@ pub fn openai_to_kiro_request(
                             if let Some(tool_use_id) = c.get("tool_use_id").and_then(|v| v.as_str())
                             {
                                 // 9router openai-to-kiro.js:148 — status reflects is_error.
-                                let is_err = c.get("is_error").and_then(Value::as_bool).unwrap_or(false);
+                                let is_err =
+                                    c.get("is_error").and_then(Value::as_bool).unwrap_or(false);
                                 pending_tool_results.push(serde_json::json!({
                                     "toolUseId": tool_use_id,
                                     "status": if is_err { "error" } else { "success" },
@@ -406,15 +411,6 @@ pub fn openai_to_kiro_request(
     // System-stable content goes into content_prefix (frozen on msg0); volatile
     // current-time only goes into current_content_prefix (current turn only).
     let mut system_prompt_parts: Vec<String> = Vec::new();
-    let thinking_enabled = body.get("reasoning_effort").is_some()
-        || body
-            .get("thinking")
-            .and_then(|t| t.get("type"))
-            .and_then(|v| v.as_str())
-            == Some("enabled");
-    if thinking_enabled {
-        system_prompt_parts.push("<thinking_mode>enabled</thinking_mode>".to_string());
-    }
 
     // Check for -agentic suffix
     let is_agentic = model.ends_with("-agentic");
@@ -430,6 +426,19 @@ pub fn openai_to_kiro_request(
         model
     };
 
+    // Resolve the Kiro thinking budget (9router resolveKiroThinkingBudget) and
+    // push the legacy `<thinking_mode>`/`<max_thinking_length>` prefix when a
+    // budget exists and the model does not use native GPT effort fields.
+    let raw_headers = crate::core::utils::session_manager::credentials_raw_headers(credentials);
+    let headers_lookup = raw_headers.as_ref().map(|h| h as &dyn HeaderLookup);
+    let thinking_budget = resolve_kiro_thinking_budget(body, headers_lookup, upstream_model);
+    let uses_native_gpt_effort = uses_kiro_native_gpt_effort(upstream_model, body);
+    if let Some(budget) = thinking_budget {
+        if !uses_native_gpt_effort {
+            system_prompt_parts.push(build_thinking_system_prefix(Some(budget)));
+        }
+    }
+
     let system_prompt = system_prompt_parts.join("\n\n");
     let timestamp = chrono::Utc::now().to_rfc3339();
     let current_time_context = format!("[Context: Current time is {timestamp}]");
@@ -443,7 +452,6 @@ pub fn openai_to_kiro_request(
     // Resolve conversation-stable session identity (client header / body field,
     // or ephemeral one-shot for Kiro when no client id is present).
     let connection_id = crate::core::utils::session_manager::credentials_connection_id(credentials);
-    let raw_headers = crate::core::utils::session_manager::credentials_raw_headers(credentials);
     let session_identity = crate::core::utils::session_manager::resolve_session_identity(
         raw_headers.as_ref(),
         // Body still has original OpenAI shape here (we replace *body later).
@@ -527,6 +535,12 @@ pub fn openai_to_kiro_request(
 
     if !system_prompt.is_empty() {
         payload["systemPrompt"] = Value::String(system_prompt);
+    }
+
+    // Native effort fields for supported models (9router
+    // buildKiroAdditionalModelRequestFieldsForModel).
+    if let Some(amrf) = build_kiro_additional_model_request_fields_for_model(body, upstream_model) {
+        payload["additionalModelRequestFields"] = amrf;
     }
 
     // Add profileArn if present
@@ -632,5 +646,113 @@ mod tests {
         openai_to_kiro_request("kiro-model", &mut body, false, None);
         let content = current_message_content(&body);
         assert!(content.contains("[Tool result: ok]"));
+    }
+
+    /// Guard test per bead P0-A6 (JS openai-to-kiro.test.js:289-302):
+    /// reasoning_effort low for claude-sonnet-4.6 emits
+    /// `<max_thinking_length>1024</max_thinking_length>` AND
+    /// additionalModelRequestFields with the adaptive-thinking shape.
+    #[test]
+    fn reasoning_effort_low_emits_max_thinking_length_1024() {
+        let mut body = json!({
+            "model": "claude-sonnet-4.6",
+            "messages": [{"role": "user", "content": "hi"}],
+            "reasoning_effort": "low"
+        });
+        openai_to_kiro_request("claude-sonnet-4.6", &mut body, false, None);
+        let system_prompt = body["systemPrompt"].as_str().unwrap_or("");
+        assert!(
+            system_prompt.contains("<max_thinking_length>1024</max_thinking_length>"),
+            "systemPrompt should carry <max_thinking_length>1024</max_thinking_length>, got: {system_prompt}"
+        );
+        assert!(
+            system_prompt.contains("<thinking_mode>enabled</thinking_mode>"),
+            "systemPrompt should carry <thinking_mode>enabled</thinking_mode>, got: {system_prompt}"
+        );
+        assert_eq!(
+            body["additionalModelRequestFields"],
+            json!({
+                "thinking": {"type": "adaptive", "display": "summarized"},
+                "output_config": {"effort": "low"}
+            })
+        );
+    }
+
+    /// Guard test per bead P0-A6 (JS lines 386-400): reasoning_effort none →
+    /// no legacy prompt tags and no additionalModelRequestFields.
+    #[test]
+    fn reasoning_effort_none_emits_nothing() {
+        let mut body = json!({
+            "model": "claude-sonnet-4.6",
+            "messages": [{"role": "user", "content": "hi"}],
+            "reasoning_effort": "none"
+        });
+        openai_to_kiro_request("claude-sonnet-4.6", &mut body, false, None);
+        let system_prompt = body["systemPrompt"].as_str().unwrap_or("");
+        assert!(
+            !system_prompt.contains("<thinking_mode>"),
+            "systemPrompt should not contain <thinking_mode>, got: {system_prompt}"
+        );
+        assert!(
+            !system_prompt.contains("<max_thinking_length>"),
+            "systemPrompt should not contain <max_thinking_length>, got: {system_prompt}"
+        );
+        assert!(
+            body.get("additionalModelRequestFields").is_none(),
+            "additionalModelRequestFields should be absent, got: {}",
+            body
+        );
+    }
+
+    /// Guard test per bead P0-A6 (JS lines 323-338): GPT-5.6 reasoning.effort
+    /// high → additionalModelRequestFields {reasoning:{effort:high}} with NO
+    /// legacy prompt tags.
+    #[test]
+    fn gpt56_reasoning_effort_maps_to_reasoning_fields() {
+        let mut body = json!({
+            "model": "gpt-5.6-sol",
+            "messages": [{"role": "user", "content": "hi"}],
+            "reasoning": {"effort": "high"}
+        });
+        openai_to_kiro_request("gpt-5.6-sol", &mut body, false, None);
+        let system_prompt = body["systemPrompt"].as_str().unwrap_or("");
+        assert!(
+            !system_prompt.contains("<thinking_mode>"),
+            "systemPrompt should not contain <thinking_mode>, got: {system_prompt}"
+        );
+        assert_eq!(
+            body["additionalModelRequestFields"],
+            json!({"reasoning": {"effort": "high"}})
+        );
+    }
+
+    /// Guard test per bead P0-A6 (JS lines 370-384): unsupported efforts
+    /// (auto/minimal/ultra) → NO additionalModelRequestFields but legacy
+    /// `<thinking_mode>enabled</thinking_mode>` + `<max_thinking_length>`
+    /// fallback.
+    #[test]
+    fn unsupported_effort_falls_back_to_legacy_tags() {
+        for effort in ["auto", "minimal", "ultra"] {
+            let mut body = json!({
+                "model": "claude-sonnet-4.6",
+                "messages": [{"role": "user", "content": "hi"}],
+                "reasoning_effort": effort
+            });
+            openai_to_kiro_request("claude-sonnet-4.6", &mut body, false, None);
+            let system_prompt = body["systemPrompt"].as_str().unwrap_or("");
+            assert!(
+                system_prompt.contains("<thinking_mode>enabled</thinking_mode>"),
+                "effort {effort}: expected legacy <thinking_mode> tag, got: {system_prompt}"
+            );
+            assert!(
+                system_prompt.contains("<max_thinking_length>"),
+                "effort {effort}: expected legacy <max_thinking_length>, got: {system_prompt}"
+            );
+            assert!(
+                body.get("additionalModelRequestFields").is_none(),
+                "effort {effort}: additionalModelRequestFields should be absent, got: {}",
+                body
+            );
+        }
     }
 }


### PR DESCRIPTION
Per spec P0-A6: resolve_kiro_thinking_budget + resolve_kiro_effort_path + build_kiro_additional_model_request_fields_for_model ported to kiro_constants.rs; both kiro translators now emit <max_thinking_length> and additionalModelRequestFields per JS. Guard tests per JS unit tests.