### PR TITLE
fix(media): embeddings encoding_format empty-string coercion to float (bead .81)

### DIFF
--- a/src/core/media/embeddings/base.rs
+++ b/src/core/media/embeddings/base.rs
@@ -20,7 +20,13 @@ impl<'a> EmbeddingRequest<'a> {
     }
 
     pub fn encoding_format(&self) -> Option<&'a str> {
-        self.body.get("encoding_format").and_then(|v| v.as_str())
+        // JS embeddingsCore.js:52 `encoding_format: body.encoding_format || "float"`
+        // coerces an empty string to "float". Treat empty as None so the caller's
+        // `unwrap_or("float")` yields "float" for both absent and empty.
+        self.body
+            .get("encoding_format")
+            .and_then(|v| v.as_str())
+            .filter(|s| !s.is_empty())
     }
 
     pub fn dimensions(&self) -> Option<u64> {
@@ -449,6 +455,44 @@ mod tests {
         };
         let v = OPENAI.build_body(&req).unwrap();
         assert_eq!(v["dimensions"], 256);
+    }
+
+    #[test]
+    fn openai_embedding_encoding_format_matches_js_coercion() {
+        // JS embeddingsCore.js:52 `encoding_format: body.encoding_format || "float"`
+        // always sends encoding_format upstream (client value or "float").
+        // Rust mirrors that: absent → "float"; empty → "float"; value → value.
+        let creds = ProviderConnection::default();
+
+        // Absent → "float" (both JS and Rust).
+        let body = json!({"input": "hi"});
+        let req = EmbeddingRequest {
+            body: &body,
+            model: "x",
+            credentials: &creds,
+        };
+        let v = OPENAI.build_body(&req).unwrap();
+        assert_eq!(v["encoding_format"], "float");
+
+        // Empty string → coerced to "float" by JS `||`; Rust now treats it as None.
+        let body = json!({"input": "hi", "encoding_format": ""});
+        let req = EmbeddingRequest {
+            body: &body,
+            model: "x",
+            credentials: &creds,
+        };
+        let v = OPENAI.build_body(&req).unwrap();
+        assert_eq!(v["encoding_format"], "float");
+
+        // Explicit value passed through.
+        let body = json!({"input": "hi", "encoding_format": "base64"});
+        let req = EmbeddingRequest {
+            body: &body,
+            model: "x",
+            credentials: &creds,
+        };
+        let v = OPENAI.build_body(&req).unwrap();
+        assert_eq!(v["encoding_format"], "base64");
     }
 
     #[test]


### PR DESCRIPTION
## Problem

Bead .81 was **REFUTED** as a parity gap: JS `embeddingsCore.js:52` always passes `encoding_format = body.encoding_format || \"float\"` into the adapter, so JS always sends `encoding_format` upstream (client value or \"float\") — exactly like Rust's `unwrap_or(\"float\")`. The spec's proposed fix (omit when absent) would have **created** a reverse divergence.

**Real edge-case gap found:** an explicit empty `encoding_format: \"\"` — JS `||\"float\"` coerces it to \"float\", but Rust sent the empty string.

## Fix

`EmbeddingRequest::encoding_format()` now treats an empty string as `None`, so `build_body`'s `unwrap_or(\"float\")` yields \"float\" for both absent and empty — matching JS coercion.

## Guard test

`openai_embedding_encoding_format_matches_js_coercion`: absent → float, empty → float, value → value.

## Verification

- 15 embeddings tests pass; lib suite 1648 passed / pre-existing failures only (3 Windows `/bin/sh` + parallel env-race)
- `cargo fmt` clean

Closes bead `openproxy-9router-parity-v0550-pnc.81` (as REFUTED-with-edge-fix).