### PR TITLE
fix(media): OpenRouter image/embedding referer headers match registry (bead .80)

### DIFF
--- a/src/core/media/embeddings/base.rs
+++ b/src/core/media/embeddings/base.rs
@@ -136,11 +136,13 @@ impl EmbeddingAdapter for OpenAiCompatAdapter {
             );
         }
         if self.include_referer {
+            // 9router parity (registry/openrouter.js:50-58): media endpoints
+            // use the endpoint-proxy.local referer, matching the chat path.
             headers.insert(
                 "HTTP-Referer",
-                HeaderValue::from_static("https://openproxy.local"),
+                HeaderValue::from_static("https://endpoint-proxy.local"),
             );
-            headers.insert("X-Title", HeaderValue::from_static("OpenProxy"));
+            headers.insert("X-Title", HeaderValue::from_static("Endpoint Proxy"));
         }
         Ok(headers)
     }
@@ -207,13 +209,16 @@ impl EmbeddingAdapter for SelfhostedEmbeddingAdapter {
             .provider_specific_data
             .get("baseUrl")
             .and_then(|v| v.as_str());
-        let raw = raw.map(str::trim).filter(|s| !s.is_empty()).ok_or_else(|| {
-            "Self-hosted Embedding needs an endpoint: set this connection's baseUrl \
+        let raw = raw
+            .map(str::trim)
+            .filter(|s| !s.is_empty())
+            .ok_or_else(|| {
+                "Self-hosted Embedding needs an endpoint: set this connection's baseUrl \
              to the OpenAI base URL of your server, e.g. http://host:8080/v1 (note \
              the /v1 — \"/embeddings\" is appended to it). Refusing to fall back to \
              api.openai.com, which would send your input and API key to OpenAI."
-                .to_string()
-        })?;
+                    .to_string()
+            })?;
         // JS order: strip a single trailing "/", then the "/embeddings" suffix.
         let trimmed = raw.trim_end_matches('/');
         let trimmed = trimmed.strip_suffix("/embeddings").unwrap_or(trimmed);
@@ -512,5 +517,26 @@ mod tests {
         };
         let err = SELFHOSTED_EMBEDDING.build_url(&req).unwrap_err();
         assert!(err.contains("needs an endpoint"));
+    }
+
+    #[test]
+    fn openrouter_embedding_referer_matches_registry() {
+        // 9router registry/openrouter.js:50-55 — endpoint-proxy.local referer.
+        let body = json!({"input": "hello"});
+        let creds = ProviderConnection::default();
+        let req = EmbeddingRequest {
+            body: &body,
+            model: "text-embedding-3-small",
+            credentials: &creds,
+        };
+        let headers = OPENROUTER.build_headers(&req).unwrap();
+        assert_eq!(
+            headers.get("HTTP-Referer").and_then(|v| v.to_str().ok()),
+            Some("https://endpoint-proxy.local")
+        );
+        assert_eq!(
+            headers.get("X-Title").and_then(|v| v.to_str().ok()),
+            Some("Endpoint Proxy")
+        );
     }
 }

--- a/src/core/media/image/openai_compat.rs
+++ b/src/core/media/image/openai_compat.rs
@@ -94,11 +94,13 @@ impl ImageAdapter for OpenAiCompatAdapter {
             );
         }
         if self.include_referer {
+            // 9router parity (registry/openrouter.js:50-58): media endpoints
+            // use the endpoint-proxy.local referer, matching the chat path.
             headers.insert(
                 "HTTP-Referer",
-                HeaderValue::from_static("https://openproxy.local"),
+                HeaderValue::from_static("https://endpoint-proxy.local"),
             );
-            headers.insert("X-Title", HeaderValue::from_static("OpenProxy"));
+            headers.insert("X-Title", HeaderValue::from_static("Endpoint Proxy"));
         }
         Ok(headers)
     }
@@ -148,9 +150,9 @@ impl ImageAdapter for OpenAiCompatAdapter {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use serde_json::json;
     use crate::core::media::image::base::ImageRequest;
     use crate::types::ProviderConnection;
+    use serde_json::json;
 
     fn xai_request() -> ImageRequest<'static> {
         let body = json!({
@@ -178,7 +180,10 @@ mod tests {
         assert!(obj.contains_key("n"));
         // xAI whitelist = [model, prompt, n, response_format] — size/quality/style dropped.
         assert!(!obj.contains_key("size"), "size must be dropped for xai");
-        assert!(!obj.contains_key("quality"), "quality must be dropped for xai");
+        assert!(
+            !obj.contains_key("quality"),
+            "quality must be dropped for xai"
+        );
         assert!(!obj.contains_key("style"), "style must be dropped for xai");
     }
 
@@ -194,7 +199,10 @@ mod tests {
         });
         req.body = Box::leak(Box::new(body));
         let out = XAI.build_body(&req).await.unwrap();
-        assert_eq!(out.get("response_format").and_then(|v| v.as_str()), Some("b64_json"));
+        assert_eq!(
+            out.get("response_format").and_then(|v| v.as_str()),
+            Some("b64_json")
+        );
     }
 
     #[tokio::test]
@@ -236,5 +244,26 @@ mod tests {
         );
         assert!(!VERCEL_AI_GATEWAY.include_referer);
         assert!(VERCEL_AI_GATEWAY.body_fields.is_empty());
+    }
+
+    #[test]
+    fn openrouter_image_referer_matches_registry() {
+        // 9router registry/openrouter.js:56-59 — endpoint-proxy.local referer.
+        let body = json!({"prompt": "cat", "model": "dall-e-3"});
+        let creds = ProviderConnection::default();
+        let req = ImageRequest {
+            body: &body,
+            model: "dall-e-3",
+            credentials: &creds,
+        };
+        let headers = OPENROUTER.build_headers(&req, &body).unwrap();
+        assert_eq!(
+            headers.get("HTTP-Referer").and_then(|v| v.to_str().ok()),
+            Some("https://endpoint-proxy.local")
+        );
+        assert_eq!(
+            headers.get("X-Title").and_then(|v| v.to_str().ok()),
+            Some("Endpoint Proxy")
+        );
     }
 }


### PR DESCRIPTION
## Problem

`registry/openrouter.js:50-58` uses `HTTP-Referer: https://endpoint-proxy.local` + `X-Title: Endpoint Proxy` for the embedding and image media endpoints. Rust used `openproxy.local`/`OpenProxy`.

## Fix

Change the `include_referer` header **values** (not names, not gating) in:
- `src/core/media/embeddings/base.rs` `OpenAiCompatAdapter::build_headers`
- `src/core/media/image/openai_compat.rs` `build_headers`

## Guard tests

- `openrouter_embedding_referer_matches_registry`
- `openrouter_image_referer_matches_registry`

## Verification

- 14 embeddings + 13 image tests pass; lib suite 1647 passed / pre-existing failures only (3 Windows `/bin/sh` + parallel env-race)
- `cargo fmt` clean

Closes bead `openproxy-9router-parity-v0550-pnc.80`.