### PR TITLE
fix(translator): minimax reasoningInject scope:all + bare-function tool shape (bead .43)

### DIFF
--- a/src/core/translator/request/openai_to_claude.rs
+++ b/src/core/translator/request/openai_to_claude.rs
@@ -630,12 +630,28 @@ pub fn openai_to_claude_request(
                 continue;
             }
 
-            let func = tool.get("function");
+            // Anthropic-compatible gateways (notably MiniMax M3 at
+            // api.minimaxi.com) may send bare `{name, description,
+            // parameters}` tools without a `function` wrapper (upstream
+            // code 2013 "invalid tool type" when the name falls through).
+            let func = tool
+                .get("function")
+                .filter(|f| {
+                    f.get("name")
+                        .and_then(Value::as_str)
+                        .map(|n| !n.is_empty())
+                        .unwrap_or(false)
+                })
+                .or(Some(tool));
             let original_name = func
                 .and_then(|f| f.get("name"))
                 .and_then(|n| n.as_str())
                 .unwrap_or("")
                 .to_string();
+            // Never push a nameless tool — gateways reject those.
+            if original_name.is_empty() {
+                continue;
+            }
 
             let tool_name = original_name
                 .strip_prefix(PROXY_TOOL_PREFIX)
@@ -905,6 +921,53 @@ mod tests {
         assert_eq!(tools.len(), 1);
         assert_eq!(tools[0].get("name").unwrap().as_str().unwrap(), "my_tool");
         assert!(tools[0].get("cache_control").is_some());
+    }
+
+    #[test]
+    fn bare_function_tool_keeps_name() {
+        // Anthropic-compatible gateways (e.g. MiniMax M3) may send tools
+        // without a `type`/`function` wrapper — the name must still resolve.
+        let mut body: Value = serde_json::from_str(
+            r#"{
+            "model": "MiniMax-M3",
+            "messages": [{"role": "user", "content": "Hello"}],
+            "tools": [
+                {
+                    "name": "echo",
+                    "description": "d",
+                    "parameters": {}
+                }
+            ]
+        }"#,
+        )
+        .unwrap();
+
+        openai_to_claude_request("claude-3", &mut body, false, None);
+
+        let tools = body.get("tools").unwrap().as_array().unwrap();
+        assert_eq!(tools.len(), 1);
+        assert_eq!(tools[0].get("name").unwrap().as_str().unwrap(), "echo");
+        assert!(tools[0].get("cache_control").is_some());
+    }
+
+    #[test]
+    fn nameless_tool_is_skipped() {
+        let mut body: Value = serde_json::from_str(
+            r#"{
+            "model": "gpt-4",
+            "messages": [{"role": "user", "content": "Hello"}],
+            "tools": [
+                {"type": "function", "function": {"description": "no name"}}
+            ]
+        }"#,
+        )
+        .unwrap();
+
+        openai_to_claude_request("claude-3", &mut body, false, None);
+
+        // When every tool is skipped the tools key is dropped entirely
+        // (result_tools is only written back when non-empty).
+        assert!(body.get("tools").is_none());
     }
 
     #[test]

--- a/src/core/utils/reasoning_content_injector.rs
+++ b/src/core/utils/reasoning_content_injector.rs
@@ -25,6 +25,11 @@ fn rule_for(provider: &str, model: &str) -> Option<Scope> {
     if provider == "deepseek" {
         return Some(Scope::All);
     }
+    // MiniMax cannot disable thinking (thinkingCanDisable: false) — the
+    // placeholder here is separate from thinking enablement.
+    if provider == "minimax" || provider == "minimax-cn" {
+        return Some(Scope::All);
+    }
     // Model-level fallback rules.
     if model.starts_with("kimi-") {
         return Some(Scope::ToolCalls);
@@ -178,6 +183,49 @@ mod tests {
         });
         inject_reasoning_content("deepseek", "deepseek-chat", &mut body);
         assert_eq!(body["messages"][0]["reasoning_content"], "preset");
+    }
+
+    #[test]
+    fn minimax_injects_on_all_assistant_messages() {
+        let mut body = json!({
+            "model": "MiniMax-M3",
+            "messages": [
+                {"role": "user", "content": "hi"},
+                {"role": "assistant", "content": "x"},
+            ]
+        });
+        inject_reasoning_content("minimax", "MiniMax-M3", &mut body);
+        assert_eq!(
+            body["messages"][1]["reasoning_content"],
+            Value::String(PLACEHOLDER.to_string())
+        );
+        // user message untouched
+        assert!(body["messages"][0].get("reasoning_content").is_none());
+
+        // Existing reasoning_content must not be overwritten.
+        let mut body = json!({
+            "model": "MiniMax-M3",
+            "messages": [
+                {"role": "assistant", "content": "x", "reasoning_content": "preset"},
+            ]
+        });
+        inject_reasoning_content("minimax", "MiniMax-M3", &mut body);
+        assert_eq!(body["messages"][0]["reasoning_content"], "preset");
+    }
+
+    #[test]
+    fn minimax_cn_injects_on_all_assistant_messages() {
+        let mut body = json!({
+            "model": "MiniMax-M3",
+            "messages": [
+                {"role": "assistant", "content": "x"},
+            ]
+        });
+        inject_reasoning_content("minimax-cn", "MiniMax-M3", &mut body);
+        assert_eq!(
+            body["messages"][0]["reasoning_content"],
+            Value::String(PLACEHOLDER.to_string())
+        );
     }
 
     #[test]


### PR DESCRIPTION
Per spec P0-A13: minimax/minimax-cn added to reasoning injector (Scope::All), bare {name,description,parameters} tools resolve original_name correctly. Guard tests: minimax_injects_on_all_assistant_messages, bare_function_tool_keeps_name.