### PR TITLE
fix(media): require auth on get_elevenlabs_voices (bead 9m2)

### DIFF
--- a/src/server/api/media_providers.rs
+++ b/src/server/api/media_providers.rs
@@ -929,8 +929,15 @@ async fn get_edge_tts_voices_impl(lang_filter: Option<&str>) -> axum::response::
 /// GET /api/media-providers/tts/elevenlabs/voices
 async fn get_elevenlabs_voices(
     State(state): State<AppState>,
+    headers: axum::http::HeaderMap,
     Query(query): Query<TtsVoiceQuery>,
 ) -> axum::response::Response {
+    // Reads the stored ElevenLabs API key from the DB — require auth like the
+    // sibling voice handlers (get_tts_voices / get_minimax_voices /
+    // get_inworld_voices). Previously unauthenticated (audit H13).
+    if let Err(e) = require_api_key(&headers, &state.db) {
+        return crate::server::api::auth_error_response(e);
+    }
     let snapshot = state.db.snapshot();
     let api_key = snapshot
         .provider_connections


### PR DESCRIPTION
## Problem

`GET /api/media-providers/tts/elevenlabs/voices` read the stored ElevenLabs API key from the DB and listed voices with **no authentication**. Its sibling handlers (`get_tts_voices`, `get_minimax_voices`, `get_inworld_voices`) all call `require_api_key`, but this one was missed (audit H13).

## Fix

Add `require_api_key` at handler entry, matching the established pattern used by the sibling voice handlers. Any caller that legitimately needs this endpoint already authenticates (dashboard session or API key).

## Verification

- `cargo check` clean
- `cargo test --test cli_m5_robot_envelopes media` = 4 passed