### PR TITLE
feat(rtk): system prompt injector handles Claude/Gemini/Responses shapes (bead .99)

### DIFF
--- a/src/core/chat/mod.rs
+++ b/src/core/chat/mod.rs
@@ -361,7 +361,19 @@ fn apply_chat_system_prompt_injection(body: &mut Value, settings: &Settings) -> 
         .filter(|s| !s.trim().is_empty())
         .map(|s| s.to_string());
     match prompt {
-        Some(p) => inject_system_prompt(body, &p),
+        Some(p) => {
+            // Dispatch by body shape (9router injectSystemPrompt format switch).
+            let format = if body.get("system").is_some() {
+                "claude"
+            } else if body.get("systemInstruction").is_some()
+                || body.get("system_instruction").is_some()
+            {
+                "gemini"
+            } else {
+                "openai"
+            };
+            inject_system_prompt(body, format, &p)
+        }
         None => false,
     }
 }

--- a/src/core/rtk/mod.rs
+++ b/src/core/rtk/mod.rs
@@ -29,7 +29,8 @@ const DEFAULT_CONTEXT_WINDOW: usize = 16_384;
 const CAVEMAN_SHARED_BOUNDARIES: &str = "Code blocks, file paths, commands, errors, URLs: keep exact. Security warnings, irreversible action confirmations, multi-step ordered sequences: write normal. Resume terse style after.";
 const CAVEMAN_SHARED_EXAMPLES: &str = "Not: \"Sure! I'd be happy to help you with that. The issue you're experiencing is likely caused by...\" Yes: \"Bug in auth middleware. Token expiry check use `<` not `<=`. Fix:\"";
 const CAVEMAN_SHARED_AUTO_CLARITY: &str = "Auto-Clarity: drop caveman for security warnings, irreversible actions, multi-step sequences where fragment ambiguity risks misread, or when user repeats a question. Resume after the clear part.";
-const CAVEMAN_SHARED_PERSISTENCE: &str = "ACTIVE EVERY RESPONSE. No revert after many turns. No filler drift. Still active if unsure.";
+const CAVEMAN_SHARED_PERSISTENCE: &str =
+    "ACTIVE EVERY RESPONSE. No revert after many turns. No filler drift. Still active if unsure.";
 const CAVEMAN_SHARED_NO_INVENTED_ABBREV: &str = "No invented abbreviations. Standard well-known tech acronyms (DB, API, HTTP, URL, JSON, ID, OS, CPU) OK. Names of code symbols, function names, API names, error strings: keep verbatim.";
 const CAVEMAN_SHARED_PRESERVE_LANGUAGE: &str = "Preserve the user's dominant language. User wrote Vietnamese, reply Vietnamese. User wrote English, reply English. Wenyan/classical-Chinese levels override this language-preservation rule. Code identifiers, error strings, file paths, commands: keep in their original form regardless of language.";
 const CAVEMAN_SHARED_NO_SELF_REFERENCE: &str = "No self-reference. Do not name or announce the style (no \"caveman mode\", no \"me caveman think\", no \"compressed mode active\"). Just respond.";
@@ -176,7 +177,28 @@ fn apply_rtk_system_injection(body: &mut Value, settings: &Settings) -> bool {
         .filter(|s| !s.trim().is_empty())
         .map(|s| s.to_string());
     match prompt {
-        Some(p) => inject_system_prompt(body, &p),
+        Some(p) => {
+            // Dispatch by body shape (9router injectSystemPrompt format switch):
+            // Claude → body.system; Gemini → systemInstruction/request;
+            // else OpenAI messages/input/instructions.
+            let format = if body.get("system").is_some() {
+                "claude"
+            } else if body.get("systemInstruction").is_some()
+                || body.get("system_instruction").is_some()
+                || body
+                    .get("request")
+                    .map(|r| {
+                        r.get("systemInstruction").is_some()
+                            || r.get("system_instruction").is_some()
+                    })
+                    .unwrap_or(false)
+            {
+                "gemini"
+            } else {
+                "openai"
+            };
+            inject_system_prompt(body, format, &p)
+        }
         None => false,
     }
 }
@@ -1104,11 +1126,23 @@ mod tests {
             let p = level.prompt();
             assert!(p.contains("keep exact"), "boundaries in {level:?}");
             assert!(p.contains("No self-reference"), "no-self-ref in {level:?}");
-            assert!(p.contains("No decorative emoji"), "no-decoration in {level:?}");
-            assert!(p.contains("Preserve the user's dominant language"), "language in {level:?}");
-            assert!(p.contains("No invented abbreviations"), "abbrev in {level:?}");
+            assert!(
+                p.contains("No decorative emoji"),
+                "no-decoration in {level:?}"
+            );
+            assert!(
+                p.contains("Preserve the user's dominant language"),
+                "language in {level:?}"
+            );
+            assert!(
+                p.contains("No invented abbreviations"),
+                "abbrev in {level:?}"
+            );
             assert!(p.contains("Auto-Clarity"), "auto-clarity in {level:?}");
-            assert!(p.contains("ACTIVE EVERY RESPONSE"), "persistence in {level:?}");
+            assert!(
+                p.contains("ACTIVE EVERY RESPONSE"),
+                "persistence in {level:?}"
+            );
         }
         // Full contains the literal JS example.
         let full = CompressionLevel::Full.prompt();

--- a/src/core/rtk/system_inject.rs
+++ b/src/core/rtk/system_inject.rs
@@ -1,40 +1,142 @@
 use serde_json::Value;
 
-/// Inject a system prompt into the OpenAI-shaped request body.
+const SEP: &str = "\n\n";
+
+/// Inject a system prompt into the request body, dispatching by format.
+/// 9router systemInject.js `injectSystemPrompt(body, format, prompt)`.
 ///
-/// Prepends to the `messages` array if no system message exists,
-/// appends to the content of the existing system message otherwise.
+/// - `"claude"` → `body.system` (string or array, inserted before the last
+///   cache_control block).
+/// - `"gemini"` / `"gemini-cli"` / `"vertex"` / `"antigravity"` →
+///   `body.systemInstruction` / `body.request.systemInstruction` (`{parts:[{text}]}`).
+/// - Everything else (OpenAI chat / Responses / codex / cursor / kiro /
+///   ollama) → `messages[]` / `input[]` / `instructions`.
+///
 /// Returns `true` if the body was modified.
-pub fn inject_system_prompt(body: &mut Value, prompt: &str) -> bool {
+pub fn inject_system_prompt(body: &mut Value, format: &str, prompt: &str) -> bool {
     if prompt.trim().is_empty() {
         return false;
     }
+    match format {
+        "claude" => inject_claude_system(body, prompt),
+        "gemini" | "gemini-cli" | "vertex" | "antigravity" => inject_gemini_system(body, prompt),
+        _ => inject_messages_system(body, prompt),
+    }
+}
 
-    let Some(messages) = body.get_mut("messages").and_then(Value::as_array_mut) else {
+/// OpenAI-shaped: `messages[]` (chat) or `input[]` (responses) or
+/// `instructions` (responses top-level string). 9router injectMessagesSystem.
+fn inject_messages_system(body: &mut Value, prompt: &str) -> bool {
+    // OpenAI Responses API: top-level string field.
+    if let Some(Value::String(instructions)) = body.get_mut("instructions") {
+        if !instructions.is_empty() {
+            instructions.push_str(SEP);
+        }
+        instructions.push_str(prompt);
+        return true;
+    }
+
+    let arr = if body.get("messages").is_some() {
+        body.get_mut("messages").and_then(Value::as_array_mut)
+    } else {
+        body.get_mut("input").and_then(Value::as_array_mut)
+    };
+    let Some(arr) = arr else {
         return false;
     };
 
-    if let Some(sys_msg) = messages
-        .iter_mut()
-        .find(|m| m.get("role").and_then(Value::as_str) == Some("system"))
-    {
-        match sys_msg.get_mut("content") {
-            Some(Value::String(content)) => {
-                if !content.is_empty() {
-                    content.push_str("\n\n");
-                }
-                content.push_str(prompt);
-                true
-            }
-            _ => false,
+    let idx = arr.iter().position(|m| {
+        let role = m.get("role").and_then(Value::as_str).unwrap_or("");
+        role == "system" || role == "developer"
+    });
+    match idx {
+        Some(i) => append_to_openai_message(&mut arr[i], prompt),
+        None => {
+            arr.insert(
+                0,
+                serde_json::json!({ "role": "system", "content": prompt }),
+            );
+            true
         }
-    } else {
-        messages.insert(
-            0,
-            serde_json::json!({ "role": "system", "content": prompt }),
-        );
-        true
     }
+}
+
+/// Append a prompt to an OpenAI message (string content, array of parts, or
+/// replace). 9router appendToOpenAIMessage.
+fn append_to_openai_message(msg: &mut Value, prompt: &str) -> bool {
+    match msg.get_mut("content") {
+        Some(Value::String(content)) => {
+            if !content.is_empty() {
+                content.push_str(SEP);
+            }
+            content.push_str(prompt);
+            true
+        }
+        Some(Value::Array(parts)) => {
+            parts.push(serde_json::json!({ "type": "input_text", "text": prompt }));
+            true
+        }
+        _ => {
+            msg["content"] = Value::String(prompt.to_string());
+            true
+        }
+    }
+}
+
+/// Claude shape: `body.system` as string or array of `{type:"text",text}`.
+/// Insert before the last cache_control block to keep injection inside the
+/// cached prefix. 9router injectClaudeSystem.
+fn inject_claude_system(body: &mut Value, prompt: &str) -> bool {
+    match body.get_mut("system") {
+        Some(Value::String(content)) => {
+            if !content.is_empty() {
+                content.push_str(SEP);
+            }
+            content.push_str(prompt);
+            true
+        }
+        Some(Value::Array(blocks)) => {
+            let block = serde_json::json!({ "type": "text", "text": prompt });
+            let last_cache = blocks
+                .iter()
+                .rposition(|b| b.get("cache_control").is_some());
+            match last_cache {
+                Some(i) => blocks.insert(i, block),
+                None => blocks.push(block),
+            }
+            true
+        }
+        _ => {
+            body["system"] = Value::String(prompt.to_string());
+            true
+        }
+    }
+}
+
+/// Gemini shape: `body.system_instruction` / `body.systemInstruction` /
+/// `body.request.systemInstruction` as `{ parts: [{ text }] }`.
+/// 9router injectGeminiSystem.
+fn inject_gemini_system(body: &mut Value, prompt: &str) -> bool {
+    let target = if body.get("request").map(Value::is_object).unwrap_or(false) {
+        body.get_mut("request").unwrap()
+    } else {
+        body
+    };
+    let use_snake = target.get("system_instruction").is_some();
+    let key = if use_snake {
+        "system_instruction"
+    } else {
+        "systemInstruction"
+    };
+    let sys = target.get_mut(key);
+    if let Some(sys) = sys {
+        if let Some(parts) = sys.get_mut("parts").and_then(Value::as_array_mut) {
+            parts.push(serde_json::json!({ "text": prompt }));
+            return true;
+        }
+    }
+    target[key] = serde_json::json!({ "parts": [{ "text": prompt }] });
+    true
 }
 
 /// Check if system injection is enabled in a raw JSON config value.
@@ -61,6 +163,7 @@ mod tests {
         });
         assert!(inject_system_prompt(
             &mut body,
+            "openai",
             "You are a helpful assistant."
         ));
         let messages = body["messages"].as_array().unwrap();
@@ -78,7 +181,11 @@ mod tests {
                 { "role": "user", "content": "Hi" }
             ]
         });
-        assert!(inject_system_prompt(&mut body, "Additional instruction."));
+        assert!(inject_system_prompt(
+            &mut body,
+            "openai",
+            "Additional instruction."
+        ));
         let content = body["messages"][0]["content"].as_str().unwrap();
         assert!(content.starts_with("Existing rules"));
         assert!(content.contains("Additional instruction."));
@@ -92,14 +199,14 @@ mod tests {
                 { "role": "user", "content": "Hello" }
             ]
         });
-        assert!(!inject_system_prompt(&mut body, ""));
-        assert!(!inject_system_prompt(&mut body, "   "));
+        assert!(!inject_system_prompt(&mut body, "openai", ""));
+        assert!(!inject_system_prompt(&mut body, "openai", "   "));
     }
 
     #[test]
     fn no_modification_when_no_messages_array() {
         let mut body = json!({ "model": "gpt-4" });
-        assert!(!inject_system_prompt(&mut body, "test"));
+        assert!(!inject_system_prompt(&mut body, "openai", "test"));
     }
 
     #[test]
@@ -125,11 +232,74 @@ mod tests {
                 { "role": "assistant", "content": "Response" }
             ]
         });
-        assert!(inject_system_prompt(&mut body, "System prompt."));
+        assert!(inject_system_prompt(&mut body, "openai", "System prompt."));
         let messages = body["messages"].as_array().unwrap();
         assert_eq!(messages[0]["role"], "system");
         assert_eq!(messages[0]["content"], "System prompt.");
         assert_eq!(messages[1]["role"], "user");
         assert_eq!(messages[2]["role"], "assistant");
+    }
+
+    #[test]
+    fn claude_system_string_appends() {
+        let mut body = json!({ "system": "Base rules", "messages": [] });
+        assert!(inject_system_prompt(&mut body, "claude", "Extra."));
+        assert_eq!(body["system"], "Base rules\n\nExtra.");
+    }
+
+    #[test]
+    fn claude_system_array_inserts_before_cache_control() {
+        let mut body = json!({
+            "system": [
+                { "type": "text", "text": "cached" },
+                { "type": "text", "text": "after", "cache_control": { "type": "ephemeral" } }
+            ]
+        });
+        assert!(inject_system_prompt(&mut body, "claude", "Injected."));
+        let blocks = body["system"].as_array().unwrap();
+        assert_eq!(blocks.len(), 3);
+        // Injected block sits before the cache_control block.
+        assert_eq!(blocks[1]["text"], "Injected.");
+        assert!(blocks[2]["cache_control"].is_object());
+    }
+
+    #[test]
+    fn gemini_system_instruction_parts() {
+        let mut body = json!({ "systemInstruction": { "parts": [{ "text": "a" }] } });
+        assert!(inject_system_prompt(&mut body, "gemini", "b"));
+        let parts = body["systemInstruction"]["parts"].as_array().unwrap();
+        assert_eq!(parts.len(), 2);
+        assert_eq!(parts[1]["text"], "b");
+    }
+
+    #[test]
+    fn gemini_request_wrapped_system_instruction() {
+        let mut body =
+            json!({ "request": { "systemInstruction": { "parts": [{ "text": "a" }] } } });
+        assert!(inject_system_prompt(&mut body, "gemini", "b"));
+        let parts = body["request"]["systemInstruction"]["parts"]
+            .as_array()
+            .unwrap();
+        assert_eq!(parts.len(), 2);
+    }
+
+    #[test]
+    fn responses_instructions_string() {
+        let mut body = json!({ "instructions": "Be terse", "input": [] });
+        assert!(inject_system_prompt(&mut body, "openai", "Also helpful."));
+        assert_eq!(body["instructions"], "Be terse\n\nAlso helpful.");
+    }
+
+    #[test]
+    fn responses_input_array_appends_to_developer() {
+        let mut body = json!({
+            "input": [
+                { "role": "developer", "content": [ { "type": "input_text", "text": "a" } ] }
+            ]
+        });
+        assert!(inject_system_prompt(&mut body, "openai", "b"));
+        let parts = body["input"][0]["content"].as_array().unwrap();
+        assert_eq!(parts.len(), 2);
+        assert_eq!(parts[1]["text"], "b");
     }
 }


### PR DESCRIPTION
## Summary
Ports 9router `systemInject.js` `injectSystemPrompt` format dispatch (`P1-B1`).

### Changes
1. **`inject_system_prompt(body, format, prompt)`** — dispatch by format:
   - `claude` → `body.system` (string concat, or array insert before last `cache_control` block)
   - `gemini`/`gemini-cli`/`vertex`/`antigravity` → `systemInstruction`/`request.systemInstruction` (`{parts:[{text}]}`)
   - default → `messages[]`/`input[]`/`instructions` (Responses)
2. **`inject_messages_system`** — handles `instructions` string, `messages[]` or `input[]`, appends to system/developer message or unshifts.
3. **Call sites** (`rtk/mod.rs`, `chat/mod.rs`) — dispatch by body shape.

### Guard tests
`claude_system_string_appends`, `claude_system_array_inserts_before_cache_control`, `gemini_system_instruction_parts`, `gemini_request_wrapped_system_instruction`, `responses_instructions_string`, `responses_input_array_appends_to_developer` ✅. 12 system_inject tests green; no new failures.