### PR TITLE
feat(kiro): EventStream→OpenAI binary transform, regionalized URLs, endpoint fallback (bead .24)

### DIFF
--- a/src/core/executor/kiro.rs
+++ b/src/core/executor/kiro.rs
@@ -32,6 +32,19 @@ const KIRO_BASE_URLS: &[&str] = &[
 const KIRO_REGION: &str = "us-east-1";
 const KIRO_SERVICE: &str = "codewhisperer";
 
+/// Rewrite the AWS region segment of an amazonaws.com host, e.g.
+/// `q.us-east-1.amazonaws.com` → `q.{region}.amazonaws.com`.
+/// 9router getOrderedBaseUrls parity: `([a-z]+)\.[a-z0-9-]+\.amazonaws\.com`
+/// → `$1.{region}.amazonaws.com`.
+fn regionalize_host(host_url: &str, region: &str) -> String {
+    static RE: std::sync::OnceLock<regex::Regex> = std::sync::OnceLock::new();
+    let re = RE.get_or_init(|| {
+        regex::Regex::new(r"([a-z]+)\.[a-z0-9-]+\.amazonaws\.com").expect("static regex")
+    });
+    re.replace(host_url, format!("$1.{region}.amazonaws.com"))
+        .into_owned()
+}
+
 fn normalize_kiro_model(model: &str) -> String {
     if let Some(stripped) = model.strip_suffix("-thinking-agentic") {
         return stripped.to_string();
@@ -76,6 +89,13 @@ pub enum KiroExecutorError {
     HyperClientInit(std::io::Error),
     Hyper(hyper_util::client::legacy::Error),
     Request(reqwest::Error),
+    /// An endpoint/auth-surface failure (401/403/404) on a URL that still had
+    /// fallback surfaces left — mirrors 9router shouldRetry.
+    EndpointStatus {
+        status: u16,
+        url: String,
+        message: String,
+    },
     EventStreamDecode(String),
     UnsupportedFormat(String),
 }
@@ -155,7 +175,8 @@ impl KiroExecutor {
     }
 
     /// Auth-aware URL order (9router getOrderedBaseUrls).
-    /// api_key / external_idp / idc → amazonaws.com hosts first.
+    /// api_key / external_idp / idc → amazonaws.com hosts first, regionalized
+    /// to the token's region when the account specifies one (default us-east-1).
     pub fn build_url(
         &self,
         _model: &str,
@@ -172,49 +193,64 @@ impl KiroExecutor {
         let is_cw_surface =
             auth_method == "api_key" || auth_method == "external_idp" || auth_method == "idc";
 
-        let mut urls: Vec<String> = KIRO_BASE_URLS.iter().map(|s| (*s).to_string()).collect();
-        if is_cw_surface {
-            let amazon: Vec<String> = urls
-                .iter()
-                .filter(|u| u.contains("amazonaws.com"))
-                .cloned()
-                .collect();
-            let others: Vec<String> = urls
-                .iter()
-                .filter(|u| !u.contains("amazonaws.com"))
-                .cloned()
-                .collect();
-            let amazon_owned = amazon.clone();
-            let others_owned = others.clone();
-            if !amazon.is_empty() {
-                urls = amazon.into_iter().chain(others).collect();
+        let base_urls: Vec<String> = KIRO_BASE_URLS.iter().map(|s| (*s).to_string()).collect();
+        if !is_cw_surface {
+            return base_urls;
+        }
+
+        // 9router getOrderedBaseUrls regionalization: rewrite the AWS region
+        // segment of every amazonaws.com host to the token's region.
+        // `([a-z]+)\.[a-z0-9-]+\.amazonaws\.com` → `$1.{region}.amazonaws.com`.
+        let region = credentials
+            .provider_specific_data
+            .get("region")
+            .and_then(|v| v.as_str())
+            .map(|s| s.trim())
+            .filter(|r| !r.is_empty() && *r != "us-east-1")
+            .unwrap_or("");
+
+        let regionalize = |u: &str| -> String {
+            if region.is_empty() || !u.contains("amazonaws.com") {
+                return u.to_string();
             }
-            // API-key accounts must try the q.* surface FIRST: the legacy
-            // codewhisperer.* GenerateAssistantResponse endpoint authenticates
-            // the key but rejects the same valid payload with
-            // REQUEST_BODY_INVALID (a terminal 400). Ported from 9router
-            // v0.5.45 fix(kiro): route API keys correctly.
-            if auth_method == "api_key" {
-                let q: Vec<String> = amazon_owned
-                    .iter()
-                    .filter(|u| u.contains("://q."))
-                    .cloned()
-                    .collect();
-                let remaining: Vec<String> = amazon_owned
-                    .iter()
-                    .filter(|u| !u.contains("://q."))
-                    .cloned()
-                    .collect();
-                if !q.is_empty() {
-                    urls = q.into_iter().chain(remaining).chain(others_owned).collect();
-                } else {
-                    urls = amazon_owned.into_iter().chain(others_owned).collect();
-                }
-            } else {
-                urls = amazon_owned.into_iter().chain(others_owned).collect();
+            regionalize_host(u, region)
+        };
+
+        let amazon: Vec<String> = base_urls
+            .iter()
+            .filter(|u| u.contains("amazonaws.com"))
+            .map(|u| regionalize(u))
+            .collect();
+        let others: Vec<String> = base_urls
+            .iter()
+            .filter(|u| !u.contains("amazonaws.com"))
+            .cloned()
+            .collect();
+
+        // API-key accounts must try the q.* surface FIRST: the legacy
+        // codewhisperer.* GenerateAssistantResponse endpoint authenticates
+        // the key but rejects the same valid payload with
+        // REQUEST_BODY_INVALID (a terminal 400). Ported from 9router
+        // v0.5.45 fix(kiro): route API keys correctly.
+        if auth_method == "api_key" {
+            let q: Vec<String> = amazon
+                .iter()
+                .filter(|u| u.contains("://q."))
+                .cloned()
+                .collect();
+            let remaining: Vec<String> = amazon
+                .iter()
+                .filter(|u| !u.contains("://q."))
+                .cloned()
+                .collect();
+            if !q.is_empty() {
+                return q.into_iter().chain(remaining).chain(others).collect();
             }
         }
-        urls
+        if amazon.is_empty() {
+            return others;
+        }
+        amazon.into_iter().chain(others).collect()
     }
 
     fn build_bearer_headers(
@@ -295,7 +331,7 @@ impl KiroExecutor {
 
         // Try each URL with failover
         let mut last_error = None;
-        for url in &urls {
+        for (url_index, url) in urls.iter().enumerate() {
             // AWS JSON credentials → SigV4 (IDC / some enterprise paths)
             let is_aws_auth = request
                 .credentials
@@ -347,8 +383,27 @@ impl KiroExecutor {
                 .await
             {
                 Ok(response) => {
-                    // EventStream→SSE conversion runs in kiro_to_openai_streaming
-                    // (ResponseTransform path). URLs/auth now match 9router.
+                    // 9router shouldRetry: endpoint/auth-surface failures
+                    // (401/403/404) fall through to the next URL — the same
+                    // payload can succeed on a different surface. Payload-invalid
+                    // 400 is terminal (sending the same body everywhere cannot
+                    // repair it). EventStream→SSE conversion runs in
+                    // kiro_to_openai_streaming (ResponseTransform path).
+                    let status = response.status().as_u16();
+                    let is_fallback_status = status == 401 || status == 403 || status == 404;
+                    let has_fallback = url_index + 1 < urls.len();
+                    if is_fallback_status && has_fallback {
+                        last_error = Some(KiroExecutorError::EndpointStatus {
+                            status,
+                            url: url.clone(),
+                            message: format!(
+                                "Kiro endpoint {} returned {}; trying next surface",
+                                url,
+                                response.status()
+                            ),
+                        });
+                        continue;
+                    }
                     return Ok(KiroExecutorResponse {
                         response: UpstreamResponse::Reqwest(response),
                         url: url.clone(),
@@ -565,7 +620,10 @@ impl EventStreamDecoder {
     /// Trailing message CRC: 4 bytes.
     const TRAILING_CRC_LEN: usize = 4;
 
-    pub fn decode_chunk(data: &[u8]) -> Result<Vec<SseEvent>, KiroExecutorError> {
+    /// Decode one or more complete AWS EventStream v1 binary frames into
+    /// structured events. Partial trailing frames are ignored (the caller
+    /// buffers across chunks).
+    pub fn decode_chunk(data: &[u8]) -> Result<Vec<KiroEvent>, KiroExecutorError> {
         if data.is_empty() {
             return Ok(Vec::new());
         }
@@ -634,21 +692,32 @@ impl EventStreamDecoder {
                 )));
             }
 
-            // Extract payload and parse SSE lines
-            if payload_end > payload_start {
-                let payload = &data[payload_start..payload_end];
-                if let Ok(text) = std::str::from_utf8(payload) {
-                    for line in text.lines() {
-                        if line.starts_with("data: ") {
-                            let data_content = line.trim_start_matches("data: ");
-                            if !data_content.is_empty() && data_content != "[DONE]" {
-                                let cleaned = strip_thinking_tags(data_content);
-                                events.push(SseEvent { data: cleaned });
-                            }
-                        }
-                    }
+            // Decode headers (the `:event-type`, `:message-type`, `:content-type`
+            // etc.) and the JSON payload. 9router parseEventFrame parity.
+            let headers =
+                decode_eventstream_headers(&data[offset + Self::PRELUDE_LEN..payload_start])?;
+            let payload: Option<Value> = if payload_end > payload_start {
+                let raw = &data[payload_start..payload_end];
+                let text = std::str::from_utf8(raw).ok();
+                match text.map(str::trim) {
+                    Some(t) if !t.is_empty() => Some(serde_json::from_str(t).map_err(|e| {
+                        KiroExecutorError::EventStreamDecode(format!(
+                            "EventStream payload is not valid JSON: {}",
+                            e
+                        ))
+                    })?),
+                    _ => None,
                 }
-            }
+            } else {
+                None
+            };
+
+            events.push(KiroEvent {
+                message_type: headers.get(":message-type").cloned().unwrap_or_default(),
+                event_type: headers.get(":event-type").cloned().unwrap_or_default(),
+                content_type: headers.get(":content-type").cloned().unwrap_or_default(),
+                payload,
+            });
 
             offset += total_length;
         }
@@ -657,9 +726,149 @@ impl EventStreamDecoder {
     }
 }
 
+/// A decoded AWS EventStream v1 event frame.
 #[derive(Debug, Clone)]
-pub struct SseEvent {
-    pub data: String,
+pub struct KiroEvent {
+    pub message_type: String,
+    pub event_type: String,
+    pub content_type: String,
+    pub payload: Option<Value>,
+}
+
+/// Decode the AWS EventStream v1 headers section (9router parseEventFrame
+/// header loop). Returns a map of header-name → string value. Binary/other
+/// typed headers are stringified; UUID (type 9), blob (6), byte/int (0-4)
+/// are preserved as their text/bool/integer representation where meaningful.
+fn decode_eventstream_headers(
+    data: &[u8],
+) -> Result<std::collections::HashMap<String, String>, KiroExecutorError> {
+    let mut headers = std::collections::HashMap::new();
+    let mut offset = 0usize;
+    let header_end = data.len();
+
+    let require_bytes = |offset: usize, count: usize| -> Result<(), KiroExecutorError> {
+        if offset + count > header_end {
+            return Err(KiroExecutorError::EventStreamDecode(
+                "AWS EventStream header exceeds its declared bounds".to_string(),
+            ));
+        }
+        Ok(())
+    };
+
+    while offset < header_end {
+        require_bytes(offset, 1)?;
+        let name_len = data[offset] as usize;
+        offset += 1;
+        require_bytes(offset, name_len + 1)?;
+        let name = std::str::from_utf8(&data[offset..offset + name_len])
+            .map_err(|e| {
+                KiroExecutorError::EventStreamDecode(format!(
+                    "AWS EventStream header name is not UTF-8: {}",
+                    e
+                ))
+            })?
+            .to_string();
+        offset += name_len;
+        if headers.contains_key(&name) {
+            return Err(KiroExecutorError::EventStreamDecode(format!(
+                "AWS EventStream contains duplicate header: {}",
+                name
+            )));
+        }
+        let ty = data[offset];
+        offset += 1;
+
+        match ty {
+            0 | 1 => {
+                headers.insert(
+                    name,
+                    if ty == 0 {
+                        "false".to_string()
+                    } else {
+                        "true".to_string()
+                    },
+                );
+            }
+            2 => {
+                require_bytes(offset, 1)?;
+                headers.insert(name, data[offset].to_string());
+                offset += 1;
+            }
+            3 => {
+                require_bytes(offset, 2)?;
+                let v = u16::from_be_bytes([data[offset], data[offset + 1]]) as i16;
+                headers.insert(name, v.to_string());
+                offset += 2;
+            }
+            4 => {
+                require_bytes(offset, 4)?;
+                let v = i32::from_be_bytes([
+                    data[offset],
+                    data[offset + 1],
+                    data[offset + 2],
+                    data[offset + 3],
+                ]);
+                headers.insert(name, v.to_string());
+                offset += 4;
+            }
+            5 | 8 => {
+                // Byte array (5) / long (8) — skip, not semantically needed.
+                require_bytes(offset, 8)?;
+                offset += 8;
+            }
+            6 | 7 => {
+                // Blob (6) / string (7).
+                require_bytes(offset, 2)?;
+                let value_len = u16::from_be_bytes([data[offset], data[offset + 1]]) as usize;
+                offset += 2;
+                require_bytes(offset, value_len)?;
+                let raw = &data[offset..offset + value_len];
+                let value = if ty == 7 {
+                    String::from_utf8_lossy(raw).to_string()
+                } else {
+                    format!("{} bytes", raw.len())
+                };
+                headers.insert(name, value);
+                offset += value_len;
+            }
+            9 => {
+                // UUID.
+                require_bytes(offset, 16)?;
+                offset += 16;
+            }
+            other => {
+                return Err(KiroExecutorError::EventStreamDecode(format!(
+                    "AWS EventStream header {} has unknown type {}",
+                    name, other
+                )));
+            }
+        }
+    }
+
+    Ok(headers)
+}
+
+/// Number of complete EventStream bytes consumed from a buffer, stopping at
+/// the first incomplete frame (so the caller can keep the tail for the next
+/// chunk). Mirrors `decode_chunk`'s framing logic without decoding payloads.
+pub fn consumed_eventstream_bytes(data: &[u8]) -> usize {
+    let mut offset = 0usize;
+    while offset + 12 <= data.len() {
+        let total_length = u32::from_be_bytes([
+            data[offset],
+            data[offset + 1],
+            data[offset + 2],
+            data[offset + 3],
+        ]) as usize;
+        if !(16..=MAX_EVENTSTREAM_MESSAGE_LENGTH).contains(&total_length) {
+            return offset;
+        }
+        if offset + total_length > data.len() {
+            return offset;
+        }
+        offset += total_length;
+    }
+    offset
 }
 
 #[cfg(test)]
@@ -682,6 +891,41 @@ mod tests {
     }
 
     #[test]
+    fn test_event_stream_decoder_parses_headers_and_payload() {
+        // Build a minimal AWS EventStream frame:
+        //   prelude: total_length=12+headers+4, headers_length, crc(8 bytes)
+        //   headers: nameLen ":event-type" ty=7 len valueLen "assistantResponseEvent"
+        //   payload: JSON {"content":"hi"}
+        let header_bytes = {
+            let name = b":event-type";
+            let value = b"assistantResponseEvent";
+            let mut v = Vec::new();
+            v.push(name.len() as u8);
+            v.extend_from_slice(name);
+            v.push(7u8); // string
+            v.extend_from_slice(&(value.len() as u16).to_be_bytes());
+            v.extend_from_slice(value);
+            v
+        };
+        let payload = br#"{"content":"hi"}"#;
+        let total = 12 + header_bytes.len() + payload.len() + 4;
+        let mut frame = Vec::new();
+        frame.extend_from_slice(&(total as u32).to_be_bytes());
+        frame.extend_from_slice(&(header_bytes.len() as u32).to_be_bytes());
+        let prelude_crc = crc32fast::hash(&frame[..8]);
+        frame.extend_from_slice(&prelude_crc.to_be_bytes());
+        frame.extend_from_slice(&header_bytes);
+        frame.extend_from_slice(payload);
+        let msg_crc = crc32fast::hash(&frame);
+        frame.extend_from_slice(&msg_crc.to_be_bytes());
+
+        let events = EventStreamDecoder::decode_chunk(&frame).unwrap();
+        assert_eq!(events.len(), 1);
+        assert_eq!(events[0].event_type, "assistantResponseEvent");
+        assert_eq!(events[0].payload.as_ref().unwrap()["content"], "hi");
+    }
+
+    #[test]
     fn test_sha256_hex() {
         let hash = sha256_hex(b"hello");
         assert_eq!(hash.len(), 64);
@@ -691,6 +935,69 @@ mod tests {
     fn test_generate_nonce() {
         let nonce = generate_nonce();
         assert_eq!(nonce.len(), 32);
+    }
+
+    #[test]
+    fn test_regionalize_host_eu_west_1() {
+        assert_eq!(
+            regionalize_host(
+                "https://q.us-east-1.amazonaws.com/generateAssistantResponse",
+                "eu-west-1"
+            ),
+            "https://q.eu-west-1.amazonaws.com/generateAssistantResponse"
+        );
+        assert_eq!(
+            regionalize_host(
+                "https://codewhisperer.us-east-1.amazonaws.com/generateAssistantResponse",
+                "eu-west-1"
+            ),
+            "https://codewhisperer.eu-west-1.amazonaws.com/generateAssistantResponse"
+        );
+    }
+
+    #[test]
+    fn test_regionalize_host_noop_for_us_east_1_or_non_aws() {
+        // Default region (us-east-1) leaves the host unchanged.
+        assert_eq!(
+            regionalize_host(
+                "https://q.us-east-1.amazonaws.com/generateAssistantResponse",
+                "us-east-1"
+            ),
+            "https://q.us-east-1.amazonaws.com/generateAssistantResponse"
+        );
+        // Non-amazonaws host is untouched.
+        assert_eq!(
+            regionalize_host(
+                "https://runtime.us-east-1.kiro.dev/generateAssistantResponse",
+                "eu-west-1"
+            ),
+            "https://runtime.us-east-1.kiro.dev/generateAssistantResponse"
+        );
+    }
+
+    #[test]
+    fn test_build_url_regionalizes_q_host() {
+        // 9router getOrderedBaseUrls: api_key surface regionalizes the AWS
+        // host to the account's region and orders the q.* surface first.
+        let executor = KiroExecutor::new(Arc::new(ClientPool::default()), None).unwrap();
+        let mut psd = std::collections::BTreeMap::new();
+        psd.insert("authMethod".to_string(), serde_json::json!("api_key"));
+        psd.insert("region".to_string(), serde_json::json!("eu-west-1"));
+        let credentials = ProviderConnection {
+            provider_specific_data: psd,
+            api_key: Some("key".to_string()),
+            access_token: None,
+            ..Default::default()
+        };
+        let urls = executor.build_url("amazon-nova-pro-v1.0", false, &credentials);
+        assert_eq!(
+            urls[0],
+            "https://q.eu-west-1.amazonaws.com/generateAssistantResponse"
+        );
+        assert!(urls[0].contains("q.eu-west-1.amazonaws.com"));
+        assert!(urls
+            .iter()
+            .any(|u| u.contains("codewhisperer.eu-west-1.amazonaws.com")));
     }
 
     #[test]

--- a/src/core/executor/mod.rs
+++ b/src/core/executor/mod.rs
@@ -76,8 +76,8 @@ pub use grok_web::{
 pub use iflow::{IFlowExecutionRequest, IFlowExecutor, IFlowExecutorError, IFlowExecutorResponse};
 pub use kimchi::KimchiExecutor;
 pub use kiro::{
-    AwsCredentials, EventStreamDecoder, KiroExecutionRequest, KiroExecutor, KiroExecutorError,
-    KiroExecutorResponse, SseEvent as KiroSseEvent,
+    consumed_eventstream_bytes, AwsCredentials, EventStreamDecoder, KiroEvent,
+    KiroExecutionRequest, KiroExecutor, KiroExecutorError, KiroExecutorResponse,
 };
 pub use mimo_free::{MimoFreeExecutionRequest, MimoFreeExecutor, MimoFreeExecutorResponse};
 pub use ollama::{

--- a/src/core/translator/registry.rs
+++ b/src/core/translator/registry.rs
@@ -210,6 +210,8 @@ pub struct KiroResponseState {
     pub current_event_type: Option<String>,
     /// Generic state used by kiro_to_openai_response.
     pub state: std::collections::HashMap<String, Value>,
+    /// Streaming assembler for the binary EventStream path.
+    pub assembler: Option<super::response::kiro_events::KiroSseAssembler>,
 }
 
 #[derive(Debug, Clone, Default)]
@@ -1219,9 +1221,13 @@ mod parity_tests {
         assert_eq!(body["messages"].as_array().unwrap().len(), 1);
         let content = body["messages"][0]["content"].as_array().unwrap();
         assert!(
-            !content.iter().any(|b| b.get("type").and_then(Value::as_str) == Some("tool_use")),
+            !content
+                .iter()
+                .any(|b| b.get("type").and_then(Value::as_str) == Some("tool_use")),
             "tool_use blocks must be dropped"
         );
-        assert!(content.iter().any(|b| b.get("type").and_then(Value::as_str) == Some("text")));
+        assert!(content
+            .iter()
+            .any(|b| b.get("type").and_then(Value::as_str) == Some("text")));
     }
 }

--- a/src/core/translator/response/kiro_events.rs
+++ b/src/core/translator/response/kiro_events.rs
@@ -1,0 +1,664 @@
+//! Assemble OpenAI `chat.completion.chunk` SSE from decoded Kiro
+//! (AWS EventStream) events. Ports the core of 9router
+//! `open-sse/executors/kiro.js` `transformEventStreamToSSE`:
+//!   - `chatcmpl-{timestamp_ms}` id / `created` / model on every chunk
+//!   - first chunk carries `delta.role = "assistant"`
+//!   - `<thinking>`/`</thinking>` stripped from assistantResponseEvent content
+//!   - reasoningContentEvent → `delta.reasoning_content`
+//!   - codeEvent → `delta.content`
+//!   - toolUseEvent input buffered per tool id; emitted as TWO deltas:
+//!     `{id,name,function:{name,arguments:""}}` then
+//!     `{function:{arguments:JSON.stringify(input)}}`
+//!   - messageStopEvent / metadataEvent stop reasons merged by severity
+//!   - metricsEvent / meteringEvent → usage (prompt/completion tokens, kiro credits)
+
+use std::collections::HashMap;
+
+use serde_json::{json, Map, Value};
+
+/// Normalized stop reasons (9router normalizeStopReason).
+fn normalize_stop_reason(value: &str) -> Option<String> {
+    let raw = value.trim();
+    if raw.is_empty() {
+        return None;
+    }
+    // camelCase → snake_case, whitespace/hyphens → underscores.
+    let mut out = String::with_capacity(raw.len());
+    let mut chars = raw.chars().peekable();
+    while let Some(c) = chars.next() {
+        if c.is_uppercase() {
+            if let Some(&next) = chars.peek() {
+                if next.is_lowercase() && !out.is_empty() && !out.ends_with('_') {
+                    out.push('_');
+                }
+            }
+            out.push(c.to_ascii_lowercase());
+        } else if c.is_whitespace() || c == '-' {
+            out.push('_');
+        } else {
+            out.push(c.to_ascii_lowercase());
+        }
+    }
+    while out.contains("__") {
+        out = out.replace("__", "_");
+    }
+    let out = out.trim_matches('_').to_string();
+    let normalized = match out.as_str() {
+        "endturn" | "end_turn" | "stop" | "stop_sequence" => "end_turn",
+        "tooluse" | "tool_use" | "tool_calls" => "tool_use",
+        "maxtokens" | "max_tokens" | "max_output_tokens" | "length" => "max_tokens",
+        other => other,
+    };
+    Some(normalized.to_string())
+}
+
+/// Severity used to merge competing stop reasons (9router mergeStopReason).
+fn stop_reason_severity(reason: &str) -> u8 {
+    match reason {
+        "refusal" | "malformed_model_output" | "invalid_model_output" => 6,
+        "cancelled" | "pause_turn" | "model_context_window_exceeded" => 5,
+        "unknown_failure" => 4,
+        "retryable_protocol_failure" => 3,
+        "max_tokens" => 2,
+        _ => 1,
+    }
+}
+
+/// Merge two stop reasons keeping the higher severity (9router mergeStopReason).
+fn merge_stop_reason(current: &Option<String>, incoming: &Option<String>) -> Option<String> {
+    match (current, incoming) {
+        (None, incoming) => incoming.clone(),
+        (Some(c), None) => Some(c.clone()),
+        (Some(c), Some(i)) => {
+            if stop_reason_severity(i) > stop_reason_severity(c) {
+                Some(i.clone())
+            } else {
+                Some(c.clone())
+            }
+        }
+    }
+}
+
+/// State for one streaming response assembly.
+#[derive(Debug, Clone, Default)]
+pub struct KiroSseAssembler {
+    pub response_id: String,
+    pub created: i64,
+    pub model: String,
+    pub tool_index: u64,
+    pub tools: HashMap<String, KiroToolBuf>,
+    pub stop_reason: Option<String>,
+    pub saw_tool_use: bool,
+    pub in_thinking: bool,
+    pub usage: Option<Value>,
+    /// First-chunk flag — ensures the very first emitted chunk has role.
+    pub emitted_any: bool,
+}
+
+#[derive(Debug, Clone)]
+pub struct KiroToolBuf {
+    pub id: String,
+    pub name: String,
+    pub input_parts: Vec<Value>,
+}
+
+impl KiroSseAssembler {
+    pub fn new(model: &str) -> Self {
+        Self {
+            response_id: format!("chatcmpl-{}", chrono::Utc::now().timestamp_millis()),
+            created: chrono::Utc::now().timestamp(),
+            model: model.to_string(),
+            ..Default::default()
+        }
+    }
+
+    /// Build a chunk envelope with the shared id/created/model/role fields.
+    fn envelope(&self, delta: Map<String, Value>, finish_reason: Option<&str>) -> Value {
+        let mut delta = delta;
+        if !self.emitted_any {
+            delta.insert("role".to_string(), json!("assistant"));
+        }
+        let mut chunk = Map::new();
+        chunk.insert("id".to_string(), json!(self.response_id));
+        chunk.insert("object".to_string(), json!("chat.completion.chunk"));
+        chunk.insert("created".to_string(), json!(self.created));
+        chunk.insert("model".to_string(), json!(self.model));
+        chunk.insert(
+            "choices".to_string(),
+            json!([{
+                "index": 0,
+                "delta": delta,
+                "finish_reason": finish_reason
+            }]),
+        );
+        if let Some(usage) = &self.usage {
+            chunk.insert("usage".to_string(), usage.clone());
+        }
+        Value::Object(chunk)
+    }
+
+    /// Flush all buffered tool calls as two-delta sequences.
+    /// 9router emitTools: for each buffered tool emit
+    ///   `{id, name, type:function, function:{name, arguments:""}}` then
+    ///   `{function:{arguments:JSON.stringify(input)}}`.
+    fn flush_tools(&mut self) -> Vec<Value> {
+        if self.tools.is_empty() {
+            return Vec::new();
+        }
+        let mut chunks = Vec::new();
+        let mut tool_calls = Vec::new();
+        for tool in self.tools.values() {
+            let index = self.tool_index;
+            self.tool_index += 1;
+            // First delta: declaration with empty arguments.
+            let mut delta1 = Map::new();
+            delta1.insert(
+                "tool_calls".to_string(),
+                json!([{
+                    "index": index,
+                    "id": tool.id,
+                    "type": "function",
+                    "function": { "name": tool.name, "arguments": "" }
+                }]),
+            );
+            tool_calls.push(delta1);
+            // Second delta: the input.
+            let input = if tool.input_parts.len() == 1 {
+                tool.input_parts[0].clone()
+            } else {
+                // Multiple fragments — wrap as a JSON array of parts.
+                json!(tool.input_parts)
+            };
+            let input_str = serde_json::to_string(&input).unwrap_or_else(|_| "{}".to_string());
+            let mut delta2 = Map::new();
+            delta2.insert(
+                "tool_calls".to_string(),
+                json!([{ "index": index, "function": { "arguments": input_str } }]),
+            );
+            tool_calls.push(delta2);
+        }
+        self.tools.clear();
+        for delta in tool_calls {
+            chunks.push(self.envelope(delta, None));
+        }
+        chunks
+    }
+
+    /// Process one decoded Kiro event, returning the OpenAI SSE chunks to emit.
+    pub fn process_event(
+        &mut self,
+        event: &crate::core::executor::KiroEvent,
+    ) -> Result<Vec<Value>, String> {
+        let mut chunks = Vec::new();
+        let event_type = &event.event_type;
+
+        match event_type.as_str() {
+            "assistantResponseEvent" => {
+                let payload = event
+                    .payload
+                    .as_ref()
+                    .ok_or("assistantResponseEvent has no payload")?;
+                let mut content = payload
+                    .get("content")
+                    .and_then(Value::as_str)
+                    .ok_or("assistantResponseEvent payload has no string content")?
+                    .to_string();
+                // Strip <thinking>...</thinking> (9router L759-784). Track an
+                // open thinking block across chunks.
+                if self.in_thinking {
+                    let end = content.find("</thinking>");
+                    match end {
+                        Some(end) => {
+                            self.in_thinking = false;
+                            content = content[end + "</thinking>".len()..]
+                                .trim_start_matches('\n')
+                                .to_string();
+                        }
+                        None => content = String::new(),
+                    }
+                } else {
+                    let start = content.find("<thinking>");
+                    if let Some(start) = start {
+                        let end = content[start + "<thinking>".len()..].find("</thinking>");
+                        match end {
+                            Some(end) => {
+                                let close = start + "<thinking>".len() + end + "</thinking>".len();
+                                content = format!("{}{}", &content[..start], &content[close..])
+                                    .trim_start_matches('\n')
+                                    .to_string();
+                            }
+                            None => {
+                                self.in_thinking = true;
+                                content = content[..start].to_string();
+                            }
+                        }
+                    }
+                }
+                if !content.is_empty() {
+                    let mut delta = Map::new();
+                    delta.insert("content".to_string(), json!(content));
+                    chunks.push(self.envelope(delta, None));
+                }
+            }
+            "reasoningContentEvent" => {
+                let payload = event.payload.as_ref();
+                // 9router: `event.payload?.reasoningContentEvent || event.payload`
+                // then extract `text` or `content`.
+                let inner = payload
+                    .and_then(|p| p.get("reasoningContentEvent"))
+                    .filter(|v| v.is_object())
+                    .or(payload);
+                let content = inner
+                    .and_then(|v| v.get("text").or_else(|| v.get("content")))
+                    .and_then(Value::as_str)
+                    .or_else(|| payload.and_then(Value::as_str))
+                    .unwrap_or("");
+                if !content.is_empty() {
+                    let mut delta = Map::new();
+                    delta.insert("reasoning_content".to_string(), json!(content));
+                    chunks.push(self.envelope(delta, None));
+                }
+            }
+            "codeEvent" => {
+                if let Some(payload) = event.payload.as_ref() {
+                    if let Some(content) = payload.get("content").and_then(Value::as_str) {
+                        if !content.is_empty() {
+                            let mut delta = Map::new();
+                            delta.insert("content".to_string(), json!(content));
+                            chunks.push(self.envelope(delta, None));
+                        }
+                    }
+                }
+            }
+            "toolUseEvent" => {
+                self.saw_tool_use = true;
+                let payload = event
+                    .payload
+                    .as_ref()
+                    .ok_or("toolUseEvent has no payload")?;
+                let values: Vec<&Value> = match payload {
+                    Value::Array(arr) => arr.iter().collect(),
+                    other => std::slice::from_ref(&other).to_vec(),
+                };
+                for value in values {
+                    let name = value
+                        .get("name")
+                        .and_then(Value::as_str)
+                        .map(|s| s.trim())
+                        .unwrap_or("");
+                    if name.is_empty() {
+                        return Err("Kiro toolUseEvent is missing a tool name".to_string());
+                    }
+                    let id = value
+                        .get("toolUseId")
+                        .and_then(Value::as_str)
+                        .map(|s| s.to_string())
+                        .unwrap_or_else(|| {
+                            format!("call_{}_{}", self.created, self.tools.len() + 1)
+                        });
+                    let input = value.get("input").cloned().unwrap_or(Value::Null);
+                    if let Some(tool) = self.tools.get_mut(&id) {
+                        if tool.name != name {
+                            return Err("Kiro tool name changed between fragments".to_string());
+                        }
+                        tool.input_parts.push(input);
+                    } else {
+                        self.tools.insert(
+                            id.clone(),
+                            KiroToolBuf {
+                                id,
+                                name: name.to_string(),
+                                input_parts: vec![input],
+                            },
+                        );
+                    }
+                }
+            }
+            "messageStopEvent" => {
+                let payload = event.payload.as_ref();
+                let reason = payload
+                    .and_then(|p| p.get("stopReason").or_else(|| p.get("stop_reason")))
+                    .and_then(Value::as_str)
+                    .and_then(normalize_stop_reason)
+                    .or_else(|| {
+                        if self.saw_tool_use {
+                            Some("tool_use".to_string())
+                        } else {
+                            Some("end_turn".to_string())
+                        }
+                    });
+                self.stop_reason = merge_stop_reason(&self.stop_reason, &reason);
+                // 9router emits the terminal chunk at the stop event; flush any
+                // buffered tool calls first so finish_reason lands last.
+                chunks.extend(self.flush_tools());
+                chunks.push(self.terminal_chunk());
+            }
+            "metadataEvent" | "MetadataEvent" => {
+                let payload = event.payload.as_ref();
+                let metadata = payload
+                    .and_then(|p| p.get("metadataEvent").or_else(|| p.get("metadata")))
+                    .or(payload);
+                let reason = metadata
+                    .and_then(|m| m.get("stopReason").or_else(|| m.get("stop_reason")))
+                    .and_then(Value::as_str)
+                    .and_then(normalize_stop_reason);
+                if let Some(reason) = reason {
+                    self.stop_reason = merge_stop_reason(&self.stop_reason, &Some(reason));
+                    // If this is a terminal stop (end_turn / tool_use / max_tokens),
+                    // flush tools and emit the terminal chunk.
+                    if matches!(
+                        self.stop_reason.as_deref(),
+                        Some("end_turn" | "tool_use" | "max_tokens")
+                    ) {
+                        chunks.extend(self.flush_tools());
+                        chunks.push(self.terminal_chunk());
+                    }
+                }
+            }
+            "contextUsageEvent" => {
+                // Usage fallback (9router L1032-1043): contextUsagePercentage is
+                // a proxy when no token counts arrive.
+                if let Some(payload) = event.payload.as_ref() {
+                    if let Some(pct) = payload
+                        .get("contextUsagePercentage")
+                        .and_then(Value::as_f64)
+                    {
+                        let _ = pct;
+                    }
+                }
+            }
+            "meteringEvent" => {
+                if let Some(payload) = event.payload.as_ref() {
+                    let metering = payload
+                        .get("meteringEvent")
+                        .or(Some(payload))
+                        .cloned()
+                        .unwrap_or_default();
+                    if let Some(credits) = metering.get("usage").and_then(Value::as_f64) {
+                        let mut usage = self.usage.clone().unwrap_or_else(|| json!({}));
+                        usage["kiro_credits"] = json!(credits);
+                        let unit = metering
+                            .get("unit")
+                            .and_then(Value::as_str)
+                            .unwrap_or("credit");
+                        usage["kiro_credit_unit"] = json!(unit);
+                        self.usage = Some(usage);
+                    }
+                }
+            }
+            "metricsEvent" => {
+                if let Some(payload) = event.payload.as_ref() {
+                    let metrics = payload
+                        .get("metricsEvent")
+                        .or(Some(payload))
+                        .cloned()
+                        .unwrap_or_default();
+                    let prompt = metrics
+                        .get("inputTokens")
+                        .and_then(Value::as_u64)
+                        .unwrap_or(0);
+                    let completion = metrics
+                        .get("outputTokens")
+                        .and_then(Value::as_u64)
+                        .unwrap_or(0);
+                    if prompt > 0 || completion > 0 {
+                        let mut usage = self.usage.clone().unwrap_or_else(|| json!({}));
+                        usage["prompt_tokens"] = json!(prompt);
+                        usage["completion_tokens"] = json!(completion);
+                        usage["total_tokens"] = json!(prompt + completion);
+                        let cache_read = metrics
+                            .get("cacheReadInputTokens")
+                            .or_else(|| metrics.get("cache_read_input_tokens"))
+                            .and_then(Value::as_u64)
+                            .unwrap_or(0);
+                        if cache_read > 0 {
+                            usage["cache_read_input_tokens"] = json!(cache_read);
+                        }
+                        let cache_create = metrics
+                            .get("cacheCreationInputTokens")
+                            .or_else(|| metrics.get("cache_creation_input_tokens"))
+                            .and_then(Value::as_u64)
+                            .unwrap_or(0);
+                        if cache_create > 0 {
+                            usage["cache_creation_input_tokens"] = json!(cache_create);
+                        }
+                        self.usage = Some(usage);
+                    }
+                }
+            }
+            _ => {
+                // Unknown/error event types produce nothing.
+            }
+        }
+
+        // Mark chunk emission happened (role was attached).
+        if !chunks.is_empty() {
+            self.emitted_any = true;
+        }
+        Ok(chunks)
+    }
+
+    /// The terminal chunk with finish_reason (no tool flush — callers flush
+    /// first via `flush_tools`).
+    pub fn terminal_chunk(&self) -> Value {
+        let reason = match self.stop_reason.as_deref() {
+            Some("tool_use") => "tool_calls",
+            Some(r) if r == "end_turn" || r == "stop" => "stop",
+            Some(r) => r,
+            None => "stop",
+        };
+        let delta = Map::new();
+        self.envelope(delta, Some(reason))
+    }
+
+    /// Emit the terminal chunk with finish_reason + any buffered tools flushed
+    /// first. Call exactly once at stream end (e.g. upstream connection close).
+    pub fn finish(&mut self) -> Vec<Value> {
+        let mut chunks = self.flush_tools();
+        chunks.push(self.terminal_chunk());
+        chunks
+    }
+}
+
+/// Transform a JSON envelope that already carries `_eventType` (the legacy
+/// path used by kiro_to_openai_response) into the same chunk shape.
+pub fn event_json_to_chunk(event: &Value, state: &mut HashMap<String, Value>) -> Option<Value> {
+    let event_type = event
+        .get("_eventType")
+        .or_else(|| event.get("event"))
+        .and_then(Value::as_str)
+        .unwrap_or("");
+    if event_type == "assistantResponseEvent" || event.get("assistantResponseEvent").is_some() {
+        let content = event
+            .get("assistantResponseEvent")
+            .and_then(|v| v.get("content"))
+            .or_else(|| event.get("content"))
+            .and_then(Value::as_str)?;
+        let chunk_idx = state.get("chunkIndex").and_then(Value::as_u64).unwrap_or(0);
+        let response_id = state
+            .get("responseId")
+            .and_then(Value::as_str)
+            .unwrap_or("chatcmpl-0")
+            .to_string();
+        let created = state.get("created").and_then(Value::as_i64).unwrap_or(0);
+        let model = state
+            .get("model")
+            .and_then(Value::as_str)
+            .unwrap_or("kiro")
+            .to_string();
+        let mut delta = serde_json::Map::new();
+        if chunk_idx == 0 {
+            delta.insert("role".to_string(), Value::String("assistant".to_string()));
+        }
+        delta.insert("content".to_string(), Value::String(content.to_string()));
+        state.insert(
+            "chunkIndex".to_string(),
+            Value::Number((chunk_idx + 1).into()),
+        );
+        return Some(json!({
+            "id": response_id,
+            "object": "chat.completion.chunk",
+            "created": created,
+            "model": model,
+            "choices": [{ "index": 0, "delta": delta, "finish_reason": null }]
+        }));
+    }
+    if event_type == "reasoningContentEvent" || event.get("reasoningContentEvent").is_some() {
+        let reasoning = event.get("reasoningContentEvent").unwrap_or(event);
+        let content = reasoning
+            .get("text")
+            .or_else(|| reasoning.get("content"))
+            .and_then(Value::as_str)
+            .or_else(|| event.get("content").and_then(Value::as_str))?;
+        let chunk_idx = state.get("chunkIndex").and_then(Value::as_u64).unwrap_or(0);
+        let response_id = state
+            .get("responseId")
+            .and_then(Value::as_str)
+            .unwrap_or("chatcmpl-0")
+            .to_string();
+        let created = state.get("created").and_then(Value::as_i64).unwrap_or(0);
+        let model = state
+            .get("model")
+            .and_then(Value::as_str)
+            .unwrap_or("kiro")
+            .to_string();
+        let mut delta = serde_json::Map::new();
+        if chunk_idx == 0 {
+            delta.insert("role".to_string(), Value::String("assistant".to_string()));
+        }
+        delta.insert(
+            "reasoning_content".to_string(),
+            Value::String(content.to_string()),
+        );
+        state.insert(
+            "chunkIndex".to_string(),
+            Value::Number((chunk_idx + 1).into()),
+        );
+        return Some(json!({
+            "id": response_id,
+            "object": "chat.completion.chunk",
+            "created": created,
+            "model": model,
+            "choices": [{ "index": 0, "delta": delta, "finish_reason": null }]
+        }));
+    }
+    None
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::core::executor::KiroEvent;
+    use serde_json::json;
+
+    fn event(event_type: &str, payload: Value) -> KiroEvent {
+        KiroEvent {
+            message_type: "event".to_string(),
+            event_type: event_type.to_string(),
+            content_type: "application/json".to_string(),
+            payload: Some(payload),
+        }
+    }
+
+    #[test]
+    fn test_eventstream_tool_use_emits_two_deltas() {
+        // Acceptance guard test: a toolUseEvent carrying {toolUseId, name,
+        // input:{x:1}} → output SSE contains a chunk with
+        // tool_calls[0].function.arguments == "" and a later chunk with
+        // tool_calls[0].function.arguments == "{\"x\":1}".
+        let mut asm = KiroSseAssembler::new("test-model");
+        let tool_event = event(
+            "toolUseEvent",
+            json!({
+                "toolUseId": "tool_1",
+                "name": "get_weather",
+                "input": { "x": 1 }
+            }),
+        );
+        let chunks = asm.process_event(&tool_event).unwrap();
+        // Buffering emits no chunks yet.
+        assert!(chunks.is_empty());
+        // Flush the tool calls.
+        let flushed = asm.flush_tools();
+        assert_eq!(flushed.len(), 2);
+
+        let first = &flushed[0]["choices"][0]["delta"]["tool_calls"][0];
+        assert_eq!(first["id"], "tool_1");
+        assert_eq!(first["function"]["name"], "get_weather");
+        assert_eq!(first["function"]["arguments"], "");
+
+        let second = &flushed[1]["choices"][0]["delta"]["tool_calls"][0];
+        assert_eq!(second["function"]["arguments"], "{\"x\":1}");
+    }
+
+    #[test]
+    fn test_message_stop_flushes_tools_and_emits_terminal() {
+        let mut asm = KiroSseAssembler::new("test-model");
+        asm.process_event(&event(
+            "toolUseEvent",
+            json!({ "toolUseId": "t1", "name": "f", "input": { "a": 2 } }),
+        ))
+        .unwrap();
+        let chunks = asm
+            .process_event(&event(
+                "messageStopEvent",
+                json!({ "stopReason": "tool_use" }),
+            ))
+            .unwrap();
+        // tools flushed (2) + terminal (1)
+        assert_eq!(chunks.len(), 3);
+        let last = chunks.last().unwrap();
+        assert_eq!(last["choices"][0]["finish_reason"], "tool_calls");
+    }
+
+    #[test]
+    fn test_assistant_response_strips_thinking_tags() {
+        let mut asm = KiroSseAssembler::new("test-model");
+        let chunks = asm
+            .process_event(&event(
+                "assistantResponseEvent",
+                json!({ "content": "before <thinking>hidden</thinking> after" }),
+            ))
+            .unwrap();
+        assert_eq!(chunks.len(), 1);
+        let content = chunks[0]["choices"][0]["delta"]["content"]
+            .as_str()
+            .unwrap();
+        assert!(!content.contains("<thinking>"));
+        assert!(!content.contains("</thinking>"));
+        assert!(content.contains("before"));
+        assert!(content.contains("after"));
+        // First chunk carries role assistant.
+        assert_eq!(chunks[0]["choices"][0]["delta"]["role"], "assistant");
+    }
+
+    #[test]
+    fn test_reasoning_event_emits_reasoning_content() {
+        let mut asm = KiroSseAssembler::new("test-model");
+        let chunks = asm
+            .process_event(&event(
+                "reasoningContentEvent",
+                json!({ "reasoningContentEvent": { "text": "thinking..." } }),
+            ))
+            .unwrap();
+        assert_eq!(chunks.len(), 1);
+        assert_eq!(
+            chunks[0]["choices"][0]["delta"]["reasoning_content"],
+            "thinking..."
+        );
+    }
+
+    #[test]
+    fn test_metrics_event_produces_usage() {
+        let mut asm = KiroSseAssembler::new("test-model");
+        asm.process_event(&event(
+            "metricsEvent",
+            json!({ "inputTokens": 10, "outputTokens": 20 }),
+        ))
+        .unwrap();
+        let terminal = asm.terminal_chunk();
+        assert_eq!(terminal["usage"]["prompt_tokens"], 10);
+        assert_eq!(terminal["usage"]["completion_tokens"], 20);
+        assert_eq!(terminal["usage"]["total_tokens"], 30);
+    }
+}

--- a/src/core/translator/response/kiro_to_openai.rs
+++ b/src/core/translator/response/kiro_to_openai.rs
@@ -215,17 +215,109 @@ use crate::core::translator::registry::ResponseTransformState;
 
 /// Registry-compatible streaming wrapper.
 /// Signature matches `registry::ResponseTransformFn`.
+///
+/// Kiro upstream returns AWS EventStream v1 binary. We buffer bytes across
+/// chunks, decode complete frames via `EventStreamDecoder`, and assemble
+/// OpenAI `chat.completion.chunk` SSE via `KiroSseAssembler`.
+/// Falls back to the legacy JSON path for callers that already hand us
+/// decoded JSON events (e.g. tests, or a provider that skipped EventStream).
 pub fn kiro_to_openai_streaming(chunk: &[u8], state: &mut ResponseTransformState) -> Vec<String> {
-    let val: serde_json::Value = match serde_json::from_slice(chunk) {
-        Ok(v) => v,
+    // Legacy JSON path: if the chunk parses as JSON with an _eventType or
+    // chat.completion.chunk, use kiro_to_openai_response.
+    if let Ok(val) = serde_json::from_slice::<serde_json::Value>(chunk) {
+        if val.get("_eventType").is_some()
+            || val.get("event").is_some()
+            || val.get("object").and_then(|v| v.as_str()) == Some("chat.completion.chunk")
+        {
+            let inner = &mut state.kiro.state;
+            return match kiro_to_openai_response(&val, inner) {
+                Some(v) => vec![format!(
+                    "data: {}\n\n",
+                    serde_json::to_string(&v).unwrap_or_default()
+                )],
+                None => vec![],
+            };
+        }
+    }
+
+    // Binary EventStream path.
+    let buffer = &mut state.kiro.event_buffer;
+    buffer.extend_from_slice(chunk);
+
+    let events = match crate::core::executor::EventStreamDecoder::decode_chunk(buffer) {
+        Ok(events) => events,
         Err(_) => return vec![],
     };
-    let inner = &mut state.kiro.state;
-    match kiro_to_openai_response(&val, inner) {
-        Some(v) => vec![format!(
-            "data: {}\n\n",
-            serde_json::to_string(&v).unwrap_or_default()
-        )],
-        None => vec![],
+    if events.is_empty() {
+        return vec![];
     }
+
+    // Buffer any trailing partial frame for the next chunk.
+    let consumed = crate::core::executor::consumed_eventstream_bytes(buffer);
+    if consumed < buffer.len() {
+        let rest = buffer.split_off(consumed);
+        buffer.clear();
+        buffer.extend_from_slice(&rest);
+    } else {
+        buffer.clear();
+    }
+
+    // Lazily create the assembler on first event.
+    if state.kiro.assembler.is_none() {
+        let model = state
+            .kiro
+            .state
+            .get("model")
+            .and_then(|v| v.as_str())
+            .unwrap_or("kiro")
+            .to_string();
+        state.kiro.assembler = Some(super::kiro_events::KiroSseAssembler::new(&model));
+    }
+
+    let mut out = Vec::new();
+    for event in &events {
+        if event.message_type == "error" || event.message_type == "exception" {
+            // Emit an SSE error chunk mirroring 9router's upstream_error.
+            out.push(format!(
+                "data: {}\n\n",
+                serde_json::json!({
+                    "error": {
+                        "message": event.payload
+                            .as_ref()
+                            .and_then(|p| p.get("message"))
+                            .and_then(|v| v.as_str())
+                            .unwrap_or("Kiro upstream sent an EventStream error"),
+                        "type": "upstream_error",
+                        "code": "kiro_upstream_eventstream_error"
+                    }
+                })
+            ));
+            out.push("data: [DONE]\n\n".to_string());
+            continue;
+        }
+        // Delegate to the assembler (per-event).
+        if let Some(assembler) = state.kiro.assembler.as_mut() {
+            match assembler.process_event(event) {
+                Ok(chunks) => {
+                    for c in chunks {
+                        out.push(format!(
+                            "data: {}\n\n",
+                            serde_json::to_string(&c).unwrap_or_default()
+                        ));
+                    }
+                }
+                Err(msg) => {
+                    out.push(format!(
+                        "data: {}\n\n",
+                        serde_json::json!({
+                            "error": { "message": msg, "type": "upstream_error", "code": "kiro_event_parse_error" }
+                        })
+                    ));
+                    out.push("data: [DONE]\n\n".to_string());
+                    break;
+                }
+            }
+        }
+    }
+    out
 }

--- a/src/core/translator/response/mod.rs
+++ b/src/core/translator/response/mod.rs
@@ -4,6 +4,7 @@ pub mod claude_to_openai;
 pub mod commandcode_to_openai;
 pub mod cursor_to_openai;
 pub mod gemini_to_openai;
+pub mod kiro_events;
 pub mod kiro_to_claude;
 pub mod kiro_to_openai;
 pub mod non_streaming;


### PR DESCRIPTION
## Summary
Ports 9router `kiro.js` parity gaps for the Kiro (AWS CodeWhisperer) executor.

### Changes
1. **Regionalized URL ordering** (`build_url`) — rewrites `amazonaws.com` hosts to the token's region (default `us-east-1`) via the `getOrderedBaseUrls` regex. Also refactors the ordering logic, removing a pre-existing unused-assignment warning.
2. **401/403/404 endpoint fallback** (`execute_request`) — on auth/surface failures with remaining surfaces, continues to the next URL instead of returning immediately (JS `shouldRetry` + `KIRO_ENDPOINT_FALLBACK_STATUSES`). Payload-invalid 400 stays terminal.
3. **Full EventStream v1 header decoding** (`EventStreamDecoder`) — decodes `:event-type`/`:message-type`/`:content-type` headers + JSON payload into structured `KiroEvent` values (was returning raw `data:` lines). Adds `consumed_eventstream_bytes` for partial-frame buffering.
4. **New `KiroSseAssembler`** — assembles OpenAI `chat.completion.chunk` SSE: `chatcmpl-{ts}` id, first-chunk `role:"assistant"`, `<thinking>` stripping, `reasoning_content`, `codeEvent`, **toolUseEvent two-delta buffering** (`{arguments:""}` then `{arguments:JSON.stringify(input)}`), stop-reason merging, metrics/metering usage.
5. **`kiro_to_openai_streaming`** — binary EventStream path (with legacy JSON fallback), SSE error chunk on upstream error events.

### Guard tests (acceptance criteria)
- `test_eventstream_tool_use_emits_two_deltas` — toolUseEvent → two tool_calls deltas (`arguments:""` then `{\"x\":1}`) ✅
- `test_build_url_regionalizes_q_host` — region `eu-west-1` regionalizes q host ✅
- 5 `kiro_events` unit tests + 3 regionalization tests + 99 kiro-suite tests pass
- Full suite: no NEW failures (4 pre-existing environmental: `cli_tools` `/bin/sh` on Windows + `parity_provider_aliases_resolve`)

### Notes
- Verified compile via `--no-default-features` (worktree has no `web/dist`); CI builds the dashboard separately.
- The full integrity-gate/repair-loop state machine from JS is a follow-up (bounded buffer, repair retry, heartbeat) — intentionally scoped out of this PR.