### PR TITLE
fix(auth): dashboard password reset takes effect immediately + banner on first boot

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -310,7 +310,7 @@ dependencies = [
  "bytes",
  "form_urlencoded",
  "hex",
- "hmac 0.13.0",
+ "hmac",
  "http 0.2.12",
  "http 1.4.2",
  "percent-encoding",
@@ -486,7 +486,7 @@ checksum = "24ae5479c93d3720e4c1dbd6b945b97457c50cb672781104768190371df1a905"
 dependencies = [
  "base64",
  "blowfish",
- "getrandom 0.4.2",
+ "getrandom 0.4.3",
  "subtle",
  "zeroize",
 ]
@@ -988,7 +988,6 @@ dependencies = [
  "block-buffer 0.10.4",
  "const-oid 0.9.6",
  "crypto-common 0.1.7",
- "subtle",
 ]
 
 [[package]]
@@ -1365,7 +1364,7 @@ version = "0.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
 dependencies = [
- "foldhash 0.2.0",
+ "foldhash",
 ]
 
 [[package]]
@@ -1394,15 +1393,6 @@ name = "hex"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
-
-[[package]]
-name = "hmac"
-version = "0.12.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c49c37c09c17a53d937dfbb742eb3a961d65a994e6bcdcf37e7399d0cc8ab5e"
-dependencies = [
- "digest 0.10.7",
-]
 
 [[package]]
 name = "hmac"
@@ -2314,7 +2304,7 @@ dependencies = [
  "fnv",
  "futures-util",
  "hex",
- "hmac 0.12.1",
+ "hmac",
  "http-body-util",
  "hyper",
  "hyper-rustls",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -54,7 +54,7 @@ tracing-subscriber = { version = "0.3", features = ["env-filter", "json"] }
 arc-swap = "1"
 
 # Crypto
-hmac = "0.12"
+hmac = "0.13"
 sha2 = "0.11"
 hex = "0.4"
 base64 = "0.22"

--- a/src/core/auth/mod.rs
+++ b/src/core/auth/mod.rs
@@ -2,7 +2,7 @@ pub mod cline_auth;
 pub mod credential_manager;
 pub mod machine_id;
 
-use hmac::{Hmac, Mac};
+use hmac::{Hmac, KeyInit, Mac};
 use rand::Rng;
 use sha2::Sha256;
 use std::path::PathBuf;

--- a/src/core/auth/mod.rs
+++ b/src/core/auth/mod.rs
@@ -104,14 +104,14 @@ fn generate_random_password() -> String {
 
 /// Resolves the dashboard initial password.
 ///
-/// Resolution order (cached for the process lifetime):
+/// Resolution order:
 /// 1. `INITIAL_PASSWORD` environment variable, when set.
 /// 2. A per-install random password persisted at `$DATA_DIR/initial_password`.
 ///    Generated on first use so there is never a well-known default; the
 ///    persisted value keeps the same password valid across restarts until
-///    the operator sets a real one (see [`dashboard_password_is_ephemeral`]).
+///    the operator sets a real one or runs `openproxy auth reset-password`.
 /// Pure resolution: env var wins, then the persisted generated password,
-/// then a fresh random one. Testable without the process-wide cache.
+/// then a fresh random one.
 fn resolve_dashboard_initial_password(env: Option<&str>, path: &std::path::Path) -> String {
     if let Some(v) = env {
         if !v.trim().is_empty() {
@@ -126,26 +126,29 @@ fn resolve_dashboard_initial_password(env: Option<&str>, path: &std::path::Path)
     fresh
 }
 
+/// Resolves the dashboard initial password.
+///
+/// Reads from disk on every call (no process-wide cache) so that:
+/// - `openproxy auth reset-password` from another process takes effect
+///   immediately on the running server (a cached value would keep the old,
+///   possibly leaked password valid until restart);
+/// - a fresh install mints the password exactly once and the startup banner
+///   can display it on first boot.
 pub fn dashboard_initial_password() -> String {
-    static PASSWORD: OnceLock<String> = OnceLock::new();
-    PASSWORD
-        .get_or_init(|| {
-            resolve_dashboard_initial_password(
-                std::env::var("INITIAL_PASSWORD").ok().as_deref(),
-                &initial_password_path(),
-            )
-        })
-        .clone()
+    resolve_dashboard_initial_password(
+        std::env::var("INITIAL_PASSWORD").ok().as_deref(),
+        &initial_password_path(),
+    )
 }
 
-/// True when the dashboard is using the generated initial password rather
-/// than an operator-set `INITIAL_PASSWORD` or a stored bcrypt hash.
-///
-/// Used to (a) surface the password in the startup banner so it can be
-/// discovered exactly once, and (b) decide whether the operator can reset
-/// it back to a freshly generated value.
+/// True when the dashboard is NOT using an operator-set `INITIAL_PASSWORD`
+/// env var. Combined with "no stored bcrypt hash" (see
+/// [`has_stored_password_hash`]), this identifies a fresh install running on
+/// the generated initial password — i.e. the password is "ephemeral": minted
+/// on first use, replaced once the operator sets a real one, and resettable
+/// via `openproxy auth reset-password`.
 pub fn dashboard_password_is_ephemeral() -> bool {
-    std::env::var("INITIAL_PASSWORD").is_err() && initial_password_path().exists()
+    std::env::var("INITIAL_PASSWORD").is_err()
 }
 
 /// Delete the persisted generated password so the next boot generates a
@@ -402,12 +405,34 @@ mod tests {
         std::env::remove_var("INITIAL_PASSWORD");
         std::env::set_var("DATA_DIR", temp.path());
 
-        // Persist directly: `dashboard_initial_password()` is OnceLock-cached
-        // process-wide, so a prior test's DATA_DIR would leak into this one.
+        // Persist directly so the reset target exists independent of any prior
+        // test's generated value.
         let secret = generate_random_secret();
         persist_secret_to(initial_password_path(), &secret);
         assert!(dashboard_password_is_ephemeral());
         assert!(reset_dashboard_initial_password());
+
+        std::env::remove_var("DATA_DIR");
+    }
+
+    #[test]
+    fn reset_takes_effect_immediately_no_cache() {
+        // Regression: `dashboard_initial_password()` used to cache the value
+        // in a process-wide OnceLock, so after `openproxy auth reset-password`
+        // the running server kept accepting the old (possibly leaked) password
+        // until restart. It must now read from disk on every call.
+        let _guard = ENV_LOCK.lock().unwrap();
+        let temp = tempfile::tempdir().expect("tempdir");
+        std::env::remove_var("INITIAL_PASSWORD");
+        std::env::set_var("DATA_DIR", temp.path());
+
+        let before = dashboard_initial_password();
+        assert!(reset_dashboard_initial_password());
+        let after = dashboard_initial_password();
+        assert_ne!(
+            before, after,
+            "reset must invalidate the previously generated password"
+        );
 
         std::env::remove_var("DATA_DIR");
     }

--- a/src/core/executor/iflow.rs
+++ b/src/core/executor/iflow.rs
@@ -1,6 +1,6 @@
 use std::sync::Arc;
 
-use hmac::{Hmac, Mac};
+use hmac::{Hmac, KeyInit, Mac};
 use reqwest::header::{HeaderMap, HeaderValue, ACCEPT, AUTHORIZATION, CONTENT_TYPE};
 use serde_json::Value;
 use sha2::Sha256;

--- a/src/core/executor/kiro.rs
+++ b/src/core/executor/kiro.rs
@@ -700,7 +700,7 @@ impl KiroExecutor {
         content_hash: &str,
         _stream: bool,
     ) -> Result<HeaderMap, KiroExecutorError> {
-        use hmac::{Hmac, Mac};
+        use hmac::{Hmac, KeyInit, Mac};
         use sha2::Sha256;
 
         type HmacSha256 = Hmac<Sha256>;

--- a/src/core/media/tts/aws_polly.rs
+++ b/src/core/media/tts/aws_polly.rs
@@ -19,7 +19,7 @@
 use async_trait::async_trait;
 use base64::Engine as _;
 use chrono::Utc;
-use hmac::{Hmac, Mac};
+use hmac::{Hmac, KeyInit, Mac};
 use reqwest::header::{HeaderMap, HeaderValue, AUTHORIZATION, CONTENT_TYPE, HOST};
 use reqwest::Client;
 use serde_json::json;

--- a/src/db/sqlite/import.rs
+++ b/src/db/sqlite/import.rs
@@ -208,11 +208,11 @@ fn import_all(conn: &Connection, payload: &Value) -> rusqlite::Result<usize> {
 
     let count = conn
         .query_row("SELECT COUNT(*) FROM providerConnections", [], |row| {
-            row.get(0)
+            row.get::<_, i64>(0)
         })
         .unwrap_or(0);
 
-    Ok(count)
+    Ok(count as usize)
 }
 
 fn import_usage_impl(conn: &Connection, payload: &Value) -> rusqlite::Result<usize> {

--- a/src/main.rs
+++ b/src/main.rs
@@ -561,7 +561,7 @@ fn spawn_usage_retention_cleanup(db: Arc<Db>) {
             let cutoff = (chrono::Utc::now() - chrono::Duration::days(30)).to_rfc3339();
             // Prune usageHistory
             match db.sqlite.with_conn(|conn| {
-                let count: u64 = conn
+                let count: i64 = conn
                     .query_row(
                         "SELECT COUNT(*) FROM usageHistory WHERE timestamp < ?1",
                         [&cutoff],
@@ -587,7 +587,7 @@ fn spawn_usage_retention_cleanup(db: Arc<Db>) {
             }
             // Prune requestDetails
             match db.sqlite.with_conn(|conn| {
-                let count: u64 = conn
+                let count: i64 = conn
                     .query_row(
                         "SELECT COUNT(*) FROM requestDetails WHERE timestamp < ?1",
                         [&cutoff],
@@ -616,7 +616,7 @@ fn spawn_usage_retention_cleanup(db: Arc<Db>) {
                 .format("%Y-%m-%d")
                 .to_string();
             match db.sqlite.with_conn(|conn| {
-                let count: u64 = conn
+                let count: i64 = conn
                     .query_row(
                         "SELECT COUNT(*) FROM usageDaily WHERE dateKey < ?1",
                         [&daily_cutoff],


### PR DESCRIPTION
## Problem

Follow-up to merged t31 (PR #372). Two bugs remain in `src/core/auth/mod.rs`:

1. **Reset defeated by cache** — `dashboard_initial_password()` caches the value in a process-wide `OnceLock`. After `openproxy auth reset-password` deletes the file, the running server keeps accepting the old (possibly leaked) password until restart. The reset escape hatch is ineffective.

2. **First-boot banner never fires** — `dashboard_password_is_ephemeral()` returns `env-unset && file-exists`. On a fresh install the password file doesn't exist yet, so the startup banner guard is false on first boot and the 'shown only once' password is never displayed.

## Fix

- `dashboard_initial_password()` reads from disk on every call (no `OnceLock` cache — login is not a hot path)
- `dashboard_password_is_ephemeral()` = `INITIAL_PASSWORD` env unset only
- Add regression test `reset_takes_effect_immediately_no_cache` proving reset invalidates the old password immediately

## Note

This branch is based on `bead/qslx-hmac-build` (PR #376, the build fix). Once #376 merges, this PR's diff against main shrinks to just the auth fix.

## Verification

- `cargo check` clean
- `cargo test --lib core::auth` = 29 passed
- Full lib suite: 1593 passed / 4 failed (pre-existing Windows `/bin/sh` + catalog alias failures, unrelated)