### PR TITLE
feat(media): Gemini TTS prebuilt voices via voices endpoint (bead .84)

### DIFF
--- a/src/core/media/tts/gemini.rs
+++ b/src/core/media/tts/gemini.rs
@@ -23,6 +23,55 @@ const SAMPLE_RATE: u32 = 24_000;
 const CHANNELS: u16 = 1;
 const BITS_PER_SAMPLE: u16 = 16;
 
+/// The 30 Gemini prebuilt voices, ported verbatim from 9router
+/// `open-sse/handlers/ttsProviders/gemini.js` PREBUILT_VOICES (lines 93-124).
+/// Each maps to `{voice_id, name, labels:{language, gender}}` per
+/// `fetchGeminiVoices` (lines 126-128).
+pub fn gemini_voices() -> Vec<Value> {
+    const VOICES: &[(&str, &str)] = &[
+        ("Zephyr", "Female"),
+        ("Puck", "Male"),
+        ("Charon", "Male"),
+        ("Kore", "Female"),
+        ("Fenrir", "Male"),
+        ("Leda", "Female"),
+        ("Orus", "Male"),
+        ("Aoede", "Female"),
+        ("Callirrhoe", "Female"),
+        ("Autonoe", "Female"),
+        ("Enceladus", "Male"),
+        ("Iapetus", "Male"),
+        ("Umbriel", "Male"),
+        ("Algieba", "Male"),
+        ("Despina", "Female"),
+        ("Erinome", "Female"),
+        ("Algenib", "Male"),
+        ("Rasalgethi", "Male"),
+        ("Laomedeia", "Female"),
+        ("Achernar", "Female"),
+        ("Alnilam", "Male"),
+        ("Schedar", "Male"),
+        ("Gacrux", "Female"),
+        ("Pulcherrima", "Female"),
+        ("Achird", "Male"),
+        ("Zubenelgenubi", "Male"),
+        ("Vindemiatrix", "Female"),
+        ("Sadachbia", "Male"),
+        ("Sadaltager", "Male"),
+        ("Sulafat", "Female"),
+    ];
+    VOICES
+        .iter()
+        .map(|(id, gender)| {
+            json!({
+                "voice_id": id,
+                "name": id,
+                "labels": { "language": "en", "gender": gender },
+            })
+        })
+        .collect()
+}
+
 fn parse_model_voice(input: &str) -> (String, String) {
     if input.is_empty() {
         return (DEFAULT_MODEL.to_string(), DEFAULT_VOICE.to_string());
@@ -175,5 +224,32 @@ mod tests {
         let (model, voice) = parse_model_voice("Kore");
         assert_eq!(model, DEFAULT_MODEL);
         assert_eq!(voice, "Kore");
+    }
+
+    #[test]
+    fn gemini_voices_returns_30_prebuilt() {
+        let voices = gemini_voices();
+        assert_eq!(voices.len(), 30, "exactly 30 prebuilt voices");
+
+        let first = &voices[0];
+        assert_eq!(first["voice_id"], "Zephyr");
+        assert_eq!(first["name"], "Zephyr");
+        assert_eq!(first["labels"]["language"], "en");
+        assert_eq!(first["labels"]["gender"], "Female");
+
+        // Spot-check genders per the JS table.
+        let by_id: std::collections::HashMap<&str, &Value> = voices
+            .iter()
+            .map(|v| (v["voice_id"].as_str().unwrap(), v))
+            .collect();
+        assert_eq!(by_id["Kore"]["labels"]["gender"], "Female");
+        assert_eq!(by_id["Puck"]["labels"]["gender"], "Male");
+        assert_eq!(by_id["Sulafat"]["labels"]["gender"], "Female");
+        assert_eq!(by_id["Enceladus"]["labels"]["gender"], "Male");
+        for v in &voices {
+            assert_eq!(v["labels"]["language"], "en");
+            let g = v["labels"]["gender"].as_str().unwrap();
+            assert!(g == "Female" || g == "Male");
+        }
     }
 }

--- a/src/core/media/tts/mod.rs
+++ b/src/core/media/tts/mod.rs
@@ -13,7 +13,7 @@ mod aws_polly;
 pub mod base;
 mod edge_tts;
 mod elevenlabs;
-mod gemini;
+pub mod gemini;
 mod generic_formats;
 mod google_tts;
 pub mod handler;

--- a/src/server/api/media_providers.rs
+++ b/src/server/api/media_providers.rs
@@ -852,6 +852,12 @@ async fn get_tts_voices(
             }
         }
         "local-device" => Json(serde_json::json!({ "voices": [], "languages": [], "byLang": {} })).into_response(),
+        // Gemini prebuilt voices (9router fetchGeminiVoices) — static table.
+        "gemini" => {
+            let voices = crate::core::media::tts::gemini::gemini_voices();
+            let by_lang = serde_json::json!({ "en": { "voices": voices, "languages": [] } });
+            Json(serde_json::json!({ "voices": voices, "byLang": by_lang })).into_response()
+        }
         _ => (StatusCode::BAD_REQUEST, Json(serde_json::json!({ "error": format!("Provider '{}' does not support voice listing", provider) }))).into_response(),
     }
 }


### PR DESCRIPTION
## Problem

Rust's Gemini TTS adapter had no voice-list support. JS `open-sse/handlers/ttsProviders/gemini.js` exposes 30 prebuilt voices via `fetchGeminiVoices`.

## Fix

1. `gemini_voices() -> Vec<Value>` (`src/core/media/tts/gemini.rs`): the 30 prebuilt voices (`{voice_id, name, labels:{language:en, gender}}`), verbatim names/genders from the JS table.
2. Wire a `gemini` arm into `get_tts_voices` (`/api/media-providers/tts/voices`) returning the voices + `byLang` shape.
3. Make `tts::gemini` pub so the endpoint can call `gemini_voices()`.

## Guard test

`gemini_voices_returns_30_prebuilt`: 30 entries, Zephyr/Female, Kore/Female, Sulafat/Female, Enceladus/Male, all `labels.language=en`.

## Verification

- 3 gemini tts tests pass; lib suite 1648 passed / pre-existing failures only (grok_cli test is flaky in parallel, passes in isolation)
- `cargo fmt` clean

Closes bead `openproxy-9router-parity-v0550-pnc.84`.