### PR TITLE
feat(media): searxng maxMaxResults=50 + youcom=100 clamp (bead .83)

### DIFF
--- a/src/core/media/search/base.rs
+++ b/src/core/media/search/base.rs
@@ -124,6 +124,12 @@ pub trait SearchProvider: Send + Sync {
     fn timeout_ms(&self) -> Option<u64> {
         None
     }
+
+    /// Per-provider maximum result count (9router registry `maxMaxResults`,
+    /// default 100). Applied after the request's max_results is resolved.
+    fn max_max_results(&self) -> u32 {
+        100
+    }
 }
 
 /// Split `domain_filter` into `(includes, excludes)` where excludes are

--- a/src/core/media/search/mod.rs
+++ b/src/core/media/search/mod.rs
@@ -26,10 +26,13 @@ pub async fn dispatch(
     body: &serde_json::Value,
 ) -> Option<Result<serde_json::Value, super::MediaError>> {
     let provider_impl = get_search_provider(provider)?;
-    let request = match base::request_from_body(body, Some(credentials)) {
+    let mut request = match base::request_from_body(body, Some(credentials)) {
         Ok(r) => r,
         Err(msg) => return Some(Err(super::MediaError::Validation(msg))),
     };
+    // 9router parity (registry maxMaxResults): clamp to the provider cap
+    // (searxng 50, youcom/default 100) after the default is resolved.
+    request.max_results = request.max_results.min(provider_impl.max_max_results());
     Some(
         handle_search(client, provider_impl, &request)
             .await

--- a/src/core/media/search/providers.rs
+++ b/src/core/media/search/providers.rs
@@ -924,6 +924,10 @@ impl SearchProvider for SearxngProvider {
         // 9router registry timeoutMs for searxng.
         Some(10_000)
     }
+    fn max_max_results(&self) -> u32 {
+        // 9router registry searxng.js maxMaxResults = 50.
+        50
+    }
     fn build_url(&self, request: &SearchRequest<'_>) -> Result<String, String> {
         // 9router: default URL comes from SEARXNG_URL env (default
         // http://localhost:8888/search).
@@ -1182,5 +1186,23 @@ mod tests {
             headers.get("X-API-Key").and_then(|v| v.to_str().ok()),
             Some("tok")
         );
+    }
+
+    #[test]
+    fn searxng_caps_max_results_at_50() {
+        // 9router registry searxng.js maxMaxResults = 50; youcom = 100.
+        assert_eq!(SEARXNG.max_max_results(), 50);
+        assert_eq!(YOUCOM.max_max_results(), 100);
+        assert_eq!(SERPER.max_max_results(), 100); // default
+
+        // A request with max_results 100 clamped to searxng's 50.
+        let mut r = req("query", 100);
+        r.max_results = r.max_results.min(SEARXNG.max_max_results());
+        assert_eq!(r.max_results, 50);
+
+        // youcom stays 100.
+        let mut y = req("query", 100);
+        y.max_results = y.max_results.min(YOUCOM.max_max_results());
+        assert_eq!(y.max_results, 100);
     }
 }


### PR DESCRIPTION
## Problem

Rust capped `max_results` at 100 universally. JS registry: searxng `maxMaxResults=50`, youcom `maxMaxResults=100`, default 100 (index.js:75 `min(max_results||default, maxMaxResults)`).

## Fix

1. `SearchProvider::max_max_results() -> u32` (default 100).
2. `SearxngProvider` overrides to 50 (timeout already 10s in Rust).
3. `dispatch` (search/mod.rs) clamps `request.max_results` to the provider cap after the default is resolved.

## Guard test

`searxng_caps_max_results_at_50`: searxng → 50, youcom → 100, serper → 100 (default).

## Verification

- 23 search tests pass; lib suite 1648 passed / pre-existing failures only (3 Windows `/bin/sh` + flaky catalog/env-race)
- `cargo fmt` clean

Closes bead `openproxy-9router-parity-v0550-pnc.83`.