### PR TITLE
fix(catalog): provider/model metadata parity for 17 providers (bead .46)

### DIFF
--- a/src/core/model/catalog.rs
+++ b/src/core/model/catalog.rs
@@ -12,6 +12,7 @@ struct ProviderCatalogFile {
 }
 
 #[derive(Debug, Clone, Deserialize, Serialize)]
+#[serde(rename_all = "camelCase")]
 pub struct ProviderCatalogModel {
     pub id: String,
     #[serde(default)]
@@ -25,7 +26,7 @@ pub struct ProviderCatalogModel {
     pub target_format: Option<String>,
     #[serde(default)]
     pub upstream_model_id: Option<String>,
-    #[serde(default)]
+    #[serde(default, alias = "contextLength")]
     pub context_window: Option<u32>,
     #[serde(default)]
     pub capabilities: Option<Vec<String>>,
@@ -150,8 +151,214 @@ mod tests {
         let models = catalog
             .models_for_alias("opencode-zen")
             .expect("opencode-zen should have models in provider_catalog.json");
-        assert!(models.len() >= 40, "expected the zen model list, got {}", models.len());
+        assert!(
+            models.len() >= 40,
+            "expected the zen model list, got {}",
+            models.len()
+        );
         assert!(models.iter().any(|m| m.id == "gpt-5.4"));
         assert!(models.iter().any(|m| m.id == "kimi-k2.6"));
+    }
+
+    // Bead .46: all 17 parity providers must be registered in the static
+    // catalog (providerIdToAlias + providerModels + providers[]), keyed by the
+    // same aliases the 9router v0.5.50 registry files declare.
+    #[test]
+    fn all_17_parity_providers_registered() {
+        let catalog = provider_catalog();
+
+        // (provider id, js alias) — mirror of the `alias` fields in
+        // open-sse/providers/registry/*.js for the 17 parity providers.
+        let expected: &[(&str, &str)] = &[
+            ("api-airforce", "af"),
+            ("baidu", "qianfan"),
+            ("bluesminds", "bm"),
+            ("clinepass", "clinepass"),
+            ("codebuddy-intl", "cbai"),
+            ("featherless", "featherless"),
+            ("kilo-gateway", "kgw"),
+            ("perplexity-agent", "perplexity-agent"),
+            ("poolside", "poolside"),
+            ("selfhosted-embedding", "selfhosted-embedding"),
+            ("selfhosted-stt", "selfhosted-stt"),
+            ("selfhosted-tts", "selfhosted-tts"),
+            ("tencent", "hunyuan"),
+            ("tokenrouter", "tokenrouter"),
+            ("venice", "venice"),
+            ("zed", "zd"),
+            ("alims-intl", "alims-intl"),
+        ];
+
+        for (provider_id, alias) in expected {
+            assert_eq!(
+                catalog.static_alias_for_provider(provider_id),
+                Some(*alias),
+                "providerIdToAlias[{}] should resolve to {}",
+                provider_id,
+                alias
+            );
+            assert!(
+                catalog.models_for_alias(alias).is_some(),
+                "providerModels should contain an entry for alias {}",
+                alias
+            );
+            let provider = catalog
+                .provider_info(provider_id)
+                .unwrap_or_else(|| panic!("providers[] should contain {}", provider_id));
+            assert_eq!(provider.alias, *alias);
+        }
+    }
+
+    // The catalog models carry the JS `contextLength` through into
+    // context_window (bead .46: it was previously dropped by deserialization).
+    #[test]
+    fn catalog_model_context_length_survives_deserialization() {
+        let catalog = provider_catalog();
+
+        let m = catalog
+            .find_model("baidu", "deepseek-v4-pro")
+            .expect("baidu/deepseek-v4-pro should be in provider_catalog.json");
+        assert_eq!(m.context_window, Some(1_048_576));
+        assert_eq!(m.kind, "llm");
+
+        // api-airforce and kilo-gateway carry explicit context lengths too.
+        let m = catalog
+            .find_model("api-airforce", "google/gemini-2.5-flash")
+            .expect("api-airforce/google/gemini-2.5-flash should be in the catalog");
+        assert_eq!(m.context_window, Some(1_048_576));
+        let m = catalog
+            .find_model("kilo-gateway", "nvidia/nemotron-3-ultra-550b-a55b:free")
+            .expect("kilo-gateway nemotron should be in the catalog");
+        assert_eq!(m.context_window, Some(1_000_000));
+    }
+
+    // Media kinds and service metadata for the parity providers must match the
+    // JS registry files (bead .46).
+    #[test]
+    fn catalog_media_kinds_match_registry() {
+        let catalog = provider_catalog();
+
+        // venice: embedding models present, image models carry kind image.
+        let venice = catalog.models_for_alias("venice").expect("venice models");
+        let emb: Vec<&str> = venice
+            .iter()
+            .filter(|m| m.kind == "embedding")
+            .map(|m| m.id.as_str())
+            .collect();
+        assert_eq!(
+            emb,
+            vec![
+                "text-embedding-3-large",
+                "text-embedding-bge-m3",
+                "text-embedding-qwen3-8b"
+            ]
+        );
+        assert!(venice
+            .iter()
+            .any(|m| m.id == "venice-sd35" && m.kind == "image"));
+
+        // tokenrouter: video/image/audio kinds preserved from the seed snapshot.
+        let tr = catalog
+            .models_for_alias("tokenrouter")
+            .expect("tokenrouter models");
+        assert!(tr
+            .iter()
+            .any(|m| m.id == "MiniMax-Hailuo-2.3" && m.kind == "video"));
+        assert!(tr
+            .iter()
+            .any(|m| m.id == "bytedance-seed/seedream-5.0-pro" && m.kind == "image"));
+        assert!(tr
+            .iter()
+            .any(|m| m.id == "openai/gpt-audio" && m.kind == "audio"));
+        assert!(tr
+            .iter()
+            .any(|m| m.id == "openai/gpt-5.4" && m.kind == "llm"));
+        // The embedding service model is declared on the provider entry, not as
+        // a kind on the model (JS leaves its kind implicit).
+        let tr_provider = catalog
+            .provider_info("tokenrouter")
+            .expect("tokenrouter provider");
+        assert_eq!(
+            tr_provider.embedding_models,
+            vec!["google/gemini-embedding-2"]
+        );
+        assert_eq!(tr_provider.service_kinds, vec!["llm", "embedding", "image"]);
+
+        // perplexity-agent: webSearch kind + hasSearch.
+        let pa = catalog
+            .provider_info("perplexity-agent")
+            .expect("perplexity-agent provider");
+        assert!(pa.has_search);
+        assert_eq!(pa.service_kinds, vec!["llm", "webSearch"]);
+
+        // selfhosted-*: single placeholder models, correct kinds and lists.
+        let se = catalog
+            .provider_info("selfhosted-embedding")
+            .expect("selfhosted-embedding");
+        assert_eq!(se.service_kinds, vec!["embedding"]);
+        assert_eq!(se.embedding_models, vec!["embedding"]);
+        assert!(catalog
+            .models_for_alias("selfhosted-embedding")
+            .is_some_and(|ms| {
+                ms.len() == 1 && ms[0].id == "embedding" && ms[0].kind == "embedding"
+            }));
+        let stt = catalog
+            .provider_info("selfhosted-stt")
+            .expect("selfhosted-stt");
+        assert_eq!(stt.service_kinds, vec!["stt"]);
+        assert!(catalog
+            .models_for_alias("selfhosted-stt")
+            .is_some_and(|ms| { ms.len() == 1 && ms[0].id == "whisper-1" && ms[0].kind == "stt" }));
+        let tts = catalog
+            .provider_info("selfhosted-tts")
+            .expect("selfhosted-tts");
+        assert_eq!(tts.service_kinds, vec!["tts"]);
+        assert_eq!(tts.tts_models, vec!["kokoro"]);
+        assert!(catalog
+            .models_for_alias("selfhosted-tts")
+            .is_some_and(|ms| { ms.len() == 1 && ms[0].id == "kokoro" && ms[0].kind == "tts" }));
+    }
+
+    // providerIdToAlias must resolve provider ids to the JS aliases, and
+    // find_model must reach models through them (bead .46).
+    #[test]
+    fn parity_provider_aliases_resolve() {
+        let catalog = provider_catalog();
+
+        for (provider_id, alias) in [
+            ("venice", "venice"),
+            ("tencent", "hunyuan"),
+            ("baidu", "qianfan"),
+            ("zed", "zd"),
+            ("codebuddy-intl", "cbai"),
+            ("kilo-gateway", "kgw"),
+            ("api-airforce", "af"),
+            ("bluesminds", "bm"),
+            ("tokenrouter", "tokenrouter"),
+            ("perplexity-agent", "perplexity-agent"),
+        ] {
+            assert_eq!(
+                catalog.static_alias_for_provider(provider_id),
+                Some(alias),
+                "{} should map to {}",
+                provider_id,
+                alias
+            );
+        }
+
+        // Reverse resolution: alias -> provider id.
+        let reverse = catalog.alias_to_provider_id();
+        for (provider_id, alias) in [
+            ("venice", "venice"),
+            ("tencent", "hunyuan"),
+            ("baidu", "qianfan"),
+        ] {
+            assert_eq!(reverse.get(alias).map(String::as_str), Some(provider_id));
+        }
+
+        let m = catalog
+            .find_model("baidu", "deepseek-v4-pro")
+            .expect("baidu/deepseek-v4-pro should resolve through qianfan");
+        assert_eq!(m.name.as_deref(), Some("DeepSeek V4 Pro"));
     }
 }

--- a/src/core/model/provider_catalog.json
+++ b/src/core/model/provider_catalog.json
@@ -113,7 +113,15 @@
   "poolside": "poolside",
   "zed": "zd",
   "codebuddy-intl": "cbai",
-  "alims-intl": "alims-intl"
+  "alims-intl": "alims-intl",
+  "baidu": "qianfan",
+  "clinepass": "clinepass",
+  "featherless": "featherless",
+  "perplexity-agent": "perplexity-agent",
+  "selfhosted-embedding": "selfhosted-embedding",
+  "selfhosted-stt": "selfhosted-stt",
+  "selfhosted-tts": "selfhosted-tts",
+  "tokenrouter": "tokenrouter"
  },
  "providerModels": [
   {
@@ -4788,6 +4796,796 @@
      "kind": "llm"
     }
    ]
+  },
+  {
+   "alias": "clinepass",
+   "models": [
+    {
+     "id": "cline-pass/glm-5.2",
+     "name": "GLM-5.2 (ClinePass)",
+     "kind": "llm"
+    },
+    {
+     "id": "cline-pass/kimi-k2.7-code",
+     "name": "Kimi K2.7 Code (ClinePass)",
+     "kind": "llm"
+    },
+    {
+     "id": "cline-pass/kimi-k2.6",
+     "name": "Kimi K2.6 (ClinePass)",
+     "kind": "llm"
+    },
+    {
+     "id": "cline-pass/deepseek-v4-pro",
+     "name": "DeepSeek V4 Pro (ClinePass)",
+     "kind": "llm"
+    },
+    {
+     "id": "cline-pass/deepseek-v4-flash",
+     "name": "DeepSeek V4 Flash (ClinePass)",
+     "kind": "llm"
+    },
+    {
+     "id": "cline-pass/mimo-v2.5",
+     "name": "MiMo-V2.5 (ClinePass)",
+     "kind": "llm"
+    },
+    {
+     "id": "cline-pass/mimo-v2.5-pro",
+     "name": "MiMo-V2.5-Pro (ClinePass)",
+     "kind": "llm"
+    },
+    {
+     "id": "cline-pass/minimax-m3",
+     "name": "MiniMax M3 (ClinePass)",
+     "kind": "llm"
+    },
+    {
+     "id": "cline-pass/qwen3.7-max",
+     "name": "Qwen3.7 Max (ClinePass)",
+     "kind": "llm"
+    },
+    {
+     "id": "cline-pass/qwen3.7-plus",
+     "name": "Qwen3.7 Plus (ClinePass)",
+     "kind": "llm"
+    }
+   ]
+  },
+  {
+   "alias": "featherless",
+   "models": [
+    {
+     "id": "deepseek-ai/DeepSeek-V4-Pro",
+     "name": "DeepSeek V4 Pro",
+     "kind": "llm"
+    },
+    {
+     "id": "deepseek-ai/DeepSeek-V4-Flash",
+     "name": "DeepSeek V4 Flash",
+     "kind": "llm"
+    },
+    {
+     "id": "zai-org/GLM-5.2",
+     "name": "GLM 5.2",
+     "kind": "llm"
+    },
+    {
+     "id": "zai-org/GLM-5.1",
+     "name": "GLM 5.1",
+     "kind": "llm"
+    },
+    {
+     "id": "moonshotai/Kimi-K2.7-Code",
+     "name": "Kimi K2.7 Code",
+     "kind": "llm"
+    },
+    {
+     "id": "moonshotai/Kimi-K2.6",
+     "name": "Kimi K2.6",
+     "kind": "llm"
+    },
+    {
+     "id": "moonshotai/Kimi-K2.5",
+     "name": "Kimi K2.5",
+     "kind": "llm"
+    }
+   ]
+  },
+  {
+   "alias": "perplexity-agent",
+   "models": [
+    {
+     "id": "perplexity/sonar",
+     "name": "Perplexity Sonar",
+     "kind": "llm"
+    },
+    {
+     "id": "openai/gpt-5.5",
+     "name": "GPT-5.5",
+     "kind": "llm"
+    },
+    {
+     "id": "openai/gpt-5.4",
+     "name": "GPT-5.4",
+     "kind": "llm"
+    },
+    {
+     "id": "openai/gpt-5.4-mini",
+     "name": "GPT-5.4 Mini",
+     "kind": "llm"
+    },
+    {
+     "id": "anthropic/claude-sonnet-4-6",
+     "name": "Claude Sonnet 4.6",
+     "kind": "llm"
+    },
+    {
+     "id": "anthropic/claude-opus-4-8",
+     "name": "Claude Opus 4.8",
+     "kind": "llm"
+    },
+    {
+     "id": "google/gemini-3.1-pro-preview",
+     "name": "Gemini 3.1 Pro",
+     "kind": "llm"
+    },
+    {
+     "id": "xai/grok-4.20-reasoning",
+     "name": "Grok 4.20 Reasoning",
+     "kind": "llm"
+    },
+    {
+     "id": "perplexity/glm-5.2",
+     "name": "GLM 5.2",
+     "kind": "llm"
+    },
+    {
+     "id": "perplexity/kimi-k2.7-code",
+     "name": "Kimi K2.7 Code",
+     "kind": "llm"
+    },
+    {
+     "id": "nvidia/nemotron-3-super-120b-a12b",
+     "name": "Nemotron 3 Super 120B",
+     "kind": "llm"
+    }
+   ]
+  },
+  {
+   "alias": "tokenrouter",
+   "models": [
+    {
+     "id": "MiniMax-Hailuo-2.3",
+     "name": "Minimax Hailuo 2.3",
+     "kind": "video"
+    },
+    {
+     "id": "MiniMax-M3",
+     "name": "Minimax M3",
+     "kind": "llm"
+    },
+    {
+     "id": "anthropic/claude-fable-5",
+     "name": "Claude Fable 5",
+     "kind": "llm"
+    },
+    {
+     "id": "anthropic/claude-haiku-4.5",
+     "name": "Claude Haiku 4.5",
+     "kind": "llm"
+    },
+    {
+     "id": "anthropic/claude-opus-4.5",
+     "name": "Claude Opus 4.5",
+     "kind": "llm"
+    },
+    {
+     "id": "anthropic/claude-opus-4.6",
+     "name": "Claude Opus 4.6",
+     "kind": "llm"
+    },
+    {
+     "id": "anthropic/claude-opus-4.7",
+     "name": "Claude Opus 4.7",
+     "kind": "llm"
+    },
+    {
+     "id": "anthropic/claude-opus-4.7-fast",
+     "name": "Claude Opus 4.7 Fast",
+     "kind": "llm"
+    },
+    {
+     "id": "anthropic/claude-opus-4.8",
+     "name": "Claude Opus 4.8",
+     "kind": "llm"
+    },
+    {
+     "id": "anthropic/claude-opus-4.8-fast",
+     "name": "Claude Opus 4.8 Fast",
+     "kind": "llm"
+    },
+    {
+     "id": "anthropic/claude-opus-5",
+     "name": "Claude Opus 5",
+     "kind": "llm"
+    },
+    {
+     "id": "anthropic/claude-opus-5-fast",
+     "name": "Claude Opus 5 Fast",
+     "kind": "llm"
+    },
+    {
+     "id": "anthropic/claude-sonnet-4",
+     "name": "Claude Sonnet 4",
+     "kind": "llm"
+    },
+    {
+     "id": "anthropic/claude-sonnet-4.5",
+     "name": "Claude Sonnet 4.5",
+     "kind": "llm"
+    },
+    {
+     "id": "anthropic/claude-sonnet-4.6",
+     "name": "Claude Sonnet 4.6",
+     "kind": "llm"
+    },
+    {
+     "id": "anthropic/claude-sonnet-5",
+     "name": "Claude Sonnet 5",
+     "kind": "llm"
+    },
+    {
+     "id": "bytedance-seed/seedream-4.5",
+     "name": "Seedream 4.5",
+     "kind": "image"
+    },
+    {
+     "id": "bytedance-seed/seedream-5.0-lite",
+     "name": "Seedream 5.0 Lite",
+     "kind": "image"
+    },
+    {
+     "id": "bytedance-seed/seedream-5.0-pro",
+     "name": "Seedream 5.0 Pro",
+     "kind": "image"
+    },
+    {
+     "id": "claude-haiku-4-5",
+     "name": "Claude Haiku 4 5",
+     "kind": "llm"
+    },
+    {
+     "id": "claude-opus-4-8-m-aws",
+     "name": "Claude Opus 4 8 M Aws",
+     "kind": "llm"
+    },
+    {
+     "id": "deepseek/deepseek-v3.2",
+     "name": "Deepseek V3.2",
+     "kind": "llm"
+    },
+    {
+     "id": "deepseek/deepseek-v4-flash",
+     "name": "Deepseek V4 Flash",
+     "kind": "llm"
+    },
+    {
+     "id": "deepseek/deepseek-v4-flash-0731",
+     "name": "Deepseek V4 Flash 0731",
+     "kind": "llm"
+    },
+    {
+     "id": "deepseek/deepseek-v4-pro",
+     "name": "Deepseek V4 Pro",
+     "kind": "llm"
+    },
+    {
+     "id": "ex/gpt-5.4",
+     "name": "Gpt 5.4",
+     "kind": "llm"
+    },
+    {
+     "id": "google/gemini-2.5-flash-image",
+     "name": "Gemini 2.5 Flash Image",
+     "kind": "llm"
+    },
+    {
+     "id": "google/gemini-3-flash-preview",
+     "name": "Gemini 3 Flash Preview",
+     "kind": "llm"
+    },
+    {
+     "id": "google/gemini-3-pro-image-preview",
+     "name": "Gemini 3 Pro Image Preview",
+     "kind": "llm"
+    },
+    {
+     "id": "google/gemini-3.1-flash-image-preview",
+     "name": "Gemini 3.1 Flash Image Preview",
+     "kind": "llm"
+    },
+    {
+     "id": "google/gemini-3.1-flash-lite-image",
+     "name": "Gemini 3.1 Flash Lite Image",
+     "kind": "llm"
+    },
+    {
+     "id": "google/gemini-3.1-pro-preview",
+     "name": "Gemini 3.1 Pro Preview",
+     "kind": "llm"
+    },
+    {
+     "id": "google/gemini-3.5-flash",
+     "name": "Gemini 3.5 Flash",
+     "kind": "llm"
+    },
+    {
+     "id": "google/gemini-3.5-flash-lite",
+     "name": "Gemini 3.5 Flash Lite",
+     "kind": "llm"
+    },
+    {
+     "id": "google/gemini-3.6-flash",
+     "name": "Gemini 3.6 Flash",
+     "kind": "llm"
+    },
+    {
+     "id": "google/gemini-embedding-2",
+     "name": "Gemini Embedding 2",
+     "kind": "llm"
+    },
+    {
+     "id": "google/gemma-4-26b-a4b-it",
+     "name": "Gemma 4 26B A4B It",
+     "kind": "llm"
+    },
+    {
+     "id": "happyhorse-1.0-t2v",
+     "name": "Happyhorse 1.0 T2V",
+     "kind": "video"
+    },
+    {
+     "id": "kling-3.0-turbo",
+     "name": "Kling 3.0 Turbo",
+     "kind": "video"
+    },
+    {
+     "id": "kling-v2-6",
+     "name": "Kling V2 6",
+     "kind": "video"
+    },
+    {
+     "id": "kling-v3",
+     "name": "Kling V3",
+     "kind": "video"
+    },
+    {
+     "id": "kling-v3-omni",
+     "name": "Kling V3 Omni",
+     "kind": "video"
+    },
+    {
+     "id": "microsoft/mai-image-2.5",
+     "name": "Mai Image 2.5",
+     "kind": "llm"
+    },
+    {
+     "id": "minimax/minimax-m2-her",
+     "name": "Minimax M2 Her",
+     "kind": "llm"
+    },
+    {
+     "id": "minimax/minimax-m2.1",
+     "name": "Minimax M2.1",
+     "kind": "llm"
+    },
+    {
+     "id": "minimax/minimax-m2.1-highspeed",
+     "name": "Minimax M2.1 Highspeed",
+     "kind": "llm"
+    },
+    {
+     "id": "minimax/minimax-m2.5",
+     "name": "Minimax M2.5",
+     "kind": "llm"
+    },
+    {
+     "id": "minimax/minimax-m2.7",
+     "name": "Minimax M2.7",
+     "kind": "llm"
+    },
+    {
+     "id": "minimax/minimax-m2.7-highspeed",
+     "name": "Minimax M2.7 Highspeed",
+     "kind": "llm"
+    },
+    {
+     "id": "miromind/mirothinker-1-7-deepresearch",
+     "name": "Mirothinker 1 7 Deepresearch",
+     "kind": "llm"
+    },
+    {
+     "id": "miromind/mirothinker-1-7-deepresearch-mini",
+     "name": "Mirothinker 1 7 Deepresearch Mini",
+     "kind": "llm"
+    },
+    {
+     "id": "mistralai/devstral-2512",
+     "name": "Devstral 2512",
+     "kind": "llm"
+    },
+    {
+     "id": "mistralai/mistral-medium-3-5",
+     "name": "Mistral Medium 3 5",
+     "kind": "llm"
+    },
+    {
+     "id": "mistralai/mistral-small-2603",
+     "name": "Mistral Small 2603",
+     "kind": "llm"
+    },
+    {
+     "id": "mistralai/voxtral-small-24b-2507",
+     "name": "Voxtral Small 24B 2507",
+     "kind": "llm"
+    },
+    {
+     "id": "moonshotai/kimi-k2.5",
+     "name": "Kimi K2.5",
+     "kind": "llm"
+    },
+    {
+     "id": "moonshotai/kimi-k2.6",
+     "name": "Kimi K2.6",
+     "kind": "llm"
+    },
+    {
+     "id": "moonshotai/kimi-k2.7-code",
+     "name": "Kimi K2.7 Code",
+     "kind": "llm"
+    },
+    {
+     "id": "moonshotai/kimi-k3",
+     "name": "Kimi K3",
+     "kind": "llm"
+    },
+    {
+     "id": "moonshotai/kimi-k3-free",
+     "name": "Kimi K3 Free",
+     "kind": "llm"
+    },
+    {
+     "id": "nvidia/nemotron-3-nano-omni-30b-a3b-reasoning:free",
+     "name": "Nemotron 3 Nano Omni 30B A3B Reasoning:Free",
+     "kind": "llm"
+    },
+    {
+     "id": "nvidia/nemotron-3-super-120b-a12b",
+     "name": "Nemotron 3 Super 120B A12B",
+     "kind": "llm"
+    },
+    {
+     "id": "openai/gpt-4o-mini",
+     "name": "Gpt 4O Mini",
+     "kind": "llm"
+    },
+    {
+     "id": "openai/gpt-5",
+     "name": "Gpt 5",
+     "kind": "llm"
+    },
+    {
+     "id": "openai/gpt-5-image",
+     "name": "Gpt 5 Image",
+     "kind": "llm"
+    },
+    {
+     "id": "openai/gpt-5-image-mini",
+     "name": "Gpt 5 Image Mini",
+     "kind": "llm"
+    },
+    {
+     "id": "openai/gpt-5-mini",
+     "name": "Gpt 5 Mini",
+     "kind": "llm"
+    },
+    {
+     "id": "openai/gpt-5.2",
+     "name": "Gpt 5.2",
+     "kind": "llm"
+    },
+    {
+     "id": "openai/gpt-5.4",
+     "name": "Gpt 5.4",
+     "kind": "llm"
+    },
+    {
+     "id": "openai/gpt-5.4-image-2",
+     "name": "Gpt 5.4 Image 2",
+     "kind": "image"
+    },
+    {
+     "id": "openai/gpt-5.4-mini",
+     "name": "Gpt 5.4 Mini",
+     "kind": "llm"
+    },
+    {
+     "id": "openai/gpt-5.4-nano",
+     "name": "Gpt 5.4 Nano",
+     "kind": "llm"
+    },
+    {
+     "id": "openai/gpt-5.4-pro",
+     "name": "Gpt 5.4 Pro",
+     "kind": "llm"
+    },
+    {
+     "id": "openai/gpt-5.5",
+     "name": "Gpt 5.5",
+     "kind": "llm"
+    },
+    {
+     "id": "openai/gpt-5.5-pro",
+     "name": "Gpt 5.5 Pro",
+     "kind": "llm"
+    },
+    {
+     "id": "openai/gpt-5.6-luna",
+     "name": "Gpt 5.6 Luna",
+     "kind": "llm"
+    },
+    {
+     "id": "openai/gpt-5.6-sol",
+     "name": "Gpt 5.6 Sol",
+     "kind": "llm"
+    },
+    {
+     "id": "openai/gpt-5.6-terra",
+     "name": "Gpt 5.6 Terra",
+     "kind": "llm"
+    },
+    {
+     "id": "openai/gpt-audio",
+     "name": "Gpt Audio",
+     "kind": "audio"
+    },
+    {
+     "id": "openai/gpt-audio-mini",
+     "name": "Gpt Audio Mini",
+     "kind": "audio"
+    },
+    {
+     "id": "openai/gpt-oss-120b",
+     "name": "Gpt Oss 120B",
+     "kind": "llm"
+    },
+    {
+     "id": "qwen/qwen3-coder-next",
+     "name": "Qwen3 Coder Next",
+     "kind": "llm"
+    },
+    {
+     "id": "qwen/qwen3.5-122b-a10b",
+     "name": "Qwen3.5 122B A10B",
+     "kind": "llm"
+    },
+    {
+     "id": "qwen/qwen3.5-35b-a3b",
+     "name": "Qwen3.5 35B A3B",
+     "kind": "llm"
+    },
+    {
+     "id": "qwen/qwen3.5-397b-a17b",
+     "name": "Qwen3.5 397B A17B",
+     "kind": "llm"
+    },
+    {
+     "id": "qwen/qwen3.5-9b",
+     "name": "Qwen3.5 9B",
+     "kind": "llm"
+    },
+    {
+     "id": "qwen/qwen3.5-flash",
+     "name": "Qwen3.5 Flash",
+     "kind": "llm"
+    },
+    {
+     "id": "qwen/qwen3.5-plus-02-15",
+     "name": "Qwen3.5 Plus 02 15",
+     "kind": "llm"
+    },
+    {
+     "id": "qwen/qwen3.6-plus",
+     "name": "Qwen3.6 Plus",
+     "kind": "llm"
+    },
+    {
+     "id": "qwen/qwen3.7-max",
+     "name": "Qwen3.7 Max",
+     "kind": "llm"
+    },
+    {
+     "id": "qwen/qwen3.7-plus",
+     "name": "Qwen3.7 Plus",
+     "kind": "llm"
+    },
+    {
+     "id": "qwen/qwen3.8-max",
+     "name": "Qwen3.8 Max",
+     "kind": "llm"
+    },
+    {
+     "id": "qwen3.5-omni-plus",
+     "name": "Qwen3.5 Omni Plus",
+     "kind": "llm"
+    },
+    {
+     "id": "qwen3.6-flash",
+     "name": "Qwen3.6 Flash",
+     "kind": "llm"
+    },
+    {
+     "id": "sakana/fugu-ultra",
+     "name": "Fugu Ultra",
+     "kind": "llm"
+    },
+    {
+     "id": "seed-2-0-code-preview-260328",
+     "name": "Seed 2 0 Code Preview 260328",
+     "kind": "llm"
+    },
+    {
+     "id": "seed-2-0-lite-260428",
+     "name": "Seed 2 0 Lite 260428",
+     "kind": "llm"
+    },
+    {
+     "id": "seed-2-0-mini-260428",
+     "name": "Seed 2 0 Mini 260428",
+     "kind": "llm"
+    },
+    {
+     "id": "seed-2-0-pro-260328",
+     "name": "Seed 2 0 Pro 260328",
+     "kind": "llm"
+    },
+    {
+     "id": "stepfun/step-3.5-flash",
+     "name": "Step 3.5 Flash",
+     "kind": "llm"
+    },
+    {
+     "id": "stepfun/step-3.7-flash",
+     "name": "Step 3.7 Flash",
+     "kind": "llm"
+    },
+    {
+     "id": "tencent/hy3-preview",
+     "name": "Hy3 Preview",
+     "kind": "llm"
+    },
+    {
+     "id": "x-ai/grok-4.1-fast",
+     "name": "Grok 4.1 Fast",
+     "kind": "llm"
+    },
+    {
+     "id": "x-ai/grok-4.20-beta",
+     "name": "Grok 4.20 Beta",
+     "kind": "llm"
+    },
+    {
+     "id": "x-ai/grok-4.3",
+     "name": "Grok 4.3",
+     "kind": "llm"
+    },
+    {
+     "id": "x-ai/grok-4.5",
+     "name": "Grok 4.5",
+     "kind": "llm"
+    },
+    {
+     "id": "x-ai/grok-build-0.1",
+     "name": "Grok Build 0.1",
+     "kind": "llm"
+    },
+    {
+     "id": "xiaomi/mimo-v2-flash",
+     "name": "Mimo V2 Flash",
+     "kind": "llm"
+    },
+    {
+     "id": "xiaomi/mimo-v2-omni",
+     "name": "Mimo V2 Omni",
+     "kind": "llm"
+    },
+    {
+     "id": "xiaomi/mimo-v2-pro",
+     "name": "Mimo V2 Pro",
+     "kind": "llm"
+    },
+    {
+     "id": "xiaomi/mimo-v2.5",
+     "name": "Mimo V2.5",
+     "kind": "llm"
+    },
+    {
+     "id": "xiaomi/mimo-v2.5-pro",
+     "name": "Mimo V2.5 Pro",
+     "kind": "llm"
+    },
+    {
+     "id": "z-ai/glm-4.5-air",
+     "name": "Glm 4.5 Air",
+     "kind": "llm"
+    },
+    {
+     "id": "z-ai/glm-4.6",
+     "name": "Glm 4.6",
+     "kind": "llm"
+    },
+    {
+     "id": "z-ai/glm-4.6v",
+     "name": "Glm 4.6V",
+     "kind": "llm"
+    },
+    {
+     "id": "z-ai/glm-4.7",
+     "name": "Glm 4.7",
+     "kind": "llm"
+    },
+    {
+     "id": "z-ai/glm-5",
+     "name": "Glm 5",
+     "kind": "llm"
+    },
+    {
+     "id": "z-ai/glm-5-turbo",
+     "name": "Glm 5 Turbo",
+     "kind": "llm"
+    },
+    {
+     "id": "z-ai/glm-5.1",
+     "name": "Glm 5.1",
+     "kind": "llm"
+    },
+    {
+     "id": "z-ai/glm-5.2",
+     "name": "Glm 5.2",
+     "kind": "llm"
+    }
+   ]
+  },
+  {
+   "alias": "selfhosted-embedding",
+   "models": [
+    {
+     "id": "embedding",
+     "name": "Self-hosted embedding model",
+     "kind": "embedding"
+    }
+   ]
+  },
+  {
+   "alias": "selfhosted-stt",
+   "models": [
+    {
+     "id": "whisper-1",
+     "name": "Whisper (self-hosted)",
+     "kind": "stt"
+    }
+   ]
+  },
+  {
+   "alias": "selfhosted-tts",
+   "models": [
+    {
+     "id": "kokoro",
+     "name": "Kokoro (self-hosted)",
+     "kind": "tts"
+    }
+   ]
   }
  ],
  "providers": [
@@ -6108,6 +6906,92 @@
     "llm"
    ],
    "ttsModels": [],
+   "embeddingModels": [],
+   "hasSearch": false,
+   "hasFetch": false
+  },
+  {
+   "id": "clinepass",
+   "alias": "clinepass",
+   "serviceKinds": [
+    "llm"
+   ],
+   "ttsModels": [],
+   "embeddingModels": [],
+   "hasSearch": false,
+   "hasFetch": false
+  },
+  {
+   "id": "featherless",
+   "alias": "featherless",
+   "serviceKinds": [
+    "llm"
+   ],
+   "ttsModels": [],
+   "embeddingModels": [],
+   "hasSearch": false,
+   "hasFetch": false
+  },
+  {
+   "id": "perplexity-agent",
+   "alias": "perplexity-agent",
+   "serviceKinds": [
+    "llm",
+    "webSearch"
+   ],
+   "ttsModels": [],
+   "embeddingModels": [],
+   "hasSearch": true,
+   "hasFetch": false
+  },
+  {
+   "id": "tokenrouter",
+   "alias": "tokenrouter",
+   "serviceKinds": [
+    "llm",
+    "embedding",
+    "image"
+   ],
+   "ttsModels": [],
+   "embeddingModels": [
+    "google/gemini-embedding-2"
+   ],
+   "hasSearch": false,
+   "hasFetch": false
+  },
+  {
+   "id": "selfhosted-embedding",
+   "alias": "selfhosted-embedding",
+   "serviceKinds": [
+    "embedding"
+   ],
+   "ttsModels": [],
+   "embeddingModels": [
+    "embedding"
+   ],
+   "hasSearch": false,
+   "hasFetch": false
+  },
+  {
+   "id": "selfhosted-stt",
+   "alias": "selfhosted-stt",
+   "serviceKinds": [
+    "stt"
+   ],
+   "ttsModels": [],
+   "embeddingModels": [],
+   "hasSearch": false,
+   "hasFetch": false
+  },
+  {
+   "id": "selfhosted-tts",
+   "alias": "selfhosted-tts",
+   "serviceKinds": [
+    "tts"
+   ],
+   "ttsModels": [
+    "kokoro"
+   ],
    "embeddingModels": [],
    "hasSearch": false,
    "hasFetch": false


### PR DESCRIPTION
Per spec P0-A7: adds missing providers[] entries (clinepass/featherless/perplexity-agent/tokenrouter/selfhosted-*), populates providerModels with contextLength/kind, adds providerIdToAlias mappings.