### PR TITLE
fix(combo): GitHub 402 monthly-reset account lock parity (bead .52)

### DIFF
--- a/src/core/account_fallback/mod.rs
+++ b/src/core/account_fallback/mod.rs
@@ -457,6 +457,43 @@ impl StickySession {
     }
 }
 
+/// The GitHub monthly-usage-limit error text (9router auth.js
+/// `GITHUB_MONTHLY_USAGE_LIMIT`). Case-insensitive substring match.
+const GITHUB_MONTHLY_USAGE_LIMIT: &str = "you've reached your additional usage limit for your plan";
+
+/// 9router `githubMonthlyResetMs`: when a GitHub account returns 402 with the
+/// monthly-usage-limit message, the account is locked until the first of the
+/// NEXT month (UTC). Returns `None` otherwise.
+pub fn github_monthly_reset_ms(
+    status: u16,
+    error_text: &str,
+    provider: &str,
+) -> Option<DateTime<Utc>> {
+    use chrono::{Datelike, TimeZone};
+    if provider != "github" || status != 402 {
+        return None;
+    }
+    if !error_text
+        .to_lowercase()
+        .contains(GITHUB_MONTHLY_USAGE_LIMIT)
+    {
+        return None;
+    }
+    let now = Utc::now();
+    // First day of next month at 00:00 UTC (9router Date.UTC(now.getUTCFullYear(),
+    // now.getUTCMonth() + 1, 1)).
+    let (year, month) = if now.month() == 12 {
+        (now.year() + 1, 1)
+    } else {
+        (now.year(), now.month() + 1)
+    };
+    Some(
+        Utc.with_ymd_and_hms(year, month, 1, 0, 0, 0)
+            .single()
+            .unwrap_or(now),
+    )
+}
+
 /// Get the flat field key for a model lock.
 pub fn get_model_lock_key(model: &str) -> String {
     if model.is_empty() {
@@ -1099,5 +1136,44 @@ mod tests {
             300,
         );
         assert_eq!(idx, Some(1)); // acc2 is sticky
+    }
+
+    #[test]
+    fn github_402_monthly_reset_returns_next_month() {
+        use chrono::{Datelike, Timelike};
+        // 9router githubMonthlyResetMs: GitHub 402 + monthly-limit text → lock
+        // until the first of next month.
+        let reset = github_monthly_reset_ms(
+            402,
+            "You've reached your additional usage limit for your plan",
+            "github",
+        );
+        assert!(reset.is_some(), "github 402 monthly text should resolve");
+        if let Some(reset_at) = reset {
+            let now = Utc::now();
+            let diff = reset_at - now;
+            assert!(diff.num_days() > 0, "should be in the future");
+            assert!(diff.num_days() <= 32, "should be within a month");
+            // First of a month at 00:00 UTC.
+            assert_eq!(reset_at.day(), 1);
+            assert_eq!(reset_at.hour(), 0);
+            assert_eq!(reset_at.minute(), 0);
+            assert_eq!(reset_at.second(), 0);
+        }
+    }
+
+    #[test]
+    fn github_402_other_message_returns_none() {
+        // Non-monthly 402 text → no reset.
+        assert!(github_monthly_reset_ms(402, "card declined", "github").is_none());
+        // Non-402 github → none.
+        assert!(github_monthly_reset_ms(429, "rate limited", "github").is_none());
+        // Non-github 402 → none.
+        assert!(github_monthly_reset_ms(
+            402,
+            "you've reached your additional usage limit for your plan",
+            "openai"
+        )
+        .is_none());
     }
 }

--- a/src/server/api/chat.rs
+++ b/src/server/api/chat.rs
@@ -1923,6 +1923,29 @@ async fn forward_with_provider_fallback(
                 }
 
                 if decision.should_fallback {
+                    // 9router githubMonthlyResetMs: a GitHub 402 with the
+                    // monthly-usage-limit message locks the ACCOUNT (model="")
+                    // until the first of next month, and resets backoff to 0.
+                    let github_reset = crate::core::account_fallback::github_monthly_reset_ms(
+                        status.as_u16(),
+                        &message,
+                        &plan.provider,
+                    );
+                    if let Some(reset_at) = github_reset {
+                        let cooldown_ms = (reset_at - Utc::now()).to_std().unwrap_or_default();
+                        mark_connection_unavailable(
+                            state,
+                            &connection.id,
+                            "",
+                            status.as_u16(),
+                            &message,
+                            cooldown_ms,
+                            0,
+                        )
+                        .await;
+                        excluded.insert(connection.id.clone());
+                        continue;
+                    }
                     mark_connection_unavailable(
                         state,
                         &connection.id,


### PR DESCRIPTION
## Summary
Ports 9router `auth.js githubMonthlyResetMs` (`P1-D4`): GitHub 402 with the monthly-usage-limit message must lock the account until the first of next month (account-level, not per-model).

### Changes
1. **`github_monthly_reset_ms`** (`account_fallback`) — GitHub 402 + monthly-limit text → first of NEXT month UTC. Case-insensitive; non-matching 402 / non-github → None.
2. **`chat.rs` dispatch** — in combo member fallback, detect the GitHub 402 monthly-reset and call `mark_connection_unavailable` with `model=""` (account-level `MODEL_LOCK_ALL`), `backoff_level=0` — mirroring JS `buildModelLockUpdate(null, ...)`. Cooldown runs to next month (not capped, matching JS).

### Guard tests (acceptance)
- `github_402_monthly_reset_returns_next_month` (first-of-month 00:00 UTC, future, ≤32 days) ✅
- `github_402_other_message_returns_none` ✅
- No new failures.