### PR TITLE
fix(translator): reasoning continuity in Responses↔chat (bead .48)

### DIFF
--- a/src/core/translator/request/openai_responses.rs
+++ b/src/core/translator/request/openai_responses.rs
@@ -27,6 +27,104 @@ fn clamp_call_id(id: &str) -> String {
     }
 }
 
+/// Extract reasoning text from a Responses reasoning item, mirroring the
+/// upstream JS `extractReasoningText` (openai-responses.js:42-52): join
+/// `item.summary[].text` with "\n"; fall back to `item.content[].text`
+/// (same join); return "" when neither exists.
+fn extract_reasoning_text(item: &Value) -> String {
+    if let Some(summaries) = item.get("summary").and_then(Value::as_array) {
+        let joined = summaries
+            .iter()
+            .filter_map(|s| s.get("text").and_then(Value::as_str))
+            .collect::<Vec<_>>()
+            .join("\n");
+        if !joined.is_empty() {
+            return joined;
+        }
+    }
+    if let Some(contents) = item.get("content").and_then(Value::as_array) {
+        return contents
+            .iter()
+            .filter_map(|c| c.get("text").and_then(Value::as_str))
+            .collect::<Vec<_>>()
+            .join("\n");
+    }
+    String::new()
+}
+
+/// Build a Responses `{type:"reasoning", ...}` input item for a chat-format
+/// assistant message, mirroring the upstream JS `buildReasoningInputItem`
+/// (openai-responses.js:266-296). Returns None when neither reasoning text
+/// nor encrypted content is present. summaryText priority:
+/// `reasoning_content` (trimmed) > `reasoning` > `reasoning_details` joined
+/// with "\n". encrypted = `encrypted_content` || `reasoning_encrypted_content`
+/// || `reasoning.encrypted_content`.
+fn build_reasoning_input_item(msg: &Value) -> Option<Value> {
+    let summary_text = msg
+        .get("reasoning_content")
+        .and_then(Value::as_str)
+        .map(str::trim)
+        .filter(|s| !s.is_empty())
+        .map(str::to_string)
+        .or_else(|| {
+            msg.get("reasoning")
+                .and_then(Value::as_str)
+                .filter(|s| !s.is_empty())
+                .map(str::to_string)
+        })
+        .or_else(|| {
+            msg.get("reasoning_details")
+                .and_then(Value::as_array)
+                .map(|details| {
+                    details
+                        .iter()
+                        .filter_map(|d| {
+                            d.get("text")
+                                .and_then(Value::as_str)
+                                .or_else(|| d.get("content").and_then(Value::as_str))
+                                .filter(|s| !s.is_empty())
+                        })
+                        .collect::<Vec<_>>()
+                        .join("\n")
+                })
+                .filter(|s| !s.is_empty())
+        });
+
+    let encrypted = msg
+        .get("encrypted_content")
+        .and_then(Value::as_str)
+        .filter(|s| !s.is_empty())
+        .map(str::to_string)
+        .or_else(|| {
+            msg.get("reasoning_encrypted_content")
+                .and_then(Value::as_str)
+                .filter(|s| !s.is_empty())
+                .map(str::to_string)
+        })
+        .or_else(|| {
+            msg.pointer("/reasoning/encrypted_content")
+                .and_then(Value::as_str)
+                .filter(|s| !s.is_empty())
+                .map(str::to_string)
+        });
+
+    if summary_text.is_none() && encrypted.is_none() {
+        return None;
+    }
+
+    let mut item = serde_json::json!({
+        "type": "reasoning",
+        "summary": [{
+            "type": "summary_text",
+            "text": summary_text.unwrap_or_default()
+        }]
+    });
+    if let Some(e) = encrypted {
+        item["encrypted_content"] = Value::String(e);
+    }
+    Some(item)
+}
+
 pub fn openai_responses_to_chat_request(
     model: &str,
     body: &mut Value,
@@ -59,6 +157,10 @@ pub fn openai_responses_to_chat_request(
     };
 
     let mut current_assistant_msg: Option<Value> = None;
+    // Reasoning continuity: buffer reasoning text/encrypted_content across
+    // input items and attach to the next assistant message (JS 33-34, 149-160).
+    let mut pending_reasoning = String::new();
+    let mut pending_reasoning_encrypted = String::new();
 
     let default_msg_type = Value::String("message".to_string());
     for item in &input_items {
@@ -99,12 +201,23 @@ pub fn openai_responses_to_chat_request(
                 };
 
                 if let Some(role) = item.get("role").and_then(|v| v.as_str()) {
-                    result["messages"]
-                        .as_array_mut()
-                        .unwrap()
-                        .push(serde_json::json!({
-                            "role": role, "content": content
-                        }));
+                    let mut msg = serde_json::json!({
+                        "role": role, "content": content
+                    });
+                    if role == "assistant" {
+                        if !pending_reasoning.is_empty() {
+                            msg["reasoning_content"] = Value::String(pending_reasoning.clone());
+                        }
+                        if !pending_reasoning_encrypted.is_empty() {
+                            msg["encrypted_content"] =
+                                Value::String(pending_reasoning_encrypted.clone());
+                        }
+                    } else {
+                        // Non-assistant messages clear the pending buffers (JS 95-98).
+                        pending_reasoning.clear();
+                        pending_reasoning_encrypted.clear();
+                    }
+                    result["messages"].as_array_mut().unwrap().push(msg);
                 }
             }
             Some("function_call") => {
@@ -113,11 +226,19 @@ pub fn openai_responses_to_chat_request(
                     continue;
                 }
                 if current_assistant_msg.is_none() {
-                    current_assistant_msg = Some(serde_json::json!({
+                    let mut msg = serde_json::json!({
                         "role": "assistant",
                         "content": null,
                         "tool_calls": []
-                    }));
+                    });
+                    if !pending_reasoning.is_empty() {
+                        msg["reasoning_content"] = Value::String(pending_reasoning.clone());
+                    }
+                    if !pending_reasoning_encrypted.is_empty() {
+                        msg["encrypted_content"] =
+                            Value::String(pending_reasoning_encrypted.clone());
+                    }
+                    current_assistant_msg = Some(msg);
                 }
                 if let Some(ref mut msg) = current_assistant_msg {
                     msg["tool_calls"].as_array_mut().unwrap().push(serde_json::json!({
@@ -134,6 +255,9 @@ pub fn openai_responses_to_chat_request(
                 if let Some(msg) = current_assistant_msg.take() {
                     result["messages"].as_array_mut().unwrap().push(msg);
                 }
+                // Non-assistant items clear the pending reasoning buffers (JS 95-98).
+                pending_reasoning.clear();
+                pending_reasoning_encrypted.clear();
                 let output = if let Some(s) = item.get("output").and_then(|v| v.as_str()) {
                     s.to_string()
                 } else {
@@ -149,7 +273,23 @@ pub fn openai_responses_to_chat_request(
                         "content": output
                     }));
             }
-            Some("reasoning") => {}
+            Some("reasoning") => {
+                let txt = extract_reasoning_text(item);
+                if !txt.is_empty() {
+                    if pending_reasoning.is_empty() {
+                        pending_reasoning = txt;
+                    } else {
+                        pending_reasoning.push('\n');
+                        pending_reasoning.push_str(&txt);
+                    }
+                }
+                if let Some(e) = item.get("encrypted_content").and_then(Value::as_str) {
+                    if !e.is_empty() {
+                        pending_reasoning_encrypted = e.to_string();
+                    }
+                }
+                continue;
+            }
             _ => {}
         }
     }
@@ -254,6 +394,13 @@ pub fn chat_to_openai_responses_request(
         }
 
         if role == "user" || role == "assistant" {
+            // Build the reasoning input item (if any) for assistant messages
+            // (JS 332-335); it is pushed immediately before the message item.
+            let reasoning_item = if role == "assistant" {
+                build_reasoning_input_item(msg)
+            } else {
+                None
+            };
             let content_type = if role == "user" {
                 "input_text"
             } else {
@@ -285,7 +432,13 @@ pub fn chat_to_openai_responses_request(
                 vec![]
             };
 
-            if !content.is_empty() {
+            // Push the reasoning item (if any) immediately before the message
+            // item; emit the message even when content is empty if a reasoning
+            // item precedes it, so the pairing survives (JS 332-335).
+            if !content.is_empty() || reasoning_item.is_some() {
+                if let Some(ri) = reasoning_item {
+                    result["input"].as_array_mut().unwrap().push(ri);
+                }
                 result["input"]
                     .as_array_mut()
                     .unwrap()
@@ -432,7 +585,10 @@ mod tests {
         });
         openai_responses_to_chat_request("gpt-4", &mut body, false, None);
         // reasoning.effort → reasoning_effort, reasoning removed.
-        assert_eq!(body.get("reasoning_effort").unwrap().as_str().unwrap(), "medium");
+        assert_eq!(
+            body.get("reasoning_effort").unwrap().as_str().unwrap(),
+            "medium"
+        );
         assert!(body.get("reasoning").is_none());
         // client_metadata removed.
         assert!(body.get("client_metadata").is_none());
@@ -448,5 +604,167 @@ mod tests {
         openai_responses_to_chat_request("gpt-4", &mut body, false, None);
         assert_eq!(body.get("max_tokens").unwrap().as_i64().unwrap(), 4096);
         assert!(body.get("max_output_tokens").is_none());
+    }
+
+    #[test]
+    fn responses_reasoning_item_buffers_onto_next_assistant() {
+        // JS: reasoning item summary text buffers across input items and
+        // attaches to the next assistant message as reasoning_content.
+        let mut body: Value = serde_json::json!({
+            "input": [
+                {"type": "reasoning", "summary": [{"type": "summary_text", "text": "hmm"}]},
+                {"type": "message", "role": "assistant", "content": []}
+            ],
+            "model": "gpt-4"
+        });
+        openai_responses_to_chat_request("gpt-4", &mut body, false, None);
+        let messages = body.get("messages").unwrap().as_array().unwrap();
+        assert_eq!(messages.len(), 1);
+        let msg = &messages[0];
+        assert_eq!(msg["role"], "assistant");
+        assert_eq!(msg["reasoning_content"], "hmm");
+    }
+
+    #[test]
+    fn responses_reasoning_item_buffers_across_items_with_newline_join() {
+        // Multiple reasoning items join with "\n"; summary[] takes priority
+        // over content[] fallback; encrypted_content is stashed.
+        let mut body: Value = serde_json::json!({
+            "input": [
+                {"type": "reasoning", "summary": [{"type": "summary_text", "text": "first"}]},
+                {"type": "reasoning", "content": [{"type": "summary_text", "text": "second"}]},
+                {"type": "reasoning", "summary": [{"type": "summary_text", "text": "third"}], "encrypted_content": "blob"},
+                {"type": "message", "role": "assistant", "content": [{"type": "output_text", "text": "hi"}]}
+            ],
+            "model": "gpt-4"
+        });
+        openai_responses_to_chat_request("gpt-4", &mut body, false, None);
+        let messages = body.get("messages").unwrap().as_array().unwrap();
+        assert_eq!(messages.len(), 1);
+        assert_eq!(messages[0]["reasoning_content"], "first\nsecond\nthird");
+        assert_eq!(messages[0]["encrypted_content"], "blob");
+    }
+
+    #[test]
+    fn responses_non_assistant_message_clears_pending_reasoning() {
+        // A non-assistant message between reasoning items and the assistant
+        // message clears the pending buffers (JS 95-98).
+        let mut body: Value = serde_json::json!({
+            "input": [
+                {"type": "reasoning", "summary": [{"type": "summary_text", "text": "hmm"}]},
+                {"type": "message", "role": "user", "content": [{"type": "input_text", "text": "hi"}]},
+                {"type": "message", "role": "assistant", "content": [{"type": "output_text", "text": "hi"}]}
+            ],
+            "model": "gpt-4"
+        });
+        openai_responses_to_chat_request("gpt-4", &mut body, false, None);
+        let messages = body.get("messages").unwrap().as_array().unwrap();
+        assert_eq!(messages.len(), 2);
+        assert!(messages[1].get("reasoning_content").is_none());
+        assert!(messages[1].get("encrypted_content").is_none());
+    }
+
+    #[test]
+    fn responses_reasoning_attaches_to_function_call_assistant() {
+        // Reasoning buffers onto the assistant message built from a
+        // function_call item (JS attachPendingReasoning at function_call).
+        let mut body: Value = serde_json::json!({
+            "input": [
+                {"type": "reasoning", "summary": [{"type": "summary_text", "text": "hmm"}], "encrypted_content": "blob"},
+                {"type": "function_call", "call_id": "call_1", "name": "f", "arguments": "{}"}
+            ],
+            "model": "gpt-4"
+        });
+        openai_responses_to_chat_request("gpt-4", &mut body, false, None);
+        let messages = body.get("messages").unwrap().as_array().unwrap();
+        assert_eq!(messages.len(), 1);
+        assert_eq!(messages[0]["role"], "assistant");
+        assert_eq!(messages[0]["reasoning_content"], "hmm");
+        assert_eq!(messages[0]["encrypted_content"], "blob");
+        assert_eq!(messages[0]["tool_calls"].as_array().unwrap().len(), 1);
+    }
+
+    #[test]
+    fn chat_assistant_reemits_reasoning_item() {
+        // JS: buildReasoningInputItem pushes a reasoning item immediately
+        // before the assistant message item.
+        let mut body: Value = serde_json::json!({
+            "model": "gpt-4",
+            "messages": [
+                {"role": "assistant", "content": [], "reasoning_content": "hmm", "encrypted_content": "blob"}
+            ]
+        });
+        chat_to_openai_responses_request("gpt-4", &mut body, false, None);
+        let input = body.get("input").unwrap().as_array().unwrap();
+        assert_eq!(input.len(), 2);
+        assert_eq!(input[0]["type"], "reasoning");
+        assert_eq!(input[0]["summary"][0]["type"], "summary_text");
+        assert_eq!(input[0]["summary"][0]["text"], "hmm");
+        assert_eq!(input[0]["encrypted_content"], "blob");
+        assert_eq!(input[1]["type"], "message");
+        assert_eq!(input[1]["role"], "assistant");
+    }
+
+    #[test]
+    fn chat_reasoning_priorities_and_fallbacks() {
+        // summaryText priority: reasoning_content (trim) > reasoning >
+        // reasoning_details joined "\n"; encrypted: encrypted_content >
+        // reasoning_encrypted_content > reasoning.encrypted_content.
+        let mut body: Value = serde_json::json!({
+            "model": "gpt-4",
+            "messages": [
+                {
+                    "role": "assistant",
+                    "content": [{"type": "text", "text": "hi"}],
+                    "reasoning_content": "  top  ",
+                    "reasoning": "plain",
+                    "reasoning_details": [{"text": "a"}, {"content": "b"}],
+                    "encrypted_content": "e1",
+                    "reasoning_encrypted_content": "e2",
+                    "reasoning": {"encrypted_content": "e3"}
+                }
+            ]
+        });
+        chat_to_openai_responses_request("gpt-4", &mut body, false, None);
+        let input = body.get("input").unwrap().as_array().unwrap();
+        assert_eq!(input[0]["type"], "reasoning");
+        assert_eq!(
+            input[0]["summary"][0]["text"], "top",
+            "reasoning_content wins and is trimmed"
+        );
+        assert_eq!(
+            input[0]["encrypted_content"], "e1",
+            "encrypted_content wins"
+        );
+
+        // Fallback: only reasoning_details + reasoning.encrypted_content.
+        let mut body: Value = serde_json::json!({
+            "model": "gpt-4",
+            "messages": [
+                {
+                    "role": "assistant",
+                    "content": [{"type": "text", "text": "hi"}],
+                    "reasoning_details": [{"text": "a"}, {"content": "b"}],
+                    "reasoning": {"encrypted_content": "e3"}
+                }
+            ]
+        });
+        chat_to_openai_responses_request("gpt-4", &mut body, false, None);
+        let input = body.get("input").unwrap().as_array().unwrap();
+        assert_eq!(input[0]["type"], "reasoning");
+        assert_eq!(input[0]["summary"][0]["text"], "a\nb");
+        assert_eq!(input[0]["encrypted_content"], "e3");
+
+        // No reasoning → no reasoning item before the assistant message.
+        let mut body: Value = serde_json::json!({
+            "model": "gpt-4",
+            "messages": [
+                {"role": "assistant", "content": [{"type": "text", "text": "hi"}]}
+            ]
+        });
+        chat_to_openai_responses_request("gpt-4", &mut body, false, None);
+        let input = body.get("input").unwrap().as_array().unwrap();
+        assert_eq!(input.len(), 1);
+        assert_eq!(input[0]["type"], "message");
     }
 }


### PR DESCRIPTION
Per spec P0-A8: pending reasoning/encrypted_content buffering across input items, buildReasoningInputItem for chat→responses. Guard tests per JS semantics.