### PR TITLE
fix(build): resolve sha2 0.11 + hmac 0.12 digest incompatibility

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -310,7 +310,7 @@ dependencies = [
  "bytes",
  "form_urlencoded",
  "hex",
- "hmac 0.13.0",
+ "hmac",
  "http 0.2.12",
  "http 1.4.2",
  "percent-encoding",
@@ -486,7 +486,7 @@ checksum = "24ae5479c93d3720e4c1dbd6b945b97457c50cb672781104768190371df1a905"
 dependencies = [
  "base64",
  "blowfish",
- "getrandom 0.4.2",
+ "getrandom 0.4.3",
  "subtle",
  "zeroize",
 ]
@@ -988,7 +988,6 @@ dependencies = [
  "block-buffer 0.10.4",
  "const-oid 0.9.6",
  "crypto-common 0.1.7",
- "subtle",
 ]
 
 [[package]]
@@ -1365,7 +1364,7 @@ version = "0.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
 dependencies = [
- "foldhash 0.2.0",
+ "foldhash",
 ]
 
 [[package]]
@@ -1394,15 +1393,6 @@ name = "hex"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
-
-[[package]]
-name = "hmac"
-version = "0.12.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c49c37c09c17a53d937dfbb742eb3a961d65a994e6bcdcf37e7399d0cc8ab5e"
-dependencies = [
- "digest 0.10.7",
-]
 
 [[package]]
 name = "hmac"
@@ -2314,7 +2304,7 @@ dependencies = [
  "fnv",
  "futures-util",
  "hex",
- "hmac 0.12.1",
+ "hmac",
  "http-body-util",
  "hyper",
  "hyper-rustls",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -54,7 +54,7 @@ tracing-subscriber = { version = "0.3", features = ["env-filter", "json"] }
 arc-swap = "1"
 
 # Crypto
-hmac = "0.12"
+hmac = "0.13"
 sha2 = "0.11"
 hex = "0.4"
 base64 = "0.22"

--- a/src/core/auth/mod.rs
+++ b/src/core/auth/mod.rs
@@ -2,7 +2,7 @@ pub mod cline_auth;
 pub mod credential_manager;
 pub mod machine_id;
 
-use hmac::{Hmac, Mac};
+use hmac::{Hmac, KeyInit, Mac};
 use rand::Rng;
 use sha2::Sha256;
 use std::path::PathBuf;

--- a/src/core/executor/iflow.rs
+++ b/src/core/executor/iflow.rs
@@ -1,6 +1,6 @@
 use std::sync::Arc;
 
-use hmac::{Hmac, Mac};
+use hmac::{Hmac, KeyInit, Mac};
 use reqwest::header::{HeaderMap, HeaderValue, ACCEPT, AUTHORIZATION, CONTENT_TYPE};
 use serde_json::Value;
 use sha2::Sha256;

--- a/src/core/executor/kiro.rs
+++ b/src/core/executor/kiro.rs
@@ -700,7 +700,7 @@ impl KiroExecutor {
         content_hash: &str,
         _stream: bool,
     ) -> Result<HeaderMap, KiroExecutorError> {
-        use hmac::{Hmac, Mac};
+        use hmac::{Hmac, KeyInit, Mac};
         use sha2::Sha256;
 
         type HmacSha256 = Hmac<Sha256>;

--- a/src/core/media/tts/aws_polly.rs
+++ b/src/core/media/tts/aws_polly.rs
@@ -19,7 +19,7 @@
 use async_trait::async_trait;
 use base64::Engine as _;
 use chrono::Utc;
-use hmac::{Hmac, Mac};
+use hmac::{Hmac, KeyInit, Mac};
 use reqwest::header::{HeaderMap, HeaderValue, AUTHORIZATION, CONTENT_TYPE, HOST};
 use reqwest::Client;
 use serde_json::json;

--- a/src/db/sqlite/import.rs
+++ b/src/db/sqlite/import.rs
@@ -208,11 +208,11 @@ fn import_all(conn: &Connection, payload: &Value) -> rusqlite::Result<usize> {
 
     let count = conn
         .query_row("SELECT COUNT(*) FROM providerConnections", [], |row| {
-            row.get(0)
+            row.get::<_, i64>(0)
         })
         .unwrap_or(0);
 
-    Ok(count)
+    Ok(count as usize)
 }
 
 fn import_usage_impl(conn: &Connection, payload: &Value) -> rusqlite::Result<usize> {

--- a/src/main.rs
+++ b/src/main.rs
@@ -561,7 +561,7 @@ fn spawn_usage_retention_cleanup(db: Arc<Db>) {
             let cutoff = (chrono::Utc::now() - chrono::Duration::days(30)).to_rfc3339();
             // Prune usageHistory
             match db.sqlite.with_conn(|conn| {
-                let count: u64 = conn
+                let count: i64 = conn
                     .query_row(
                         "SELECT COUNT(*) FROM usageHistory WHERE timestamp < ?1",
                         [&cutoff],
@@ -587,7 +587,7 @@ fn spawn_usage_retention_cleanup(db: Arc<Db>) {
             }
             // Prune requestDetails
             match db.sqlite.with_conn(|conn| {
-                let count: u64 = conn
+                let count: i64 = conn
                     .query_row(
                         "SELECT COUNT(*) FROM requestDetails WHERE timestamp < ?1",
                         [&cutoff],
@@ -616,7 +616,7 @@ fn spawn_usage_retention_cleanup(db: Arc<Db>) {
                 .format("%Y-%m-%d")
                 .to_string();
             match db.sqlite.with_conn(|conn| {
-                let count: u64 = conn
+                let count: i64 = conn
                     .query_row(
                         "SELECT COUNT(*) FROM usageDaily WHERE dateKey < ?1",
                         [&daily_cutoff],


### PR DESCRIPTION
## Problem

origin/main does not compile. Cargo.toml pins `sha2 = 0.11` (digest 0.11) but `hmac = 0.12` (digest 0.10), so `Hmac<Sha256>` fails to resolve in 4 files:

- `src/core/auth/mod.rs`
- `src/core/executor/iflow.rs`
- `src/core/executor/kiro.rs`
- `src/core/media/tts/aws_polly.rs`

The break came from Renovate PR #28 (`sha2 0.10.9 → 0.11.0`) without bumping hmac. This blocks ALL `cargo build` / `cargo test` / parity work.

## Fix

- Bump `hmac 0.12 → 0.13` (supports digest 0.11 / sha2 0.11)
- Import `KeyInit` alongside `Hmac`/`Mac` — `new_from_slice` moved to `KeyInit` in digest 0.11 / hmac 0.13
- rusqlite 0.40 dropped `FromSql` for `usize`/`u64`: fix `COUNT(*)` reads in `db/sqlite/import.rs` (`usize` → `i64` + cast) and `main.rs` retention (`u64` → `i64`)

## Verification

- `cargo build` clean
- `cargo test --lib` = 1593 passed / 3 failed (the 3 are pre-existing Windows-only `/bin/sh` path failures, unrelated to this change)