### PR TITLE
feat(media): search query sanitization — control chars, NFKC, whitespace collapse (bead .77)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2424,6 +2424,7 @@ dependencies = [
  "tower-http",
  "tracing",
  "tracing-subscriber",
+ "unicode-normalization",
  "url",
  "urlencoding",
  "uuid",
@@ -3888,6 +3889,15 @@ name = "unicode-ident"
 version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
+
+[[package]]
+name = "unicode-normalization"
+version = "0.1.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5fd4f6878c9cb28d874b009da9e8d183b5abc80117c40bbd187a1fde336be6e8"
+dependencies = [
+ "tinyvec",
+]
 
 [[package]]
 name = "universal-hash"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -65,6 +65,7 @@ subtle = "2"
 # URL / query
 url = "2"
 urlencoding = "2"
+unicode-normalization = "0.1"
 serde_urlencoded = "0.7"
 
 # Time

--- a/src/core/media/search/base.rs
+++ b/src/core/media/search/base.rs
@@ -155,19 +155,39 @@ pub fn get_provider_setting(request: &SearchRequest<'_>, key: &str) -> Option<St
     }
 }
 
+/// Port of 9router `search/index.js sanitizeQuery` (index.js:17-25):
+/// reject control characters, NFKC-normalize, trim, and collapse whitespace.
+///
+/// The control-char set is NOT the full 0x00-0x1F range — tab (0x09), LF
+/// (0x0A), and CR (0x0D) are excluded (they're valid whitespace).
+pub fn sanitize_query(raw: &str) -> Result<String, String> {
+    let has_control_char = raw
+        .bytes()
+        .any(|b| matches!(b, 0x00..=0x08 | 0x0B | 0x0C | 0x0E..=0x1F | 0x7F));
+    if has_control_char {
+        return Err("Query contains invalid control characters".to_string());
+    }
+    let nfkc = unicode_normalization::UnicodeNormalization::nfkc(raw);
+    let normalized: String = nfkc.collect();
+    let clean: String = normalized.split_whitespace().collect::<Vec<_>>().join(" ");
+    if clean.is_empty() {
+        return Err("Query is empty after normalization".to_string());
+    }
+    Ok(clean)
+}
+
 /// Build a SearchRequest from credentials + JSON body. Useful when the
 /// caller has the inbound `/v1/search` request body in hand.
 pub fn request_from_body<'a>(
     body: &'a Value,
     credentials: Option<&'a ProviderConnection>,
 ) -> Result<SearchRequest<'a>, String> {
-    let query = body
+    let raw_query = body
         .get("query")
         .and_then(|v| v.as_str())
-        .map(str::trim)
         .filter(|s| !s.is_empty())
-        .ok_or_else(|| "Missing required field: query".to_string())?
-        .to_string();
+        .ok_or_else(|| "Missing required field: query".to_string())?;
+    let query = sanitize_query(raw_query)?;
     let search_type = SearchType::parse(body.get("search_type").and_then(|v| v.as_str()));
     let max_results = body
         .get("max_results")
@@ -342,5 +362,44 @@ mod tests {
         let body = serde_json::json!({"query": "x", "max_results": 1000});
         let r = request_from_body(&body, None).unwrap();
         assert_eq!(r.max_results, 100);
+    }
+
+    #[test]
+    fn search_query_rejects_control_chars() {
+        assert!(sanitize_query("hello\x07").is_err());
+        assert!(sanitize_query("\x00abc").is_err());
+        assert!(sanitize_query("a\x7fb").is_err());
+        // The error message mentions control characters.
+        assert!(sanitize_query("x\x01")
+            .unwrap_err()
+            .contains("control characters"));
+        // Tab / LF / CR are allowed (valid whitespace).
+        assert!(sanitize_query("a\tb").is_ok());
+        assert!(sanitize_query("a\nb").is_ok());
+    }
+
+    #[test]
+    fn search_query_collapses_whitespace() {
+        assert_eq!(sanitize_query("a  b").unwrap(), "a b");
+        assert_eq!(
+            sanitize_query("  leading and   trailing  ").unwrap(),
+            "leading and trailing"
+        );
+        // NFKC: full-width digits normalize to ASCII.
+        assert_eq!(sanitize_query("１２３").unwrap(), "123");
+        // Empty after normalization errors.
+        assert!(sanitize_query("   ")
+            .unwrap_err()
+            .contains("empty after normalization"));
+    }
+
+    #[test]
+    fn request_from_body_uses_sanitized_query() {
+        let body = serde_json::json!({"query": "a  b\tc"});
+        let r = request_from_body(&body, None).unwrap();
+        assert_eq!(r.query, "a b c");
+        // Control char → Err.
+        let body = serde_json::json!({"query": "bad\x07query"});
+        assert!(request_from_body(&body, None).is_err());
     }
 }


### PR DESCRIPTION
## Problem

`request_from_body` only did trim + non-empty. JS `search/index.js sanitizeQuery` (index.js:17-25) rejects control characters, NFKC-normalizes, trims, and collapses whitespace runs.

## Fix

1. `sanitize_query()` (base.rs): rejects control chars (0x00-0x08, 0x0B, 0x0C, 0x0E-0x1F, 0x7F — tab/LF/CR excluded as valid whitespace), NFKC-normalizes (new `unicode-normalization` dep), trims + collapses whitespace runs to a single space, errors on empty-after-normalization.
2. `request_from_body()` routes the query through `sanitize_query`.

## Guard tests

- `search_query_rejects_control_chars` (incl. tab/LF allowed)
- `search_query_collapses_whitespace` (incl. NFKC full-width→ASCII)
- `request_from_body_uses_sanitized_query`

## Verification

- 22 search tests pass; lib suite 1645 passed / pre-existing failures only (3 Windows `/bin/sh` + parallel env-race)
- `cargo fmt` clean

Closes bead `openproxy-9router-parity-v0550-pnc.77`.