### PR TITLE
security: remove hardcoded OAuth client secrets, use env vars exclusively

### DIFF
--- a/src/oauth/secret.rs
+++ b/src/oauth/secret.rs
@@ -1,79 +1,100 @@
 //! OAuth client-secret resolution.
 //!
-//! Client secrets for OAuth providers are resolved from environment variables
-//! (e.g. `IFLOW_CLIENT_SECRET`) with a hardcoded fallback so existing flows
-//! keep working. Operators should set the env vars to rotate/revoke the
-//! bundled secrets. 9router tracks the same values; the fallbacks here mirror
-//! them so a fresh checkout works out of the box.
+//! Client secrets for OAuth providers are resolved **exclusively** from
+//! environment variables at runtime. No hardcoded fallback values are stored
+//! in the repository. Operators MUST set the appropriate environment variables
+//! before starting the server, otherwise OAuth flows for those providers will
+//! not be available.
+//!
+//! | Provider     | Environment variable            |
+//! |--------------|---------------------------------|
+//! | iFlow        | `IFLOW_CLIENT_SECRET`           |
+//! | Qoder        | `QODER_CLIENT_SECRET`           |
+//! | Antigravity  | `ANTIGRAVITY_CLIENT_SECRET`     |
+//! | Gemini       | `GEMINI_CLIENT_SECRET`          |
 
 use once_cell::sync::Lazy;
 use std::sync::Mutex;
 
-fn resolve(name: &str, fallback: &'static str) -> &'static str {
-    // Resolve once per name; the value is static for the process lifetime.
-    static CACHE: Lazy<Mutex<std::collections::HashMap<String, &'static str>>> =
-        Lazy::new(|| Mutex::new(std::collections::HashMap::new()));
-    let mut cache = CACHE.lock().unwrap_or_else(|p| p.into_inner());
+/// Resolution cache: resolved once per name, cached for the process lifetime.
+static CACHE: Lazy<Mutex<std::collections::HashMap<String, &'static str>>> =
+    Lazy::new(|| Mutex::new(std::collections::HashMap::new()));
+
+fn resolve(name: &str) -> &'static str {
+    let mut cache = CACHE.lock().unwrap();
     if let Some(v) = cache.get(name) {
         return *v;
     }
-    let value = std::env::var(name).unwrap_or_else(|_| fallback.to_string());
-    let leaked: &'static str = Box::leak(value.into_boxed_str());
+    let leaked: &'static str = Box::leak(std::env::var(name).unwrap_or_default().into_boxed_str());
     cache.insert(name.to_string(), leaked);
     leaked
 }
 
-/// iflow OAuth client secret (env `IFLOW_CLIENT_SECRET`).
+#[cfg(test)]
+fn clear_cache() {
+    let mut cache = CACHE.lock().unwrap();
+    cache.clear();
+}
+
+/// iFlow OAuth client secret (env `IFLOW_CLIENT_SECRET`).
 pub fn iflow_client_secret() -> &'static str {
-    resolve("IFLOW_CLIENT_SECRET", "4Z3YjXycVsQvyGF1etiNlIBB4RsqSDtW")
+    resolve("IFLOW_CLIENT_SECRET")
 }
 
-/// qoder OAuth client secret (env `QODER_CLIENT_SECRET`).
+/// Qoder OAuth client secret (env `QODER_CLIENT_SECRET`).
 pub fn qoder_client_secret() -> &'static str {
-    resolve("QODER_CLIENT_SECRET", "4Z3YjXycVsQvyGF1etiNlIBB4RsqSDtW")
+    resolve("QODER_CLIENT_SECRET")
 }
 
-/// antigravity OAuth client secret (env `ANTIGRAVITY_CLIENT_SECRET`).
+/// Antigravity OAuth client secret (env `ANTIGRAVITY_CLIENT_SECRET`).
 pub fn antigravity_client_secret() -> &'static str {
-    resolve(
-        "ANTIGRAVITY_CLIENT_SECRET",
-        "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",
-    )
+    resolve("ANTIGRAVITY_CLIENT_SECRET")
 }
 
-/// gemini-cli OAuth client secret (env `GEMINI_CLIENT_SECRET`).
+/// Gemini CLI OAuth client secret (env `GEMINI_CLIENT_SECRET`).
 pub fn gemini_cli_client_secret() -> &'static str {
-    resolve(
-        "GEMINI_CLIENT_SECRET",
-        "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",
-    )
+    resolve("GEMINI_CLIENT_SECRET")
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
 
+    /// Serialize tests that mutate global environment variables and the secret
+    /// cache to avoid cross-test interference when the lib test suite runs in
+    /// parallel.
+    static ENV_LOCK: Mutex<()> = Mutex::new(());
+
     #[test]
-    fn secrets_resolve_from_env_with_fallback() {
-        // The resolver reads the env var at first access (cached thereafter).
-        // Verify the fallback path returns the bundled value (the security fix:
-        // the value is no longer a bare const — it is env-overridable).
+    fn secrets_return_empty_without_env() {
+        let _guard = ENV_LOCK.lock().unwrap();
+        clear_cache();
         std::env::remove_var("IFLOW_CLIENT_SECRET");
-        assert_eq!(iflow_client_secret(), "4Z3YjXycVsQvyGF1etiNlIBB4RsqSDtW");
-        std::env::remove_var("IFLOW_CLIENT_SECRET");
+        std::env::remove_var("QODER_CLIENT_SECRET");
+        std::env::remove_var("ANTIGRAVITY_CLIENT_SECRET");
+        std::env::remove_var("GEMINI_CLIENT_SECRET");
+        // Without env vars set, secrets are empty strings (no hardcoded fallback).
+        assert_eq!(iflow_client_secret(), "");
+        assert_eq!(qoder_client_secret(), "");
+        assert_eq!(antigravity_client_secret(), "");
+        assert_eq!(gemini_cli_client_secret(), "");
     }
 
     #[test]
-    fn antigravity_and_gemini_secrets_resolve() {
+    fn secrets_resolve_from_env() {
+        let _guard = ENV_LOCK.lock().unwrap();
+        clear_cache();
+        std::env::set_var("IFLOW_CLIENT_SECRET", "test-secret-iflow");
+        std::env::set_var("QODER_CLIENT_SECRET", "test-secret-qoder");
+        std::env::set_var("ANTIGRAVITY_CLIENT_SECRET", "test-secret-anti");
+        std::env::set_var("GEMINI_CLIENT_SECRET", "test-secret-gemini");
+        assert_eq!(iflow_client_secret(), "test-secret-iflow");
+        assert_eq!(qoder_client_secret(), "test-secret-qoder");
+        assert_eq!(antigravity_client_secret(), "test-secret-anti");
+        assert_eq!(gemini_cli_client_secret(), "test-secret-gemini");
+        std::env::remove_var("IFLOW_CLIENT_SECRET");
+        std::env::remove_var("QODER_CLIENT_SECRET");
         std::env::remove_var("ANTIGRAVITY_CLIENT_SECRET");
         std::env::remove_var("GEMINI_CLIENT_SECRET");
-        assert_eq!(
-            antigravity_client_secret(),
-            "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"
-        );
-        assert_eq!(
-            gemini_cli_client_secret(),
-            "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"
-        );
     }
 }


### PR DESCRIPTION
## Summary

Remove hardcoded OAuth client secret values from . All secrets are now resolved exclusively from environment variables at runtime:

- iFlow: 
- Qoder:   
- Antigravity: 
- Gemini: 

When the env var is not set, an empty string is returned (no secret value is hardcoded in the repository). Operators MUST set the appropriate environment variables before starting the server, otherwise OAuth flows for those providers will not function.

### Security Impact
Before: hardcoded production OAuth client secrets were stored in source code (git history, forks, etc.)

After: secrets are 12-factor compliant — loaded from environment at runtime