### PR TITLE
fix(combo): body-based retryAfter fallback + earliest-retry parity (bead .107)

### DIFF
--- a/src/core/combo/mod.rs
+++ b/src/core/combo/mod.rs
@@ -146,6 +146,36 @@ impl ComboAttemptError {
     }
 }
 
+/// Parse a `retryAfter` value from an upstream error body into a concrete
+/// timestamp. 9router `handleComboChat` reads `errorBody.retryAfter` and
+/// normalizes via `new Date(retryAfter)`, which accepts both an ISO-8601 date
+/// string and a numeric seconds count. Returns `None` when absent/unparseable.
+pub fn parse_retry_after_from_body(body: &[u8]) -> Option<DateTime<Utc>> {
+    let value: serde_json::Value = serde_json::from_slice(body).ok()?;
+    let retry_after = value
+        .get("error")
+        .and_then(|e| e.get("retryAfter"))
+        .or_else(|| value.get("retryAfter"))?;
+    if let Some(iso) = retry_after.as_str() {
+        // ISO-8601 date string.
+        if let Ok(dt) = DateTime::parse_from_rfc3339(iso) {
+            return Some(dt.with_timezone(&Utc));
+        }
+        // Numeric string of seconds.
+        if let Ok(secs) = iso.parse::<i64>() {
+            return Utc::now().checked_add_signed(chrono::Duration::seconds(secs));
+        }
+        return None;
+    }
+    if let Some(secs) = retry_after.as_i64() {
+        return Utc::now().checked_add_signed(chrono::Duration::seconds(secs));
+    }
+    if let Some(secs) = retry_after.as_f64() {
+        return Utc::now().checked_add_signed(chrono::Duration::seconds(secs as i64));
+    }
+    None
+}
+
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct ComboExecutionError {
     pub status: u16,
@@ -771,7 +801,8 @@ where
                     };
                 }
 
-                let decision = check_fallback_error(error.status, &error.message, consecutive_backoff_level);
+                let decision =
+                    check_fallback_error(error.status, &error.message, consecutive_backoff_level);
                 if !decision.should_fallback {
                     return Err(ComboExecutionError {
                         status: error.status,
@@ -831,4 +862,41 @@ where
         earliest_retry_after,
         upstream_body: final_upstream_body,
     })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn combo_retry_after_from_body_parsed() {
+        // Acceptance guard test (bead .107): an error whose JSON body carries
+        // retryAfter as an ISO date string (no Retry-After header needed).
+        let body = br#"{"error":{"message":"rate limited","retryAfter":"2030-01-01T00:00:00Z"}}"#;
+        let retry_after = parse_retry_after_from_body(body);
+        assert!(retry_after.is_some(), "ISO retryAfter should parse");
+        if let Some(ra) = retry_after {
+            assert!(ra > Utc::now(), "parsed date should be in the future");
+        }
+    }
+
+    #[test]
+    fn combo_retry_after_from_body_numeric_seconds() {
+        // retryAfter as a numeric seconds count → future timestamp.
+        let body = br#"{"error":{"retryAfter":120}}"#;
+        let retry_after = parse_retry_after_from_body(body);
+        assert!(retry_after.is_some(), "numeric retryAfter should parse");
+        if let Some(ra) = retry_after {
+            let delta = ra.signed_duration_since(Utc::now());
+            assert!(delta.num_seconds() >= 100 && delta.num_seconds() <= 140);
+        }
+    }
+
+    #[test]
+    fn combo_retry_after_from_body_absent() {
+        // No retryAfter → None.
+        let body = br#"{"error":{"message":"boom"}}"#;
+        assert!(parse_retry_after_from_body(body).is_none());
+        assert!(parse_retry_after_from_body(b"not json").is_none());
+    }
 }

--- a/src/server/api/chat.rs
+++ b/src/server/api/chat.rs
@@ -1829,8 +1829,13 @@ async fn forward_with_provider_fallback(
                     .await);
                 }
 
-                let retry_after = retry_after_from_headers(result.response.headers());
-                let message = extract_error_message(result.response).await;
+                // 9router parity: retryAfter may come from the Retry-After header
+                // OR the error JSON body (errorBody.retryAfter). Header wins; the
+                // body is the fallback when a provider returns it only in JSON.
+                let header_retry_after = retry_after_from_headers(result.response.headers());
+                let (message, body_retry_after) =
+                    extract_error_message_and_retry_after(result.response).await;
+                let retry_after = header_retry_after.or(body_retry_after);
                 state
                     .usage_live
                     .finish_request(model, provider, Some(connection.id.as_str()), true)
@@ -3422,7 +3427,12 @@ async fn extract_upstream_error_with_body(response: UpstreamResponse) -> (String
     (message, raw_body)
 }
 
-async fn extract_error_message(response: UpstreamResponse) -> String {
+/// Read the error response body once and return both the extracted message and
+/// a body-based `retryAfter` (9router `handleComboChat` reads
+/// `errorBody.retryAfter`; `new Date(retryAfter)` accepts ISO date or seconds).
+async fn extract_error_message_and_retry_after(
+    response: UpstreamResponse,
+) -> (String, Option<DateTime<Utc>>) {
     let status = response.status();
     let text = match response {
         UpstreamResponse::Reqwest(response) => response.text().await.unwrap_or_default(),
@@ -3434,27 +3444,35 @@ async fn extract_error_message(response: UpstreamResponse) -> String {
                 .unwrap_or_default()
         }
     };
-    if let Ok(value) = serde_json::from_str::<Value>(&text) {
-        if let Some(message) = value
-            .get("error")
-            .and_then(|error| error.get("message").or(Some(error)))
-            .and_then(Value::as_str)
-            .map(str::trim)
-            .filter(|value| !value.is_empty())
-        {
-            return message.to_string();
+    let retry_after = crate::core::combo::parse_retry_after_from_body(text.as_bytes());
+    let message = {
+        if let Ok(value) = serde_json::from_str::<Value>(&text) {
+            if let Some(message) = value
+                .get("error")
+                .and_then(|error| error.get("message").or(Some(error)))
+                .and_then(Value::as_str)
+                .map(str::trim)
+                .filter(|value| !value.is_empty())
+            {
+                message.to_string()
+            } else if let Some(message) = value
+                .get("message")
+                .and_then(Value::as_str)
+                .map(str::trim)
+                .filter(|value| !value.is_empty())
+            {
+                message.to_string()
+            } else {
+                fallback_error_text(status, &text)
+            }
+        } else {
+            fallback_error_text(status, &text)
         }
+    };
+    (message, retry_after)
+}
 
-        if let Some(message) = value
-            .get("message")
-            .and_then(Value::as_str)
-            .map(str::trim)
-            .filter(|value| !value.is_empty())
-        {
-            return message.to_string();
-        }
-    }
-
+fn fallback_error_text(status: StatusCode, text: &str) -> String {
     let trimmed = text.trim();
     if trimmed.is_empty() {
         status


### PR DESCRIPTION
## Summary
Ports the actionable 9router `combo.js` gap (`P2-C1`): a provider that returns `retryAfter` only in the error JSON body (not the `Retry-After` header) was ignored.

### Changes
1. **`parse_retry_after_from_body`** (`combo/mod.rs`) — parse `errorBody.retryAfter` from an upstream error body: accepts ISO-8601 date strings and numeric seconds (9router `new Date(retryAfter)` normalization).
2. **`chat.rs` dispatch** — on combo member failure, `retryAfter` now comes from the header **or** the JSON body (header wins). New `extract_error_message_and_retry_after` reads the body once and returns both; replaces the old `extract_error_message`.
3. **earliest-retry-after tracking** (min across failures) already matched JS — documented as verified.

### Guard tests (acceptance)
- `combo_retry_after_from_body_parsed` (ISO date) ✅
- `combo_retry_after_from_body_numeric_seconds` ✅
- `combo_retry_after_from_body_absent` ✅
- 46 combo tests green; no new failures.