### PR TITLE
test(media): jina-ai embedding endpoint regression test (bead .88)

### DIFF
--- a/src/core/media/embeddings/base.rs
+++ b/src/core/media/embeddings/base.rs
@@ -583,4 +583,23 @@ mod tests {
             Some("Endpoint Proxy")
         );
     }
+
+    #[test]
+    fn jina_embedding_endpoint_matches() {
+        // 9router embeddingProviders/openai.js ENDPOINTS: jina-ai →
+        // https://api.jina.ai/v1/embeddings (no override needed).
+        assert_eq!(JINA_AI.endpoint, "https://api.jina.ai/v1/embeddings");
+        // The adapter's build_url returns the endpoint verbatim.
+        let body = serde_json::json!({"input": "hi"});
+        let creds = ProviderConnection::default();
+        let req = EmbeddingRequest {
+            body: &body,
+            model: "jina-embeddings-v3",
+            credentials: &creds,
+        };
+        assert_eq!(
+            JINA_AI.build_url(&req).unwrap(),
+            "https://api.jina.ai/v1/embeddings"
+        );
+    }
 }


### PR DESCRIPTION
## Problem

Bead .88 asked for jina-ai embedding endpoint parity. Cross-check confirmed the endpoint **already matches** JS `ENDPOINTS` (https://api.jina.ai/v1/embeddings) — no production change needed. Gap was a regression test.

## Fix

`jina_embedding_endpoint_matches`: asserts `JINA_AI.endpoint` and `build_url` equal `https://api.jina.ai/v1/embeddings`.

## Verification

- embeddings suite green; lib suite 1657 passed / pre-existing failures only
- `cargo fmt` clean

Closes bead `openproxy-9router-parity-v0550-pnc.88`.