### PR TITLE
fix(executor): codex parity — instructions, include gating, image prefetch, SSE peek retry, usage_limit parse (bead .38)

### DIFF
--- a/src/core/executor/codex.rs
+++ b/src/core/executor/codex.rs
@@ -1,6 +1,8 @@
 use std::sync::Arc;
 use std::time::Duration;
 
+use futures_util::stream;
+use futures_util::StreamExt;
 use hyper::http;
 use hyper::http::uri::InvalidUri;
 use reqwest::header::{HeaderMap, HeaderValue, AUTHORIZATION, CONTENT_TYPE};
@@ -13,6 +15,27 @@ use crate::types::{ProviderConnection, ProviderNode};
 use super::{ClientPool, TransportKind, UpstreamResponse};
 
 const CODEX_RESPONSES_URL: &str = "https://chatgpt.com/backend-api/codex/responses";
+
+/// SSE peek size (256 KiB) — ported from JS `CODEX_SSE_PEEK_BYTES`.
+const CODEX_SSE_PEEK_BYTES: usize = 256 * 1024;
+
+/// Transient-overload patterns that trigger a retry (JS `CODEX_SSE_RETRY_PATTERNS`).
+const CODEX_SSE_RETRY_PATTERNS: &[&str] = &["server_is_overloaded", "service_unavailable_error"];
+
+/// Account-fallback patterns → 503 with the capacity message (JS `CODEX_SSE_ACCOUNT_FALLBACK_PATTERNS`).
+const CODEX_SSE_ACCOUNT_FALLBACK_PATTERNS: &[&str] =
+    &["selected model is at capacity", "model_at_capacity"];
+
+/// Patterns that indicate real user output has started → stop peeking (JS `CODEX_SSE_USER_OUTPUT_PATTERNS`).
+const CODEX_SSE_USER_OUTPUT_PATTERNS: &[&str] = &[
+    "event: response.output_text.delta",
+    "event: response.function_call_arguments.delta",
+    "\"type\":\"response.output_text.delta\"",
+    "\"type\":\"response.function_call_arguments.delta\"",
+];
+
+const CODEX_MODEL_CAPACITY_MESSAGE: &str =
+    "Selected model is at capacity. Please try a different model.";
 
 #[derive(Clone)]
 #[allow(dead_code)]
@@ -209,8 +232,9 @@ impl CodexExecutor {
     }
 
     /// Default instructions injected when none are present in the request body.
-    const DEFAULT_CODEX_INSTRUCTIONS: &'static str =
-        "You are a highly capable coding agent. Use the tools and instructions provided to fulfill the user's request.";
+    /// Verbatim port of 9router `open-sse/config/codexInstructions.js`
+    /// `CODEX_DEFAULT_INSTRUCTIONS` (JS backtick-escaped `` \` `` → plain backticks).
+    const DEFAULT_CODEX_INSTRUCTIONS: &'static str = "You are Codex, based on GPT-5. You are running as a coding agent in the Codex CLI on a user's computer.\n\n## General\n\n- When searching for text or files, prefer using `rg` or `rg --files` respectively because `rg` is much faster than alternatives like `grep`. (If the `rg` command is not found, then use alternatives.)\n\n## Editing constraints\n\n- Default to ASCII when editing or creating files. Only introduce non-ASCII or other Unicode characters when there is a clear justification and the file already uses them.\n- Add succinct code comments that explain what is going on if code is not self-explanatory. You should not add comments like \"Assigns the value to the variable\", but a brief comment might be useful ahead of a complex code block that the user would otherwise have to spend time parsing out. Usage of these comments should be rare.\n- Try to use apply_patch for single file edits, but it is fine to explore other options to make the edit if it does not work well. Do not use apply_patch for changes that are auto-generated (i.e. generating package.json or running a lint or format command like gofmt) or when scripting is more efficient (such as search and replacing a string across a codebase).\n- You may be in a dirty git worktree.\n    * NEVER revert existing changes you did not make unless explicitly requested, since these changes were made by the user.\n    * If asked to make a commit or code edits and there are unrelated changes to your work or changes that you didn't make in those files, don't revert those changes.\n    * If the changes are in files you've touched recently, you should read carefully and understand how you can work with the changes rather than reverting them.\n    * If the changes are in unrelated files, just ignore them and don't revert them.\n- Do not amend a commit unless explicitly requested to do so.\n- While you are working, you might notice unexpected changes that you didn't make. If this happens, STOP IMMEDIATELY and ask the user how they would like to proceed.\n- **NEVER** use destructive commands like `git reset --hard` or `git checkout --` unless specifically requested or approved by the user.\n\n## Plan tool\n\nWhen using the planning tool:\n- Skip using the planning tool for straightforward tasks (roughly the easiest 25%).\n- Do not make single-step plans.\n- When you made a plan, update it after having performed one of the sub-tasks that you shared on the plan.\n\n## Codex CLI harness, sandboxing, and approvals\n\nThe Codex CLI harness supports several different configurations for sandboxing and escalation approvals that the user can choose from.\n\nFilesystem sandboxing defines which files can be read or written. The options for `sandbox_mode` are:\n- **read-only**: The sandbox only permits reading files.\n- **workspace-write**: The sandbox permits reading files, and editing files in `cwd` and `writable_roots`. Editing files in other directories requires approval.\n- **danger-full-access**: No filesystem sandboxing - all commands are permitted.\n\nNetwork sandboxing defines whether network can be accessed without approval. Options for `network_access` are:\n- **restricted**: Requires approval\n- **enabled**: No approval needed\n\nApprovals are your mechanism to get user consent to run shell commands without the sandbox. Possible configuration options for `approval_policy` are\n- **untrusted**: The harness will escalate most commands for user approval, apart from a limited allowlist of safe \"read\" commands.\n- **on-failure**: The harness will allow all commands to run in the sandbox (if enabled), and failures will be escalated to the user for approval to run again without the sandbox.\n- **on-request**: Commands will be run in the sandbox by default, and you can specify in your tool call if you want to escalate a command to run without sandboxing. (Note that this mode is not always available. If it is, you'll see parameters for it in the `shell` command description.)\n- **never**: This is a non-interactive mode where you may NEVER ask the user for approval to run commands. Instead, you must always persist and work around constraints to solve the task for the user. You MUST do your utmost best to finish the task and validate your work before yielding. If this mode is paired with `danger-full-access`, take advantage of it to deliver the best outcome for the user. Further, in this mode, your default testing philosophy is overridden: Even if you don't see local patterns for testing, you may add tests and scripts to validate your work. Just remove them before yielding.\n\nWhen you are running with `approval_policy == on-request`, and sandboxing enabled, here are scenarios where you'll need to request approval:\n- You need to run a command that writes to a directory that requires it (e.g. running tests that write to /var)\n- You need to run a GUI app (e.g., open/xdg-open/osascript) to open browsers or files.\n- You are running sandboxed and need to run a command that requires network access (e.g. installing packages)\n- If you run a command that is important to solving the user's query, but it fails because of sandboxing, rerun the command with approval. ALWAYS proceed to use the `sandbox_permissions` and `justification` parameters - do not message the user before requesting approval for the command.\n- You are about to take a potentially destructive action such as an `rm` or `git reset` that the user did not explicitly ask for\n- (for all of these, you should weigh alternative paths that do not require approval)\n\nWhen `sandbox_mode` is set to read-only, you'll need to request approval for any command that isn't a read.\n\nYou will be told what filesystem sandboxing, network sandboxing, and approval mode are active in a developer or user message. If you are not told about this, assume that you are running with workspace-write, network sandboxing enabled, and approval on-failure.\n\nAlthough they introduce friction to the user because your work is paused until the user responds, you should leverage them when necessary to accomplish important work. If the completing the task requires escalated permissions, Do not let these settings or the sandbox deter you from attempting to accomplish the user's task unless it is set to \"never\", in which case never ask for approvals.\n\nWhen requesting approval to execute a command that will require escalated privileges:\n  - Provide the `sandbox_permissions` parameter with the value `\"require_escalated\"`\n  - Include a short, 1 sentence explanation for why you need escalated permissions in the justification parameter\n\n## Special user requests\n\n- If the user makes a simple request (such as asking for the time) which you can fulfill by running a terminal command (such as `date`), you should do so.\n- If the user asks for a \"review\", default to a code review mindset: prioritise identifying bugs, risks, behavioural regressions, and missing tests. Findings must be the primary focus of the response - keep summaries or overviews brief and only after enumerating the issues. Present findings first (ordered by severity with file/line references), follow with open questions or assumptions, and offer a change-summary only as a secondary detail. If no findings are discovered, state that explicitly and mention any residual risks or testing gaps.\n\n## Frontend tasks\nWhen doing frontend design tasks, avoid collapsing into \"AI slop\" or safe, average-looking layouts.\nAim for interfaces that feel intentional, bold, and a bit surprising.\n- Typography: Use expressive, purposeful fonts and avoid default stacks (Inter, Roboto, Arial, system).\n- Color & Look: Choose a clear visual direction; define CSS variables; avoid purple-on-white defaults. No purple bias or dark mode bias.\n- Motion: Use a few meaningful animations (page-load, staggered reveals) instead of generic micro-motions.\n- Background: Don't rely on flat, single-color backgrounds; use gradients, shapes, or subtle patterns to build atmosphere.\n- Overall: Avoid boilerplate layouts and interchangeable UI patterns. Vary themes, type families, and visual languages across outputs.\n- Ensure the page loads properly on both desktop and mobile\n\nException: If working within an existing website or design system, preserve the established patterns, structure, and visual language.\n\n## Presenting your work and final message\n\nYou are producing plain text that will later be styled by the CLI. Follow these rules exactly. Formatting should make results easy to scan, but not feel mechanical. Use judgment to decide how much structure adds value.\n\n- Default: be very concise; friendly coding teammate tone.\n- Ask only when needed; suggest ideas; mirror the user's style.\n- For substantial work, summarize clearly; follow final-answer formatting.\n- Skip heavy formatting for simple confirmations.\n- Don't dump large files you've written; reference paths only.\n- No \"save/copy this file\" - User is on the same machine.\n- Offer logical next steps (tests, commits, build) briefly; add verify steps if you couldn't do something.\n- For code changes:\n  * Lead with a quick explanation of the change, and then give more details on the context covering where and why a change was made. Do not start this explanation with \"summary\", just jump right in.\n  * If there are natural next steps the user may want to take, suggest them at the end of your response. Do not make suggestions if there are no natural next steps.\n  * When suggesting multiple options, use numeric lists for the suggestions so the user can quickly respond with a single number.\n- The user does not command execution outputs. When asked to show the output of a command (e.g. `git show`), relay the important details in your answer or summarize the key lines so the user understands the result.\n\n### Final answer structure and style guidelines\n\n- Plain text; CLI handles styling. Use structure only when it helps scanability.\n- Headers: optional; short Title Case (1-3 words) wrapped in **…**; no blank line before the first bullet; add only if they truly help.\n- Bullets: use - ; merge related points; keep to one line when possible; 4–6 per list ordered by importance; keep phrasing consistent.\n- Monospace: backticks for commands/paths/env vars/code ids and inline examples; use for literal keyword bullets; never combine with **.\n- Code samples or multi-line snippets should be wrapped in fenced code blocks; include an info string as often as possible.\n- Structure: group related bullets; order sections general → specific → supporting; for subsections, start with a bolded keyword bullet, then items; match complexity to the task.\n- Tone: collaborative, concise, factual; present tense, active voice; self-contained; no \"above/below\"; parallel wording.\n- Don'ts: no nested bullets/hierarchies; no ANSI codes; don't cram unrelated keywords; keep keyword lists short—wrap/reformat if long; avoid naming formatting styles in answers.\n- Adaptation: code explanations → precise, structured with code refs; simple tasks → lead with outcome; big changes → logical walkthrough + rationale + next actions; casual one-offs → plain sentences, no headers/bullets.\n- File References: When referencing files in your response follow the below rules:\n  * Use inline code to make file paths clickable.\n  * Each reference should have a stand alone path. Even if it's the same file.\n  * Accepted: absolute, workspace-relative, a/ or b/ diff prefixes, or bare filename/suffix.\n  * Optionally include line/column (1-based): :line[:column] or #Lline[Ccolumn] (column defaults to 1).\n  * Do not use URIs like file://, vscode://, or https://.\n  * Do not provide range of lines\n  * Examples: src/app.ts, src/app.ts:42, b/server/index.js#L10, C:\\repo\\project\\main.rs:12:5";
 
     /// Transform the request body from Chat Completions format to Codex Responses API format.
     ///
@@ -296,11 +320,43 @@ impl CodexExecutor {
         if let Some(tool_choice) = body.get("tool_choice") {
             request_body["tool_choice"] = tool_choice.clone();
         }
-        if let Some(include) = body.get("include") {
-            request_body["include"] = include.clone();
+
+        // Include reasoning encrypted content — Codex backend requires this for
+        // reasoning models. JS: `if effort !== "none" → body.include =
+        // ["reasoning.encrypted_content"]` (codex.js:457-459). Overwrite any
+        // client-supplied include per JS.
+        if effort != "none" {
+            request_body["include"] = json!(["reasoning.encrypted_content"]);
         }
-        if let Some(prompt_cache_key) = body.get("prompt_cache_key") {
-            request_body["prompt_cache_key"] = prompt_cache_key.clone();
+
+        // Inject prompt_cache_key for stable Codex prompt caching when the
+        // caller didn't supply one (JS codex.js:426-428).
+        let cache_session = body
+            .get("prompt_cache_key")
+            .and_then(Value::as_str)
+            .filter(|s| !s.is_empty())
+            .map(|s| s.to_string())
+            .or_else(|| {
+                body.get("input")
+                    .and_then(Value::as_array)
+                    .and_then(|a| a.first())
+                    .and_then(|item| item.get("session_id"))
+                    .and_then(Value::as_str)
+                    .map(|s| s.to_string())
+            });
+        if let Some(ck) = cache_session {
+            request_body["prompt_cache_key"] = Value::String(ck);
+        }
+
+        // service_tier mapping: "fast" → "priority", delete other non-priority
+        // (JS codex.js:480-481).
+        if let Some(tier) = body.get("service_tier").and_then(Value::as_str) {
+            if tier == "fast" {
+                request_body["service_tier"] = Value::String("priority".to_string());
+            } else if tier == "priority" {
+                request_body["service_tier"] = Value::String("priority".to_string());
+            }
+            // else: dropped (not carried into request_body)
         }
 
         Ok(request_body)
@@ -414,9 +470,114 @@ impl CodexExecutor {
         Ok(items)
     }
 
+    /// Prefetch remote `image_url` content parts into `input_image` parts with
+    /// inline base64 data URIs. Mirrors JS `prefetchImages` (codex.js:241-256):
+    /// `data:` URLs pass through directly; remote URLs are fetched (15s timeout).
+    async fn prefetch_images(&self, body: &mut Value) {
+        let Some(input) = body.get_mut("input").and_then(Value::as_array_mut) else {
+            return;
+        };
+        for item in input.iter_mut() {
+            let Some(content) = item.get_mut("content").and_then(Value::as_array_mut) else {
+                continue;
+            };
+            for part in content.iter_mut() {
+                let Some(obj) = part.as_object_mut() else {
+                    continue;
+                };
+                if obj.get("type").and_then(Value::as_str) != Some("image_url") {
+                    continue;
+                }
+                let url = obj
+                    .get("image_url")
+                    .and_then(|v| match v {
+                        Value::String(s) => Some(s.clone()),
+                        Value::Object(o) => o.get("url").and_then(Value::as_str).map(String::from),
+                        _ => None,
+                    })
+                    .unwrap_or_default();
+                if url.is_empty() {
+                    continue;
+                }
+                let detail = obj
+                    .get("image_url")
+                    .and_then(|v| v.get("detail"))
+                    .and_then(Value::as_str)
+                    .unwrap_or("auto")
+                    .to_string();
+                let image_url = if url.starts_with("data:") {
+                    url
+                } else {
+                    // Remote URL: fetch and inline as base64 data URI.
+                    let client = reqwest::Client::new();
+                    match crate::core::translator::helpers::image_helper::fetch_image_as_base64(
+                        &client, &url,
+                    )
+                    .await
+                    {
+                        Some(fetched) => fetched.data_url,
+                        None => url,
+                    }
+                };
+                let _ = obj.insert("type".into(), Value::String("input_image".to_string()));
+                let _ = obj.insert("image_url".into(), Value::String(image_url));
+                let _ = obj.insert("detail".into(), Value::String(detail));
+            }
+        }
+    }
+
+    /// Parse a Codex upstream error, mapping `usage_limit_reached` to a
+    /// resetsAtMs (JS `parseError`, codex.js:365-387).
+    pub fn parse_error(status: u16, body_text: &str) -> crate::core::utils::error::UpstreamError {
+        if status == 429 && !body_text.is_empty() {
+            if let Ok(v) = serde_json::from_str::<Value>(body_text) {
+                let err = v.get("error");
+                if err.and_then(|e| e.get("type")).and_then(Value::as_str)
+                    == Some("usage_limit_reached")
+                {
+                    let now_ms = std::time::SystemTime::now()
+                        .duration_since(std::time::UNIX_EPOCH)
+                        .map(|d| d.as_millis() as u64)
+                        .unwrap_or(0);
+                    let mut resets_at_ms = None;
+                    if let Some(secs) = err.and_then(|e| e.get("resets_at")).and_then(Value::as_u64)
+                    {
+                        let ms = secs * 1000;
+                        if ms > now_ms {
+                            resets_at_ms = Some(ms);
+                        }
+                    }
+                    if resets_at_ms.is_none() {
+                        if let Some(secs) = err
+                            .and_then(|e| e.get("resets_in_seconds"))
+                            .and_then(Value::as_u64)
+                        {
+                            resets_at_ms = Some(now_ms + secs * 1000);
+                        }
+                    }
+                    let message = err
+                        .and_then(|e| e.get("message"))
+                        .and_then(Value::as_str)
+                        .unwrap_or(body_text)
+                        .to_string();
+                    return crate::core::utils::error::UpstreamError {
+                        status: 429,
+                        message,
+                        resets_at_ms,
+                    };
+                }
+            }
+        }
+        crate::core::utils::error::UpstreamError {
+            status,
+            message: crate::core::utils::error::friendly_error_message(status, body_text),
+            resets_at_ms: None,
+        }
+    }
+
     pub async fn execute(
         &self,
-        request: CodexExecutionRequest,
+        mut request: CodexExecutionRequest,
     ) -> Result<CodexExecutorResponse, CodexExecutorError> {
         let actual_model = Self::parse_codex_model(&request.model);
         let url = self.build_url(&actual_model);
@@ -439,13 +600,24 @@ impl CodexExecutor {
             .or(request.credentials.display_name.as_deref());
         // Always stream upstream (9router force stream); client JSON via chat sse_to_json
         let headers = self.build_headers(api_key, true, connection_id, &request.credentials)?;
+
+        // Prefetch remote images into inline base64 data URIs (JS prefetchImages).
+        if let Some(input) = request.body.get("input") {
+            if input
+                .as_array()
+                .is_some_and(|arr| arr.iter().any(|it| it.get("content").is_some()))
+            {
+                self.prefetch_images(&mut request.body).await;
+            }
+        }
+
         let transformed_body = self.transform_request_body(&request.body, &actual_model, true)?;
 
         let client = self.pool.get("openai", request.proxy.as_ref())?;
 
-        // Retry up to 3 times with exponential backoff when the response
-        // body (first 4096 bytes) contains "server_is_overloaded" or
-        // "service_unavailable_error" (transient overload errors inside 200 OK).
+        // SSE-level transient-error retry (JS execute/_peekSseTransientError,
+        // codex.js:258-362). Retries on server_is_overloaded /
+        // service_unavailable_error; account-fallback → 503 capacity message.
         const MAX_RETRIES: usize = 3;
         for attempt in 0..MAX_RETRIES {
             let resp = client
@@ -459,27 +631,107 @@ impl CodexExecutor {
             let status = resp.status();
             let resp_headers = resp.headers().clone();
 
-            // Read the full body so we can inspect it for overload errors
-            // and then reconstruct the response downstream.
-            let body_bytes = resp.bytes().await?;
+            // Stream-peek the first ≤256 KiB of the SSE body.
+            let stream = resp.bytes_stream();
+            let mut chunks: Vec<bytes::Bytes> = Vec::new();
+            let mut text = String::new();
+            let mut matched: Option<&str> = None;
+            let mut account_fallback = false;
+            let mut pinned = stream;
+            let mut total = 0usize;
+            while total < CODEX_SSE_PEEK_BYTES {
+                match pinned.next().await {
+                    Some(Ok(chunk)) => {
+                        total += chunk.len();
+                        chunks.push(chunk.clone());
+                        text.push_str(&String::from_utf8_lossy(&chunk));
+                        let lower = text.to_lowercase();
+                        let account_hit = CODEX_SSE_ACCOUNT_FALLBACK_PATTERNS
+                            .iter()
+                            .find(|p| lower.contains(**p));
+                        if let Some(hit) = account_hit {
+                            matched = Some(hit);
+                            account_fallback = true;
+                            break;
+                        }
+                        let retry_hit = CODEX_SSE_RETRY_PATTERNS
+                            .iter()
+                            .find(|p| lower.contains(**p));
+                        if let Some(hit) = retry_hit {
+                            matched = Some(hit);
+                            break;
+                        }
+                        if CODEX_SSE_USER_OUTPUT_PATTERNS
+                            .iter()
+                            .any(|p| lower.contains(*p))
+                        {
+                            break;
+                        }
+                    }
+                    Some(Err(_)) | None => break,
+                }
+            }
 
-            // Peek at the first 4096 bytes for overload indicators,
-            // but only when we still have retries remaining.
-            if attempt + 1 < MAX_RETRIES {
-                let peek_end = body_bytes.len().min(4096);
-                let head_str = String::from_utf8_lossy(&body_bytes[..peek_end]);
-                if head_str.contains("server_is_overloaded")
-                    || head_str.contains("service_unavailable_error")
-                {
+            if let Some(_hit) = matched {
+                if account_fallback {
+                    // Return 503 with the exact capacity message for downstream
+                    // account fallback matching.
+                    let err_body = json!({
+                        "error": {
+                            "message": CODEX_MODEL_CAPACITY_MESSAGE,
+                            "type": "server_error",
+                            "code": "service_unavailable",
+                        }
+                    });
+                    let bytes = serde_json::to_vec(&err_body).unwrap_or_default();
+                    let mut http_resp = http::Response::new(ReqwestBody::from(bytes));
+                    *http_resp.status_mut() = reqwest::StatusCode::SERVICE_UNAVAILABLE;
+                    http_resp.headers_mut().insert(
+                        reqwest::header::CONTENT_TYPE,
+                        HeaderValue::from_static("application/json"),
+                    );
+                    return Ok(CodexExecutorResponse {
+                        response: UpstreamResponse::Reqwest(reqwest::Response::from(http_resp)),
+                        url,
+                        headers,
+                        transformed_body,
+                        transport: TransportKind::Reqwest,
+                    });
+                }
+                if attempt + 1 < MAX_RETRIES {
                     let delay = Duration::from_millis(500 * 2u64.pow(attempt as u32));
                     tokio::time::sleep(delay).await;
                     continue;
                 }
+                let err_body = json!({
+                    "error": {
+                        "message": matched.unwrap_or("server_is_overloaded"),
+                        "type": "server_error",
+                        "code": "service_unavailable",
+                    }
+                });
+                let bytes = serde_json::to_vec(&err_body).unwrap_or_default();
+                let mut http_resp = http::Response::new(ReqwestBody::from(bytes));
+                *http_resp.status_mut() = reqwest::StatusCode::SERVICE_UNAVAILABLE;
+                http_resp.headers_mut().insert(
+                    reqwest::header::CONTENT_TYPE,
+                    HeaderValue::from_static("application/json"),
+                );
+                return Ok(CodexExecutorResponse {
+                    response: UpstreamResponse::Reqwest(reqwest::Response::from(http_resp)),
+                    url,
+                    headers,
+                    transformed_body,
+                    transport: TransportKind::Reqwest,
+                });
             }
 
-            // Reconstruct the reqwest::Response from its parts so the body
-            // remains available for downstream consumers (bytes_stream / text / bytes).
-            let mut http_resp = http::Response::new(ReqwestBody::from(body_bytes));
+            // No transient error matched → re-assemble a live stream from the
+            // peeked prefix chunks + the remaining upstream body so SSE flows.
+            // Both sides must yield `Result<Bytes, reqwest::Error>`.
+            let prefix = stream::iter(chunks).map(Ok::<_, reqwest::Error>);
+            let combined = prefix.chain(pinned);
+            let mut http_resp = http::Response::new(ReqwestBody::wrap_stream(combined));
             *http_resp.status_mut() = status;
             *http_resp.headers_mut() = resp_headers;
             let reconstructed = reqwest::Response::from(http_resp);
@@ -755,5 +1007,96 @@ mod tests {
             url,
             "https://chatgpt.com/backend-api/codex/responses/compact"
         );
+    }
+
+    #[test]
+    fn test_codex_instructions_matches_js() {
+        // Guard test: DEFAULT_CODEX_INSTRUCTIONS must be the full JS prompt,
+        // not the old one-liner.
+        assert!(
+            CodexExecutor::DEFAULT_CODEX_INSTRUCTIONS
+                .starts_with("You are Codex, based on GPT-5. You are running as a coding agent"),
+            "instructions must match the JS default (codexInstructions.js)"
+        );
+        assert!(
+            CodexExecutor::DEFAULT_CODEX_INSTRUCTIONS.contains("## Editing constraints"),
+            "instructions should include the full multi-section prompt"
+        );
+        assert!(
+            CodexExecutor::DEFAULT_CODEX_INSTRUCTIONS.contains("## Plan tool"),
+            "instructions should include the Plan tool section"
+        );
+    }
+
+    #[test]
+    fn test_codex_include_reasoning_when_effort() {
+        let executor = CodexExecutor::new(Arc::new(ClientPool::new()), None).unwrap();
+
+        // effort high → include == ["reasoning.encrypted_content"]
+        let body = json!({
+            "messages": [{ "role": "user", "content": "hi" }],
+            "reasoning": { "effort": "high" },
+            "model": "codex/o4-mini"
+        });
+        let out = executor
+            .transform_request_body(&body, "o4-mini", false)
+            .unwrap();
+        assert_eq!(out["include"], json!(["reasoning.encrypted_content"]));
+
+        // effort none → NO include
+        let body = json!({
+            "messages": [{ "role": "user", "content": "hi" }],
+            "reasoning": { "effort": "none" },
+            "model": "codex/o4-mini"
+        });
+        let out = executor
+            .transform_request_body(&body, "o4-mini", false)
+            .unwrap();
+        assert!(
+            out.get("include").is_none(),
+            "no include when effort is none"
+        );
+    }
+
+    #[test]
+    fn test_codex_service_tier_mapping() {
+        let executor = CodexExecutor::new(Arc::new(ClientPool::new()), None).unwrap();
+
+        // fast → priority
+        let body = json!({
+            "messages": [{ "role": "user", "content": "hi" }],
+            "service_tier": "fast",
+            "model": "codex/o4-mini"
+        });
+        let out = executor
+            .transform_request_body(&body, "o4-mini", false)
+            .unwrap();
+        assert_eq!(out["service_tier"], "priority");
+
+        // non-priority, non-fast → dropped
+        let body = json!({
+            "messages": [{ "role": "user", "content": "hi" }],
+            "service_tier": "flexible",
+            "model": "codex/o4-mini"
+        });
+        let out = executor
+            .transform_request_body(&body, "o4-mini", false)
+            .unwrap();
+        assert!(out.get("service_tier").is_none());
+    }
+
+    #[test]
+    fn test_codex_parse_error_usage_limit_reached() {
+        // resets_at is in seconds since epoch; use a far-future value.
+        let body = json!({
+            "error": { "type": "usage_limit_reached", "message": "Limit hit", "resets_at": 4_100_000_000u64 }
+        });
+        let err = CodexExecutor::parse_error(429, &body.to_string());
+        assert_eq!(err.status, 429);
+        assert!(
+            err.resets_at_ms.is_some(),
+            "resets_at_ms should be populated"
+        );
+        assert_eq!(err.message, "Limit hit");
     }
 }


### PR DESCRIPTION
## Problem

The Rust codex executor diverged from `open-sse/executors/codex.js` in 6 ways:

1. **Instructions** — one-liner vs the full multi-section JS prompt.
2. **include gating** — never injected `reasoning.encrypted_content` (required by Codex backend).
3. **prefetchImages** — no image prefetch.
4. **SSE peek retry (CRITICAL)** — `execute()` read the ENTIRE body via `resp.bytes().await?`, breaking SSE streaming.
5. **usage_limit_reached** — `resets_at_ms` always `None`.
6. **service_tier** — no fast→priority mapping.

## Fix

1. Full `CODEX_DEFAULT_INSTRUCTIONS` (verbatim port of `codexInstructions.js`).
2. `include = ["reasoning.encrypted_content"]` when `effort != "none"`.
3. `prefetch_images`: `image_url` → `input_image` with inline base64 data URI (data: short-circuits, remote fetched via `fetch_image_as_base64`).
4. **SSE peek retry**: stream-peek ≤256 KiB for transient-error patterns (`server_is_overloaded`/`service_unavailable_error` → retry; account-fallback → 503 capacity message), then re-assemble a **live stream** from peeked prefix + remaining upstream body (SSE now flows instead of being fully buffered).
5. `parse_error`: 429 `usage_limit_reached` → `resetsAtMs` from `resets_at`/`resets_in_seconds`.
6. `service_tier`: `fast`→`priority`, other non-priority dropped.

## Verification

- 18 codex tests pass (4 new: instructions-matches-js, include-reasoning-when-effort, service_tier mapping, usage_limit_reached parse)
- `cargo test --lib` = 1633 passed / pre-existing failures only (3 Windows `/bin/sh` + flaky catalog/env-race)
- `cargo fmt` clean

Closes bead `openproxy-9router-parity-v0550-pnc.38`.